### PR TITLE
Improve security, reliability, and error handling in video export

### DIFF
--- a/apps/api/app/application/use_cases/export_video.py
+++ b/apps/api/app/application/use_cases/export_video.py
@@ -30,6 +30,10 @@ from app.domain.models.export_job import ExportJobStatus, TtsConfig
 
 logger = logging.getLogger(__name__)
 
+# Cap per-step TTS audio download to prevent memory exhaustion from a
+# malicious or buggy TTS endpoint. 50 MB easily covers ~30 min of MP3.
+_MAX_TTS_AUDIO_BYTES = 50 * 1024 * 1024
+
 
 class ExportVideoUseCase:
     def __init__(
@@ -52,14 +56,17 @@ class ExportVideoUseCase:
         with_audio: bool,
         tts: TtsConfig | None,
     ) -> None:
+        job_dir = self._artifacts / job_id
+        succeeded = False
         try:
             run = self._runs.get(run_id)
             if run is None or run.playbook is None:
                 raise ValueError(f"Run {run_id!r} has no playbook to export")
 
             playbook = run.playbook.model_dump()
+            if not playbook.get("steps"):
+                raise ValueError("playbook has no steps to render")
 
-            job_dir = self._artifacts / job_id
             job_dir.mkdir(parents=True, exist_ok=True)
             audio_files: list[str] = []
 
@@ -104,6 +111,7 @@ class ExportVideoUseCase:
                 message="完成",
                 output_path=str(output_path),
             )
+            succeeded = True
         except Exception as exc:  # noqa: BLE001
             logger.exception("export job %s failed", job_id)
             self._exports.update(
@@ -111,6 +119,12 @@ class ExportVideoUseCase:
                 status=ExportJobStatus.FAILED,
                 error=str(exc),
             )
+        finally:
+            if not succeeded and job_dir.exists():
+                # Clean up partial artifacts on failure; keep on success so
+                # the user can download. TTL-based cleanup of completed jobs
+                # is the caller's responsibility.
+                shutil.rmtree(job_dir, ignore_errors=True)
 
     async def _generate_step_audio(
         self,
@@ -120,29 +134,41 @@ class ExportVideoUseCase:
     ) -> list[str]:
         steps = playbook.get("steps", [])
         files: list[str] = []
-        async with httpx.AsyncClient(timeout=120.0) as client:
+        # Per-request timeout; total client budget is sum of per-step calls.
+        timeout = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=10.0)
+        async with httpx.AsyncClient(timeout=timeout) as client:
             for i, step in enumerate(steps):
                 text = (step.get("voiceover_text") or "").strip()
                 if not text:
                     files.append("")
                     continue
                 audio_path = audio_dir / f"step_{i:03d}.mp3"
-                resp = await client.post(
-                    f"{tts.base_url.rstrip('/')}/audio/speech",
-                    headers={
-                        "Authorization": f"Bearer {tts.api_key}",
-                        "Content-Type": "application/json",
-                    },
-                    json={
-                        "model": tts.model,
-                        "voice": tts.voice,
-                        "input": text,
-                        "format": "mp3",
-                    },
-                )
+                try:
+                    resp = await client.post(
+                        f"{tts.base_url.rstrip('/')}/audio/speech",
+                        headers={
+                            "Authorization": f"Bearer {tts.api_key}",
+                            "Content-Type": "application/json",
+                        },
+                        json={
+                            "model": tts.model,
+                            "voice": tts.voice,
+                            "input": text,
+                            "format": "mp3",
+                        },
+                    )
+                except httpx.TimeoutException:
+                    logger.warning("TTS timeout for step %d; skipping audio", i)
+                    files.append("")
+                    continue
                 if resp.status_code >= 400:
                     raise RuntimeError(
                         f"TTS HTTP {resp.status_code} for step {i}: {resp.text[:200]}"
+                    )
+                if len(resp.content) > _MAX_TTS_AUDIO_BYTES:
+                    raise RuntimeError(
+                        f"TTS audio for step {i} too large: "
+                        f"{len(resp.content)} bytes > {_MAX_TTS_AUDIO_BYTES}"
                     )
                 audio_path.write_bytes(resp.content)
                 files.append(str(audio_path))
@@ -167,8 +193,18 @@ class ExportVideoUseCase:
             "--log",
             "info",
         ]
-        env = os.environ.copy()
-        env.setdefault("NODE_ENV", "production")
+        # Whitelist env vars passed to the render subprocess. Avoid leaking
+        # parent-process secrets (API keys, DB URLs, etc.) into Remotion/Node.
+        env = {
+            "NODE_ENV": "production",
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": os.environ.get("HOME", ""),
+        }
+        # Preserve a few opt-in vars commonly required by Remotion/Chromium.
+        for key in ("LANG", "LC_ALL", "TMPDIR", "PUPPETEER_EXECUTABLE_PATH"):
+            value = os.environ.get(key)
+            if value is not None:
+                env[key] = value
 
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -263,8 +299,10 @@ def _probe_audio_duration_seconds(path: Path) -> float:
                 timeout=30,
             ).stdout.strip()
             return float(out)
-        except (subprocess.SubprocessError, ValueError):
-            pass
+        except (subprocess.SubprocessError, ValueError) as exc:
+            logger.warning("ffprobe failed for %s: %s; falling back", path, exc)
+    else:
+        logger.warning("ffprobe not on PATH; audio duration probe limited to .wav")
     if path.suffix.lower() == ".wav":
         try:
             with wave.open(str(path), "rb") as w:
@@ -272,6 +310,9 @@ def _probe_audio_duration_seconds(path: Path) -> float:
                 rate = w.getframerate()
                 if rate > 0:
                     return frames / rate
-        except wave.Error:
-            pass
+        except wave.Error as exc:
+            logger.warning("wave.open failed for %s: %s", path, exc)
+    logger.warning(
+        "audio duration unknown for %s; using animation duration as fallback", path
+    )
     return 0.0

--- a/apps/api/app/domain/services/playbook_builder.py
+++ b/apps/api/app/domain/services/playbook_builder.py
@@ -37,8 +37,15 @@ _ALGORITHM_KEYWORDS: tuple[tuple[tuple[str, ...], str], ...] = (
 def _infer_algorithm_id(title: str) -> str | None:
     lowered = title.lower()
     for keywords, algo_id in _ALGORITHM_KEYWORDS:
-        if any(k in title or k in lowered for k in keywords):
-            return algo_id
+        for k in keywords:
+            # ASCII keywords use word boundaries so "bubble tea sort" does not
+            # match "bubble". CJK strings have no \b in regex, so fall back to
+            # plain containment for those.
+            if k.isascii():
+                if re.search(rf"\b{re.escape(k.lower())}\b", lowered):
+                    return algo_id
+            elif k in title:
+                return algo_id
     return None
 
 

--- a/apps/api/app/presentation/router_exports.py
+++ b/apps/api/app/presentation/router_exports.py
@@ -102,15 +102,21 @@ def get_export(
 def download_export(
     job_id: str,
     export_repo: Annotated[IExportJobRepository, Depends(get_export_repo)],
+    settings: Annotated[Settings, Depends(get_settings)],
 ) -> FileResponse:
     job = export_repo.get(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail=f"Export {job_id!r} not found")
     if job.status != ExportJobStatus.COMPLETED or not job.output_path:
         raise HTTPException(status_code=409, detail="export not finished")
-    path = Path(job.output_path)
-    if not path.exists():
-        raise HTTPException(status_code=410, detail="output file missing")
+    artifacts_root = _resolve_path(settings.export_artifacts_dir).resolve()
+    try:
+        path = Path(job.output_path).resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=410, detail="output file missing") from exc
+    # Reject paths that escape the artifacts root (symlink / traversal guard).
+    if not path.is_relative_to(artifacts_root):
+        raise HTTPException(status_code=403, detail="output path outside artifacts root")
     return FileResponse(
         path,
         media_type="video/mp4",

--- a/apps/web/src/remotion/Root.tsx
+++ b/apps/web/src/remotion/Root.tsx
@@ -5,8 +5,8 @@ import { PLAYBOOK_DEFAULTS } from "../shared/config/constants";
 import { PlaybookExportComposition, type PlaybookExportProps } from "./PlaybookExportComposition";
 
 const FALLBACK_SCRIPT: PlaybookScript = {
-  fps: 30,
-  total_frames: 60,
+  fps: PLAYBOOK_DEFAULTS.FPS,
+  total_frames: PLAYBOOK_DEFAULTS.STEP_FRAMES,
   domain: "algorithm",
   title: "MetaView Export",
   summary: "",
@@ -27,8 +27,8 @@ export const RemotionRoot: React.FC = () => {
     <Composition
       id="playbook"
       component={PlaybookExportComposition}
-      durationInFrames={60}
-      fps={30}
+      durationInFrames={PLAYBOOK_DEFAULTS.STEP_FRAMES}
+      fps={PLAYBOOK_DEFAULTS.FPS}
       width={PLAYBOOK_DEFAULTS.COMPOSITION_WIDTH}
       height={PLAYBOOK_DEFAULTS.COMPOSITION_HEIGHT}
       defaultProps={{


### PR DESCRIPTION
## Summary
This PR enhances the video export functionality with improved security controls, better error handling, and increased robustness against malicious or buggy external services.

## Key Changes

### Security Improvements
- **Environment variable whitelisting**: Subprocess environment now uses an explicit whitelist instead of copying all parent process variables, preventing accidental leakage of API keys and database credentials to Remotion/Node processes
- **Path traversal protection**: Added validation in `download_export` to ensure downloaded files are within the artifacts root directory, preventing symlink/traversal attacks
- **TTS audio size limits**: Implemented `_MAX_TTS_AUDIO_BYTES` cap (50 MB) to prevent memory exhaustion from malicious or buggy TTS endpoints

### Reliability & Error Handling
- **TTS timeout handling**: Added explicit `httpx.TimeoutException` catching with graceful degradation (skip audio for that step instead of failing entire export)
- **Improved timeout configuration**: Replaced single timeout value with granular per-operation timeouts (connect, read, write, pool)
- **Cleanup on failure**: Added `finally` block to remove partial artifacts when export fails, keeping successful outputs for user download
- **Better logging**: Enhanced error messages throughout with context-aware warnings for ffprobe, wave.open, and audio duration probing failures

### Bug Fixes
- **Playbook validation**: Added check to ensure playbook has steps before processing
- **Algorithm keyword matching**: Fixed `_infer_algorithm_id` to use word boundaries for ASCII keywords (prevents "bubble tea sort" matching "bubble") while maintaining substring matching for CJK text
- **Remotion defaults**: Updated hardcoded fps/frame values to use `PLAYBOOK_DEFAULTS` constants for consistency

### Implementation Details
- TTS requests now use structured timeout with separate connect/read/write/pool budgets instead of a single timeout
- Audio duration probing gracefully falls back through ffprobe → wave.open → animation duration
- Environment variable whitelist includes PATH, HOME, and opt-in vars (LANG, LC_ALL, TMPDIR, PUPPETEER_EXECUTABLE_PATH) commonly needed by Chromium
- Path resolution uses `strict=True` and `is_relative_to()` for robust traversal protection

https://claude.ai/code/session_01UoSMY6y826T4gZbSmTB5Fu