### PR TITLE
Resolve 7 backlog issues + flatten bar renderer to theme-reactive 2D

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,9 +2,13 @@ name: Check
 
 on:
   push:
-    branches: ["main", "dev"]
+    branches: ["main", "dev", "feat/**", "fix/**", "claude/**"]
   pull_request:
     branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:

--- a/apps/api/tests/test_playbook_builder.py
+++ b/apps/api/tests/test_playbook_builder.py
@@ -301,6 +301,266 @@ class TestCodeHighlightOverlay:
             assert step.code_highlight is None
 
 
+class TestEdgeCases:
+    """Edge cases for build_playbook (issue #36).
+
+    Covers branches that the happy-path tests above don't exercise.
+    """
+
+    def test_empty_cir_produces_empty_playbook(self):
+        cir = CirDocument(
+            title="空教学",
+            domain=TopicDomain.ALGORITHM,
+            summary="",
+            steps=[],
+        )
+        playbook = build_playbook(cir, execution_map=None)
+
+        assert playbook.steps == []
+        # Avoid div-by-zero / negative durations downstream
+        assert playbook.total_frames >= 1
+        assert playbook.fps == 30
+
+    def test_missing_execution_map_uses_default_duration(self):
+        cir = _make_array_cir()
+        playbook = build_playbook(cir, execution_map=None)
+
+        # Default _DEFAULT_STEP_FRAMES = 60 (2 s @ 30 fps)
+        assert playbook.steps[0].end_frame == 60
+        assert playbook.steps[1].end_frame == 120
+        assert playbook.steps[2].end_frame == 180
+        assert playbook.parameter_controls == []
+        assert playbook.initial_data == {}
+
+    def test_zero_duration_checkpoint_falls_back_to_default(self):
+        cir = _make_array_cir()
+        em = _make_execution_map(cir)
+        # Collapse the first checkpoint to zero duration
+        em.checkpoints[0].start_s = 0.0
+        em.checkpoints[0].end_s = 0.0
+        playbook = build_playbook(cir, execution_map=em)
+
+        # Zero-duration falls back to _DEFAULT_STEP_FRAMES (60), not 0
+        assert playbook.steps[0].end_frame == 60
+
+    def test_negative_duration_checkpoint_falls_back(self):
+        cir = _make_array_cir()
+        em = _make_execution_map(cir)
+        em.checkpoints[0].start_s = 5.0
+        em.checkpoints[0].end_s = 1.0  # negative span
+        playbook = build_playbook(cir, execution_map=em)
+
+        # Should not produce 0 or negative frame count
+        assert playbook.steps[0].end_frame >= 1
+
+    def test_user_source_overrides_library(self):
+        cir = _make_array_cir()  # title triggers bubble_sort library
+        em = _make_execution_map(cir)
+        em.checkpoints[0].code_lines = [0]
+        playbook = build_playbook(
+            cir,
+            execution_map=em,
+            source_code="custom_line_one\ncustom_line_two",
+            source_language="rust",
+        )
+        overlay = playbook.steps[0].code_highlight
+        assert overlay is not None
+        assert overlay.language == "rust"
+        assert overlay.lines == ["custom_line_one", "custom_line_two"]
+
+    def test_library_source_used_when_no_user_source(self):
+        cir = _make_array_cir()
+        em = _make_execution_map(cir)
+        em.checkpoints[0].code_lines = [0]
+        playbook = build_playbook(cir, execution_map=em)
+
+        overlay = playbook.steps[0].code_highlight
+        assert overlay is not None
+        # Library should win since title matches bubble_sort and no user source supplied
+        assert len(overlay.lines) > 0
+        # algorithm_id propagates back to script
+        assert playbook.algorithm_id == "bubble_sort"
+
+    def test_execution_map_algorithm_code_used_when_no_library_match(self):
+        cir = _make_array_cir()
+        cir.title = "未知教学题目-不匹配任何关键字"  # avoid library match
+        em = _make_execution_map(cir)
+        em.checkpoints[0].code_lines = [0]
+        em.algorithm_code = ["llm_generated_line_1", "llm_generated_line_2"]
+        playbook = build_playbook(cir, execution_map=em)
+
+        overlay = playbook.steps[0].code_highlight
+        assert overlay is not None
+        assert overlay.lines == ["llm_generated_line_1", "llm_generated_line_2"]
+        # Falls back to "pseudocode" because algorithm_language is opportunistic
+        assert overlay.language == "pseudocode"
+
+    def test_out_of_range_code_lines_filtered(self):
+        cir = _make_array_cir()
+        em = _make_execution_map(cir)
+        # source has 2 lines; checkpoint claims line 99 (LLM hallucination)
+        em.checkpoints[0].code_lines = [99, 100]
+        playbook = build_playbook(
+            cir,
+            execution_map=em,
+            source_code="line0\nline1",
+            source_language="python",
+        )
+        # All hallucinated lines filtered out → no overlay
+        assert playbook.steps[0].code_highlight is None
+
+    def test_out_of_range_mixed_with_valid_keeps_valid(self):
+        cir = _make_array_cir()
+        em = _make_execution_map(cir)
+        em.checkpoints[0].code_lines = [0, 99, 1]  # 99 out of range
+        playbook = build_playbook(
+            cir,
+            execution_map=em,
+            source_code="line0\nline1",
+            source_language="python",
+        )
+        overlay = playbook.steps[0].code_highlight
+        assert overlay is not None
+        assert overlay.active_lines == [0, 1]
+        assert overlay.active_line == 0
+
+    def test_negative_code_lines_filtered(self):
+        cir = _make_array_cir()
+        em = _make_execution_map(cir)
+        em.checkpoints[0].code_lines = [-1, -5]
+        playbook = build_playbook(
+            cir,
+            execution_map=em,
+            source_code="line0\nline1",
+            source_language="python",
+        )
+        assert playbook.steps[0].code_highlight is None
+
+    def test_algorithm_id_inference_fallback_unmatched(self):
+        cir = CirDocument(
+            title="某种无人知道的算法 zzzzz",
+            domain=TopicDomain.ALGORITHM,
+            summary="",
+            steps=[
+                CirStep(
+                    id="s1",
+                    title="t",
+                    narration="n",
+                    visual_kind=VisualKind.ARRAY,
+                    tokens=[VisualToken(id="t0", label="1")],
+                )
+            ],
+        )
+        playbook = build_playbook(cir, execution_map=None)
+        assert playbook.algorithm_id is None
+
+    def test_explicit_execution_map_algorithm_id_wins(self):
+        cir = _make_array_cir()  # title would otherwise match bubble_sort
+        em = _make_execution_map(cir)
+        em.algorithm_id = "quick_sort"
+        playbook = build_playbook(cir, execution_map=em)
+        assert playbook.algorithm_id == "quick_sort"
+
+    def test_edgeless_tree_produces_no_edges(self):
+        cir = CirDocument(
+            title="孤立节点",
+            domain=TopicDomain.ALGORITHM,
+            summary="",
+            steps=[
+                CirStep(
+                    id="s1",
+                    title="t",
+                    narration="n",
+                    visual_kind=VisualKind.GRAPH,
+                    tokens=[
+                        VisualToken(id="a", label="A"),
+                        VisualToken(id="b", label="B"),
+                        VisualToken(id="c", label="C"),
+                    ],
+                )
+            ],
+        )
+        playbook = build_playbook(cir, execution_map=None)
+        snap = playbook.steps[0].snapshot
+        assert isinstance(snap, AlgorithmTreeSnapshot)
+        assert len(snap.nodes) == 3
+        assert snap.edges == []
+
+    def test_explicit_edges_override_heuristic(self):
+        from app.domain.models.cir import EdgeRef as CirEdge
+        cir = CirDocument(
+            title="explicit-edge",
+            domain=TopicDomain.ALGORITHM,
+            summary="",
+            steps=[
+                CirStep(
+                    id="s1",
+                    title="t",
+                    narration="n",
+                    visual_kind=VisualKind.GRAPH,
+                    tokens=[
+                        VisualToken(id="a", label="A"),
+                        VisualToken(id="b", label="B", value="parent:a"),
+                    ],
+                    edges=[CirEdge(from_id="a", to_id="b")],
+                )
+            ],
+        )
+        playbook = build_playbook(cir, execution_map=None)
+        snap = playbook.steps[0].snapshot
+        assert isinstance(snap, AlgorithmTreeSnapshot)
+        # Even though token has parent: hint, explicit edge list is preferred & deduplicated
+        assert len(snap.edges) == 1
+        assert snap.edges[0]["from_id"] == "a"
+
+    def test_swap_inference_only_when_title_signals_swap(self):
+        cir = _make_array_cir()
+        em = _make_execution_map(cir)
+        # Step 1 has 2 active indices but title is "第一次比较" → no swap
+        em.checkpoints[1].title = "第一次比较"
+        playbook = build_playbook(cir, execution_map=em)
+        snap = playbook.steps[1].snapshot
+        assert isinstance(snap, AlgorithmBarsSnapshot)
+        assert snap.swap_indices == []
+
+        # Same setup but title contains "swap" → swap_indices populated
+        em.checkpoints[1].title = "swap A[0] and A[1]"
+        playbook2 = build_playbook(cir, execution_map=em)
+        snap2 = playbook2.steps[1].snapshot
+        assert isinstance(snap2, AlgorithmBarsSnapshot)
+        assert snap2.swap_indices == [0, 1]
+
+    def test_explicit_swap_indices_used_directly(self):
+        cir = _make_array_cir()
+        em = _make_execution_map(cir)
+        em.checkpoints[1].swap_indices = [2, 3]
+        em.checkpoints[1].title = "neutral title"  # no swap keyword
+        playbook = build_playbook(cir, execution_map=em)
+        snap = playbook.steps[1].snapshot
+        assert isinstance(snap, AlgorithmBarsSnapshot)
+        assert snap.swap_indices == [2, 3]
+
+    def test_single_step_animation_hint_is_reveal_not_enter(self):
+        # When total == 1, the loop hits both `index == 0` and `index == total - 1`.
+        # The first branch returns "enter" — verify the documented contract.
+        cir = CirDocument(
+            title="单步",
+            domain=TopicDomain.ALGORITHM,
+            summary="",
+            steps=[
+                CirStep(
+                    id="only",
+                    title="x",
+                    narration="y",
+                    visual_kind=VisualKind.ARRAY,
+                    tokens=[VisualToken(id="t0", label="1")],
+                )
+            ],
+        )
+        playbook = build_playbook(cir, execution_map=None)
+        assert playbook.steps[0].animation_hint == "enter"
+
+
 class TestParseNarrationTemplate:
     def test_json_array_parsed(self):
         raw = '["Compare ", {"t": "t0"}, " and ", {"t": "t1"}]'

--- a/apps/web/src/features/playbook/engine/player/ttsCache.test.ts
+++ b/apps/web/src/features/playbook/engine/player/ttsCache.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { TTSAudioCache, ttsCacheKey } from "./ttsCache";
+
+function buf(size: number): ArrayBuffer {
+  return new ArrayBuffer(size);
+}
+
+describe("ttsCacheKey", () => {
+  it("normalizes rate to 2 decimals", () => {
+    const a = ttsCacheKey({ baseUrl: "u", model: "m", voice: "v", rate: 1, text: "t" });
+    const b = ttsCacheKey({ baseUrl: "u", model: "m", voice: "v", rate: 1.0, text: "t" });
+    const c = ttsCacheKey({ baseUrl: "u", model: "m", voice: "v", rate: 1.005, text: "t" });
+    expect(a).toBe(b);
+    expect(a).toBe(c);
+  });
+
+  it("distinguishes by voice and text", () => {
+    const a = ttsCacheKey({ baseUrl: "u", model: "m", voice: "alloy", rate: 1, text: "hi" });
+    const b = ttsCacheKey({ baseUrl: "u", model: "m", voice: "echo", rate: 1, text: "hi" });
+    const c = ttsCacheKey({ baseUrl: "u", model: "m", voice: "alloy", rate: 1, text: "hello" });
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+  });
+});
+
+describe("TTSAudioCache", () => {
+  it("get returns undefined for missing key and counts miss", () => {
+    const c = new TTSAudioCache(1024);
+    expect(c.get("k")).toBeUndefined();
+    expect(c.stats().misses).toBe(1);
+    expect(c.stats().hits).toBe(0);
+  });
+
+  it("set then get returns buffer and counts hit", () => {
+    const c = new TTSAudioCache(1024);
+    const b = buf(10);
+    c.set("k", b);
+    expect(c.get("k")).toBe(b);
+    expect(c.stats()).toMatchObject({ hits: 1, misses: 0, entries: 1, bytes: 10 });
+  });
+
+  it("tracks byte usage and evicts when over maxBytes", () => {
+    const c = new TTSAudioCache(30);
+    c.set("a", buf(10));
+    c.set("b", buf(10));
+    c.set("c", buf(10));
+    expect(c.stats().bytes).toBe(30);
+    c.set("d", buf(10));
+    // oldest "a" should be evicted
+    expect(c.get("a")).toBeUndefined();
+    expect(c.get("b")).not.toBeUndefined();
+    expect(c.get("c")).not.toBeUndefined();
+    expect(c.get("d")).not.toBeUndefined();
+    expect(c.stats().bytes).toBe(30);
+  });
+
+  it("evicts multiple entries when a single set overflows", () => {
+    const c = new TTSAudioCache(50);
+    c.set("a", buf(20));
+    c.set("b", buf(20));
+    c.set("big", buf(50));
+    expect(c.get("a")).toBeUndefined();
+    expect(c.get("b")).toBeUndefined();
+    expect(c.get("big")).not.toBeUndefined();
+    expect(c.stats().bytes).toBe(50);
+  });
+
+  it("LRU: get moves entry to most-recent", () => {
+    const c = new TTSAudioCache(30);
+    c.set("a", buf(10));
+    c.set("b", buf(10));
+    c.set("c", buf(10));
+    // touch "a" so it's most-recent
+    expect(c.get("a")).not.toBeUndefined();
+    // adding "d" should evict "b" now (oldest), not "a"
+    c.set("d", buf(10));
+    expect(c.get("a")).not.toBeUndefined();
+    expect(c.get("b")).toBeUndefined();
+  });
+
+  it("re-setting same key replaces buffer and updates bytes", () => {
+    const c = new TTSAudioCache(1024);
+    c.set("k", buf(10));
+    c.set("k", buf(25));
+    expect(c.stats().entries).toBe(1);
+    expect(c.stats().bytes).toBe(25);
+  });
+
+  it("delete removes a single entry and frees bytes", () => {
+    const c = new TTSAudioCache(1024);
+    c.set("k", buf(40));
+    expect(c.delete("k")).toBe(true);
+    expect(c.stats()).toMatchObject({ entries: 0, bytes: 0 });
+    expect(c.delete("k")).toBe(false);
+  });
+
+  it("clear drops everything (bytes counter resets)", () => {
+    const c = new TTSAudioCache(1024);
+    c.set("a", buf(10));
+    c.set("b", buf(10));
+    c.clear();
+    expect(c.stats()).toMatchObject({ entries: 0, bytes: 0 });
+  });
+
+  it("stats hits/misses persist across clear (observability)", () => {
+    const c = new TTSAudioCache(1024);
+    c.set("a", buf(10));
+    c.get("a"); // hit
+    c.get("missing"); // miss
+    c.clear();
+    expect(c.stats().hits).toBe(1);
+    expect(c.stats().misses).toBe(1);
+  });
+
+  it("multiple instances do not share state", () => {
+    const a = new TTSAudioCache(1024);
+    const b = new TTSAudioCache(1024);
+    a.set("k", buf(10));
+    expect(b.get("k")).toBeUndefined();
+    expect(a.get("k")).not.toBeUndefined();
+  });
+});

--- a/apps/web/src/features/playbook/engine/player/ttsCache.ts
+++ b/apps/web/src/features/playbook/engine/player/ttsCache.ts
@@ -1,0 +1,112 @@
+/**
+ * LRU cache for OpenAI TTS audio buffers, bounded by total bytes.
+ *
+ * Why: see issue #33. The previous module-level `Map` was untestable, unclear-able,
+ * and unobservable. It also counted entries, not bytes — so 50 long utterances
+ * could pin ~2.5 GB in memory.
+ *
+ * This class:
+ *   - tracks total bytes and evicts oldest until under `maxBytes`
+ *   - reports hit/miss counts via `stats()`
+ *   - supports `clear()` for tests and player teardown
+ *   - is constructible: multiple instances do NOT share state
+ */
+
+export interface TTSCacheStats {
+  hits: number;
+  misses: number;
+  entries: number;
+  bytes: number;
+  maxBytes: number;
+}
+
+export interface TTSCacheKeyParts {
+  baseUrl: string;
+  model: string;
+  voice: string;
+  rate: number;
+  text: string;
+}
+
+const DEFAULT_MAX_BYTES = 64 * 1024 * 1024; // 64 MB — generous but bounded
+
+export function ttsCacheKey(parts: TTSCacheKeyParts): string {
+  return `${parts.baseUrl}|${parts.model}|${parts.voice}|${parts.rate.toFixed(2)}|${parts.text}`;
+}
+
+export class TTSAudioCache {
+  private readonly store = new Map<string, ArrayBuffer>();
+  private readonly maxBytes: number;
+  private currentBytes = 0;
+  private hits = 0;
+  private misses = 0;
+
+  constructor(maxBytes: number = DEFAULT_MAX_BYTES) {
+    this.maxBytes = maxBytes;
+  }
+
+  get(key: string): ArrayBuffer | undefined {
+    const buf = this.store.get(key);
+    if (buf === undefined) {
+      this.misses += 1;
+      return undefined;
+    }
+    // LRU touch
+    this.store.delete(key);
+    this.store.set(key, buf);
+    this.hits += 1;
+    return buf;
+  }
+
+  set(key: string, buf: ArrayBuffer): void {
+    const existing = this.store.get(key);
+    if (existing) {
+      this.currentBytes -= existing.byteLength;
+      this.store.delete(key);
+    }
+    this.store.set(key, buf);
+    this.currentBytes += buf.byteLength;
+    this.evictIfNeeded();
+  }
+
+  /** Drop a single entry (e.g. corrupted). Returns true if removed. */
+  delete(key: string): boolean {
+    const existing = this.store.get(key);
+    if (!existing) return false;
+    this.currentBytes -= existing.byteLength;
+    this.store.delete(key);
+    return true;
+  }
+
+  clear(): void {
+    this.store.clear();
+    this.currentBytes = 0;
+  }
+
+  stats(): TTSCacheStats {
+    return {
+      hits: this.hits,
+      misses: this.misses,
+      entries: this.store.size,
+      bytes: this.currentBytes,
+      maxBytes: this.maxBytes,
+    };
+  }
+
+  private evictIfNeeded(): void {
+    while (this.currentBytes > this.maxBytes) {
+      const oldest = this.store.keys().next();
+      if (oldest.done) break;
+      const buf = this.store.get(oldest.value);
+      if (!buf) break;
+      this.currentBytes -= buf.byteLength;
+      this.store.delete(oldest.value);
+    }
+  }
+}
+
+/**
+ * Shared instance used by `useTTS`. Exported so callers can `clear()` or
+ * `stats()` it from devtools / settings UI, and so tests can reset state.
+ */
+export const sharedTTSCache = new TTSAudioCache();

--- a/apps/web/src/features/playbook/engine/player/useResolvedScript.ts
+++ b/apps/web/src/features/playbook/engine/player/useResolvedScript.ts
@@ -56,9 +56,14 @@ export function useResolvedScript(base: PlaybookScript, overrides: ScriptOverrid
         sorted_indices: r.snapshot.sorted_indices,
         pointers: r.snapshot.pointers,
       };
+      const overrides: Partial<MetaStep> = {};
+      if (r.tts_rate != null) overrides.tts_rate = r.tts_rate;
+      if (r.codeHighlight != null) overrides.code_highlight = r.codeHighlight;
+      if (r.narrationTemplate != null) overrides.narration_template = r.narrationTemplate;
+
       if (baseSnap.kind === "algorithm_array") {
         const newSnapshot: AlgorithmArraySnapshot = { ...baseSnap, ...common };
-        return { ...step, snapshot: newSnapshot };
+        return { ...step, ...overrides, snapshot: newSnapshot };
       }
       if (baseSnap.kind === "algorithm_bars") {
         const numeric_values =
@@ -66,7 +71,7 @@ export function useResolvedScript(base: PlaybookScript, overrides: ScriptOverrid
             ? r.snapshot.numeric_values
             : r.snapshot.array_values.map(Number);
         const newSnapshot: AlgorithmBarsSnapshot = { ...baseSnap, ...common, numeric_values };
-        return { ...step, snapshot: newSnapshot };
+        return { ...step, ...overrides, snapshot: newSnapshot };
       }
       // Preserve tree/other kinds untouched.
       return step;

--- a/apps/web/src/features/playbook/engine/player/useTTS.ts
+++ b/apps/web/src/features/playbook/engine/player/useTTS.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { isSSML, normalizeSSML } from "./ssml";
+import { sharedTTSCache, ttsCacheKey, type TTSCacheStats } from "./ttsCache";
 
 export interface TTSConfig {
   enabled: boolean;
@@ -79,36 +80,6 @@ function saveConfig(cfg: TTSConfig): void {
   }
 }
 
-// ── In-memory LRU cache for OpenAI TTS audio ────────────────────────────────
-// Keyed by `${baseUrl}|${model}|${voice}|${rate}|${text}`. Bounded to 50 entries
-// to avoid unbounded memory growth on long sessions.
-const TTS_CACHE_MAX = 50;
-const ttsAudioCache = new Map<string, ArrayBuffer>();
-
-function cacheKey(baseUrl: string, model: string, voice: string, rate: number, text: string): string {
-  return `${baseUrl}|${model}|${voice}|${rate.toFixed(2)}|${text}`;
-}
-
-function cacheGet(key: string): ArrayBuffer | undefined {
-  const buf = ttsAudioCache.get(key);
-  if (buf) {
-    // re-insert to mark as recently used
-    ttsAudioCache.delete(key);
-    ttsAudioCache.set(key, buf);
-  }
-  return buf;
-}
-
-function cacheSet(key: string, buf: ArrayBuffer): void {
-  if (ttsAudioCache.has(key)) ttsAudioCache.delete(key);
-  ttsAudioCache.set(key, buf);
-  while (ttsAudioCache.size > TTS_CACHE_MAX) {
-    const oldest = ttsAudioCache.keys().next().value;
-    if (oldest === undefined) break;
-    ttsAudioCache.delete(oldest);
-  }
-}
-
 export interface UseTTSResult {
   enabled: boolean;
   toggle: () => void;
@@ -118,6 +89,10 @@ export interface UseTTSResult {
   supported: boolean;
   config: TTSConfig;
   updateConfig: (patch: Partial<TTSConfig>) => void;
+  /** Read current cache stats (hit/miss counts, byte usage). Useful for debugging. */
+  cacheStats: () => TTSCacheStats;
+  /** Manually clear the shared TTS audio cache. */
+  clearCache: () => void;
 }
 
 export function useTTS(): UseTTSResult {
@@ -206,12 +181,20 @@ export function useTTS(): UseTTSResult {
       audioSrcRef.current = null;
       setSpeaking(true);
 
-      const key = cacheKey(config.baseUrl, config.model, voice, rate, text);
-      const cached = cacheGet(key);
+      const key = ttsCacheKey({
+        baseUrl: config.baseUrl,
+        model: config.model,
+        voice,
+        rate,
+        text,
+      });
+      const cached = sharedTTSCache.get(key);
       if (cached) {
         try {
           await playArrayBuffer(cached, ac.signal);
         } catch {
+          // Likely a corrupted entry — drop it so the next call refetches.
+          sharedTTSCache.delete(key);
           setSpeaking(false);
         }
         return;
@@ -232,7 +215,7 @@ export function useTTS(): UseTTSResult {
 
         const buf = await res.arrayBuffer();
         if (ac.signal.aborted) return;
-        cacheSet(key, buf);
+        sharedTTSCache.set(key, buf);
         await playArrayBuffer(buf, ac.signal);
       } catch (err) {
         if ((err as DOMException).name === "AbortError") return;
@@ -301,5 +284,19 @@ export function useTTS(): UseTTSResult {
     };
   }, []);
 
-  return { enabled: config.enabled, toggle, speaking, speak, stop, supported, config, updateConfig };
+  const cacheStats = useCallback(() => sharedTTSCache.stats(), []);
+  const clearCache = useCallback(() => sharedTTSCache.clear(), []);
+
+  return {
+    enabled: config.enabled,
+    toggle,
+    speaking,
+    speak,
+    stop,
+    supported,
+    config,
+    updateConfig,
+    cacheStats,
+    clearCache,
+  };
 }

--- a/apps/web/src/features/playbook/engine/renderers/BarBlockRenderer.test.tsx
+++ b/apps/web/src/features/playbook/engine/renderers/BarBlockRenderer.test.tsx
@@ -65,11 +65,11 @@ describe("BarBlockRenderer", () => {
     expect(hs).toContain(120);
   });
 
-  it("highlights active and sorted indices distinctly", () => {
+  it("highlights active and sorted indices via the theme accent variable", () => {
     const snap = makeBars([5, 2, 8], { active_indices: [0], sorted_indices: [2] });
     const markup = renderToStaticMarkup(BarBlockRenderer(props(barsStep(snap))));
-    // active highlight color (dark theme accent) and sorted checkmark present
-    expect(markup).toContain("#ffd84d");
+    // Colors flow through CSS vars so theme + accent changes take effect live
+    expect(markup).toContain("var(--accent");
     expect(markup).toContain("✓");
   });
 
@@ -78,11 +78,23 @@ describe("BarBlockRenderer", () => {
     expect(markup).toContain("比较相邻元素");
   });
 
-  it("uses the light-theme background when theme is light", () => {
-    const markup = renderToStaticMarkup(
+  it("uses CSS variables so theme switches re-style without re-rendering", () => {
+    const dark = renderToStaticMarkup(BarBlockRenderer(props(barsStep(makeBars([1, 2])))));
+    const light = renderToStaticMarkup(
       BarBlockRenderer(props(barsStep(makeBars([1, 2])), { theme: "light" })),
     );
-    expect(markup).toContain("#f5f7fa");
+    // Both themes resolve background through the same --surface-2 var
+    expect(dark).toContain("var(--surface-2");
+    expect(light).toContain("var(--surface-2");
+    // Theme-specific fallbacks are kept for SSR / no-CSS-var environments
+    expect(dark).toContain("#0e1412");
+    expect(light).toContain("#faf8f3");
+  });
+
+  it("renders flat 2D bars without fake 3D faces", () => {
+    const markup = renderToStaticMarkup(BarBlockRenderer(props(barsStep(makeBars([5, 2, 8])))));
+    // The old renderer used skewX/skewY to fake top + side faces.
+    expect(markup).not.toMatch(/skew[XY]\(/);
   });
 
   it("is registered for the algorithm_bars snapshot kind", () => {

--- a/apps/web/src/features/playbook/engine/renderers/BarBlockRenderer.tsx
+++ b/apps/web/src/features/playbook/engine/renderers/BarBlockRenderer.tsx
@@ -5,44 +5,62 @@ import type { RendererProps } from "./types";
 import { selectMotion, swapMotion, writeMotion } from "./animationTemplates";
 import { buildPrevIndexMap } from "./prevIndexMap";
 
-const PALETTE = {
+/**
+ * Theme-reactive palette built on the app's CSS variables (see
+ * `useTweaks.themeVars`). Bars consume `var(--ink-2)` / `var(--accent)` so
+ * switching theme or accent at the root re-styles the renderer instantly
+ * without a renderer re-render — the inline `var(...)` references resolve at
+ * paint time against the live root vars.
+ *
+ * Theme-specific fallbacks keep server-rendered markup (tests, exports) from
+ * collapsing to transparent when CSS vars aren't yet applied. Values are kept
+ * subdued and aligned with the rest of the studio surface.
+ */
+const FALLBACKS = {
   dark: {
-    bg: "#0a0c10",
-    floor: "rgba(255,255,255,0.06)",
-    floorLine: "rgba(255,255,255,0.10)",
-    text: "#e8ecf4",
-    label: "rgba(232,236,244,0.85)",
-    narration: "rgba(232,236,244,0.6)",
-    barShadow: "rgba(0,0,0,0.45)",
-    active: "#ffd84d",
-    activeGlow: "rgba(255,216,77,0.55)",
-    swap: "#ff9e8a",
-    swapGlow: "rgba(255,158,138,0.5)",
-    sorted: "#5be8b4",
-    pointer: "#c8a8f8",
-    // heatmap: low value → cool, high value → warm
-    heat: (t: number) => `hsl(${Math.round(210 - 210 * t)}, 68%, 56%)`,
-    heatTop: (t: number) => `hsl(${Math.round(210 - 210 * t)}, 72%, 68%)`,
-    heatSide: (t: number) => `hsl(${Math.round(210 - 210 * t)}, 62%, 40%)`,
+    bg: "#0e1412",
+    text: "#e8efe9",
+    label: "#9ba8a0",
+    narration: "#5b6862",
+    barBase: "#27332c",
+    barAccent: "#10b981",
+    barOutline: "rgba(255,255,255,0.06)",
+    floor: "#27332c",
+    warn: "#e9a23b",
+    swapShadow: "rgba(233,162,59,0.35)",
+    accentShadow: "rgba(16,185,129,0.30)",
+    barShadow: "rgba(0,0,0,0.35)",
   },
   light: {
-    bg: "#f5f7fa",
-    floor: "rgba(0,0,0,0.05)",
-    floorLine: "rgba(0,0,0,0.12)",
-    text: "#141820",
-    label: "rgba(20,24,32,0.85)",
-    narration: "rgba(20,24,32,0.6)",
-    barShadow: "rgba(0,0,0,0.18)",
-    active: "#d4a017",
-    activeGlow: "rgba(212,160,23,0.45)",
-    swap: "#c05030",
-    swapGlow: "rgba(192,80,48,0.4)",
-    sorted: "#1a7a5e",
-    pointer: "#6030c0",
-    heat: (t: number) => `hsl(${Math.round(210 - 210 * t)}, 64%, 50%)`,
-    heatTop: (t: number) => `hsl(${Math.round(210 - 210 * t)}, 68%, 62%)`,
-    heatSide: (t: number) => `hsl(${Math.round(210 - 210 * t)}, 58%, 36%)`,
+    bg: "#faf8f3",
+    text: "#161a18",
+    label: "#5d655f",
+    narration: "#9aa39d",
+    barBase: "#d6d1c2",
+    barAccent: "#10b981",
+    barOutline: "rgba(0,0,0,0.05)",
+    floor: "#d6d1c2",
+    warn: "#e9a23b",
+    swapShadow: "rgba(233,162,59,0.30)",
+    accentShadow: "rgba(16,185,129,0.25)",
+    barShadow: "rgba(0,0,0,0.12)",
   },
+} as const;
+
+const VAR = {
+  bg: (t: "dark" | "light") => `var(--surface-2, ${FALLBACKS[t].bg})`,
+  text: (t: "dark" | "light") => `var(--ink, ${FALLBACKS[t].text})`,
+  label: (t: "dark" | "light") => `var(--ink-2, ${FALLBACKS[t].label})`,
+  narration: (t: "dark" | "light") => `var(--ink-3, ${FALLBACKS[t].narration})`,
+  barBase: (t: "dark" | "light") => `var(--line-2, ${FALLBACKS[t].barBase})`,
+  accent: (t: "dark" | "light") => `var(--accent, ${FALLBACKS[t].barAccent})`,
+  accentSoft: (t: "dark" | "light") => `var(--accent-soft, ${FALLBACKS[t].accentShadow})`,
+  warn: (t: "dark" | "light") => `var(--warn, ${FALLBACKS[t].warn})`,
+  floor: (t: "dark" | "light") => `var(--line, ${FALLBACKS[t].floor})`,
+  barOutline: (t: "dark" | "light") => FALLBACKS[t].barOutline,
+  barShadow: (t: "dark" | "light") => FALLBACKS[t].barShadow,
+  swapShadow: (t: "dark" | "light") => FALLBACKS[t].swapShadow,
+  accentShadow: (t: "dark" | "light") => FALLBACKS[t].accentShadow,
 } as const;
 
 const ENTER_BEZIER = Easing.bezier(0.16, 1, 0.3, 1);
@@ -50,7 +68,6 @@ const MOVE_FRAMES = 22;
 const MAX_BAR_HEIGHT = 360;
 const MIN_BAR_HEIGHT = 6;
 const SWAP_LIFT_REFERENCE = 90;
-const DEPTH = 14; // px of fake 3-D depth (top + side faces)
 
 export const BarBlockRenderer: React.FC<RendererProps> = ({
   step,
@@ -64,7 +81,7 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
     prevStep && prevStep.snapshot.kind === "algorithm_bars"
       ? (prevStep.snapshot as AlgorithmBarsSnapshot)
       : null;
-  const colors = PALETTE[theme];
+  const c = VAR;
   const elapsed = Math.max(0, frame - stepStartFrame);
 
   const n = snap.numeric_values.length;
@@ -84,7 +101,7 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
     return (
       <div
         style={{
-          background: colors.bg,
+          background: c.bg(theme),
           width: "100%",
           height: "100%",
           display: "flex",
@@ -92,7 +109,7 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
           justifyContent: "center",
         }}
       >
-        <p style={{ color: colors.narration, fontFamily: "system-ui", fontSize: 16 }}>
+        <p style={{ color: c.narration(theme), fontFamily: "system-ui", fontSize: 16 }}>
           {step.voiceover_text}
         </p>
       </div>
@@ -116,7 +133,7 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
       style={{
         width: "100%",
         height: "100%",
-        background: colors.bg,
+        background: c.bg(theme),
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
@@ -128,9 +145,10 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
     >
       <h2
         style={{
-          color: colors.text,
+          color: c.text(theme),
           fontSize: 20,
-          fontWeight: 700,
+          fontWeight: 600,
+          letterSpacing: "0.01em",
           margin: 0,
           opacity: titleOpacity,
         }}
@@ -138,23 +156,27 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
         {step.title}
       </h2>
 
-      {/* Bar field — bars rise from a shared baseline */}
+      {/* Bar field — flat 2D bars on a single baseline */}
       <div
         style={{
           display: "flex",
           alignItems: "flex-end",
           gap: barGap,
           position: "relative",
-          height: MAX_BAR_HEIGHT + DEPTH + 8,
-          paddingTop: DEPTH + 24,
-          // half-transparent floor grid as a coordinate reference
-          borderBottom: `2px solid ${colors.floorLine}`,
+          height: MAX_BAR_HEIGHT + 8,
+          paddingTop: 24,
+          borderBottom: `1px solid ${c.floor(theme)}`,
         }}
       >
         {snap.numeric_values.map((val, i) => {
           const label = snap.array_values[i] ?? String(val);
-          const t = Math.abs(val) / heightRef; // 0..1 heatmap position
-          const barH = Math.max(MIN_BAR_HEIGHT, (Math.abs(val) / heightRef) * MAX_BAR_HEIGHT);
+          // value-driven fill strength: shorter bars lean toward the base
+          // line color, taller bars saturate toward the accent. Keeps the
+          // whole field in one hue family (theme accent) instead of a
+          // rainbow heatmap.
+          const t = Math.abs(val) / heightRef; // 0..1
+          const fillRatio = 0.35 + 0.65 * t; // 0.35..1
+          const barH = Math.max(MIN_BAR_HEIGHT, t * MAX_BAR_HEIGHT);
 
           const prevIdx = prevIndexMap[i];
           const isActive = activeSet.has(i);
@@ -166,7 +188,7 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
           let ty = 0;
           let scale = 1;
           let shadowOpacity = 0;
-          let shadowColor: string = colors.swapGlow;
+          let shadowColor: string = c.swapShadow(theme);
           let zIndex = 0;
           let writeOpacity = 1;
 
@@ -184,7 +206,7 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
             ty = m.translateY;
             scale = m.scale;
             shadowOpacity = m.shadowOpacity;
-            shadowColor = colors.swapGlow;
+            shadowColor = c.swapShadow(theme);
             zIndex = m.zIndex;
           } else if (prevIdx >= 0 && prevIdx !== i) {
             const progress = interpolate(elapsed, [0, MOVE_FRAMES], [0, 1], {
@@ -200,36 +222,42 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
           }
 
           // ── Fill colors ──
-          let face = colors.heat(t);
-          let faceTop = colors.heatTop(t);
-          let faceSide = colors.heatSide(t);
-          let outline = "rgba(0,0,0,0.18)";
-          let labelColor: string = colors.label;
+          // Default: line color (subtle) blended into accent based on height.
+          // We use a single solid color per bar (no top/side faces, no
+          // multi-stop gradient) so the visual is genuinely flat 2D.
+          let face: string = c.accent(theme);
+          let opacity = fillRatio;
+          let outline: string = c.barOutline(theme);
+          let labelColor: string = c.label(theme);
 
           if (isActive) {
             const s = selectMotion(elapsed);
             ty += s.translateY;
             scale = Math.max(scale, s.scale);
-            face = colors.active;
-            faceTop = colors.active;
-            faceSide = colors.active;
-            outline = colors.active;
-            labelColor = colors.text;
+            face = c.accent(theme);
+            opacity = 1;
+            outline = c.accent(theme);
+            labelColor = c.text(theme);
             shadowOpacity = Math.max(shadowOpacity, s.shadowOpacity);
-            shadowColor = colors.activeGlow;
+            shadowColor = c.accentShadow(theme);
           } else if (isSwap) {
-            face = colors.swap;
-            faceTop = colors.swap;
-            faceSide = colors.swap;
-            outline = colors.swap;
-            labelColor = colors.text;
+            face = c.warn(theme);
+            opacity = 1;
+            outline = c.warn(theme);
+            labelColor = c.text(theme);
             if (shadowOpacity === 0) shadowOpacity = 0.4;
-            shadowColor = colors.swapGlow;
+            shadowColor = c.swapShadow(theme);
           } else if (isSorted) {
-            face = colors.sorted;
-            faceTop = colors.sorted;
-            faceSide = colors.sorted;
-            outline = "rgba(0,0,0,0.18)";
+            // Sorted: same hue as accent, slightly lower opacity to read as
+            // "settled, no longer interactive".
+            face = c.accent(theme);
+            opacity = 0.55;
+            outline = c.barOutline(theme);
+            labelColor = c.label(theme);
+          } else {
+            // Idle bars: muted color so highlights pop.
+            face = c.barBase(theme);
+            opacity = Math.max(0.5, fillRatio);
           }
 
           // ── Staggered entry ──
@@ -251,10 +279,7 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
 
           const glow =
             shadowOpacity > 0
-              ? `, 0 0 ${12 + shadowOpacity * 16}px ${shadowColor.replace(
-                  /[\d.]+\)$/,
-                  `${shadowOpacity})`,
-                )}`
+              ? `, 0 0 ${10 + shadowOpacity * 12}px ${shadowColor}`
               : "";
 
           return (
@@ -279,7 +304,7 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
                   position: "absolute",
                   top: -22,
                   fontSize: labelFont,
-                  fontWeight: 700,
+                  fontWeight: 600,
                   color: labelColor,
                   lineHeight: 1,
                   whiteSpace: "nowrap",
@@ -287,51 +312,31 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
               >
                 {label}
                 {isSorted && (
-                  <span style={{ color: colors.sorted, marginLeft: 3, fontSize: labelFont * 0.9 }}>
+                  <span
+                    style={{
+                      color: c.accent(theme),
+                      marginLeft: 3,
+                      fontSize: labelFont * 0.9,
+                      opacity: 0.85,
+                    }}
+                  >
                     ✓
                   </span>
                 )}
               </span>
 
-              {/* top face (fake 3-D) */}
+              {/* flat 2D bar */}
               <div
                 style={{
-                  position: "absolute",
-                  bottom: renderedH,
                   width: barW,
-                  height: DEPTH,
-                  background: faceTop,
-                  transform: `skewX(-45deg) translateX(${DEPTH / 2}px)`,
-                  transformOrigin: "bottom left",
+                  height: renderedH,
+                  background: face,
+                  opacity,
+                  border: `1px solid ${outline}`,
+                  borderBottom: "none",
                   borderTopLeftRadius: 3,
                   borderTopRightRadius: 3,
-                  filter: "brightness(1.18)",
-                }}
-              />
-              {/* right side face (fake 3-D) */}
-              <div
-                style={{
-                  position: "absolute",
-                  bottom: 0,
-                  left: barW,
-                  width: DEPTH,
-                  height: renderedH,
-                  background: faceSide,
-                  transform: "skewY(-45deg)",
-                  transformOrigin: "bottom left",
-                  filter: "brightness(0.78)",
-                }}
-              />
-              {/* front face */}
-              <div
-                style={{
-                  width: barW,
-                  height: renderedH,
-                  background: `linear-gradient(160deg, ${face} 0%, ${faceSide} 130%)`,
-                  border: `1.5px solid ${outline}`,
-                  borderTopLeftRadius: 4,
-                  borderTopRightRadius: 4,
-                  boxShadow: `0 4px 10px ${colors.barShadow}${glow}`,
+                  boxShadow: `0 1px 2px ${c.barShadow(theme)}${glow}`,
                 }}
               />
               {/* index label below the baseline */}
@@ -340,7 +345,7 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
                   position: "absolute",
                   bottom: -22,
                   fontSize: 11,
-                  color: colors.narration,
+                  color: c.narration(theme),
                   fontWeight: 400,
                 }}
               >
@@ -366,7 +371,7 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
                   display: "flex",
                   flexDirection: "column",
                   alignItems: "center",
-                  color: colors.pointer,
+                  color: c.accent(theme),
                   fontSize: 13,
                   fontWeight: 600,
                   opacity: pointerOpacity,
@@ -383,7 +388,7 @@ export const BarBlockRenderer: React.FC<RendererProps> = ({
 
       <p
         style={{
-          color: colors.narration,
+          color: c.narration(theme),
           fontSize: 15,
           maxWidth: 720,
           textAlign: "center",

--- a/apps/web/src/features/playbook/engine/renderers/CodeHighlightRenderer.tsx
+++ b/apps/web/src/features/playbook/engine/renderers/CodeHighlightRenderer.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { CodeHighlightOverlay } from "../types";
-import { tokenize, type TokenKind } from "./codeTokenizer";
+import { tokenizeLines, type TokenKind } from "./codeTokenizer";
 
 interface CodeHighlightRendererProps {
   overlay: CodeHighlightOverlay;
@@ -116,11 +116,16 @@ export const CodeHighlightRenderer: React.FC<CodeHighlightRendererProps> = ({
 
       {/* Code lines */}
       <div style={{ flex: 1, overflowY: "auto", overflowX: "auto" }}>
-        {overlay.lines.map((line, i) => {
-          const isActive = activeSet.has(i);
-          const isAnchor = i === overlay.active_line;
-          const showLabel = isAnchor && !!overlay.operation_label;
-          const tokens = tokenize(line || " ", overlay.language);
+        {(() => {
+          const allTokens = tokenizeLines(
+            overlay.lines.map((l) => l || " "),
+            overlay.language,
+          );
+          return overlay.lines.map((line, i) => {
+            const isActive = activeSet.has(i);
+            const isAnchor = i === overlay.active_line;
+            const showLabel = isAnchor && !!overlay.operation_label;
+            const tokens = allTokens[i];
 
           return (
             <div
@@ -190,7 +195,8 @@ export const CodeHighlightRenderer: React.FC<CodeHighlightRendererProps> = ({
               </pre>
             </div>
           );
-        })}
+          });
+        })()}
       </div>
 
       {/* Variable watch panel */}

--- a/apps/web/src/features/playbook/engine/renderers/codeTokenizer.test.ts
+++ b/apps/web/src/features/playbook/engine/renderers/codeTokenizer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { tokenize } from "./codeTokenizer";
+import { tokenize, tokenizeLines } from "./codeTokenizer";
 
 describe("tokenize — JavaScript", () => {
   it("classifies function keyword", () => {
@@ -81,6 +81,94 @@ describe("tokenize — Go", () => {
   it("// comment in Go", () => {
     const tokens = tokenize("// go comment", "golang");
     expect(tokens[0].kind).toBe("comment");
+  });
+});
+
+describe("tokenize — block comments (#32)", () => {
+  it("recognizes inline /* */ as a single comment token in C++", () => {
+    const tokens = tokenize("/* hello */ int x = 1;", "cpp");
+    expect(tokens[0]).toEqual({ kind: "comment", text: "/* hello */" });
+    expect(tokens.find((t) => t.text === "int")?.kind).toBe("keyword");
+  });
+
+  it("recognizes /* */ inline in Java", () => {
+    const tokens = tokenize("public /* note */ void run() {}", "java");
+    expect(tokens.find((t) => t.text === "/* note */")?.kind).toBe("comment");
+  });
+
+  it("recognizes /* */ inline in JavaScript", () => {
+    const tokens = tokenize("const x = /* inline */ 42;", "javascript");
+    expect(tokens.find((t) => t.text === "/* inline */")?.kind).toBe("comment");
+  });
+
+  it("unclosed /* on a single line tokenize() treats rest as comment", () => {
+    const tokens = tokenize("foo /* unclosed forever", "cpp");
+    expect(tokens.find((t) => t.text === "/* unclosed forever")?.kind).toBe("comment");
+  });
+
+  it("Python does not treat /* as block comment", () => {
+    const tokens = tokenize("a / b", "python");
+    expect(tokens.every((t) => t.kind !== "comment")).toBe(true);
+  });
+
+  it("tokenizeLines preserves block comment across lines", () => {
+    const lines = ["/* start", "  body", "  end */ int z;"];
+    const result = tokenizeLines(lines, "cpp");
+    expect(result[0][0].kind).toBe("comment");
+    expect(result[1][0].kind).toBe("comment");
+    expect(result[2][0].kind).toBe("comment");
+    expect(result[2].find((t) => t.text === "int")?.kind).toBe("keyword");
+  });
+
+  it("tokenizeLines: code before and after multi-line block stays normal", () => {
+    const lines = ["int a;", "/* block", "still */", "int b;"];
+    const result = tokenizeLines(lines, "cpp");
+    expect(result[0].find((t) => t.text === "int")?.kind).toBe("keyword");
+    expect(result[3].find((t) => t.text === "int")?.kind).toBe("keyword");
+    expect(result[1].some((t) => t.kind === "comment")).toBe(true);
+    expect(result[2].some((t) => t.kind === "comment")).toBe(true);
+  });
+});
+
+describe("tokenize — Rust (#37)", () => {
+  it("classifies fn keyword", () => {
+    const tokens = tokenize("fn main() {}", "rust");
+    expect(tokens[0]).toEqual({ kind: "keyword", text: "fn" });
+  });
+
+  it("classifies let mut as keywords", () => {
+    const tokens = tokenize("let mut x = 0;", "rust");
+    expect(tokens.find((t) => t.text === "let")?.kind).toBe("keyword");
+    expect(tokens.find((t) => t.text === "mut")?.kind).toBe("keyword");
+  });
+
+  it("recognizes match, impl, trait", () => {
+    expect(tokenize("match x {}", "rust")[0].kind).toBe("keyword");
+    expect(tokenize("impl Foo {}", "rust")[0].kind).toBe("keyword");
+    expect(tokenize("trait Bar {}", "rust")[0].kind).toBe("keyword");
+  });
+
+  it("recognizes Self/Result/Option", () => {
+    const tokens = tokenize("fn f() -> Result<Self, Option<u32>> {}", "rust");
+    expect(tokens.find((t) => t.text === "Result")?.kind).toBe("keyword");
+    expect(tokens.find((t) => t.text === "Self")?.kind).toBe("keyword");
+    expect(tokens.find((t) => t.text === "Option")?.kind).toBe("keyword");
+    expect(tokens.find((t) => t.text === "u32")?.kind).toBe("keyword");
+  });
+
+  it("recognizes macros like println!", () => {
+    const tokens = tokenize('println!("hi");', "rust");
+    expect(tokens[0]).toEqual({ kind: "keyword", text: "println!" });
+  });
+
+  it("rs alias works", () => {
+    const tokens = tokenize("fn x() {}", "rs");
+    expect(tokens[0].kind).toBe("keyword");
+  });
+
+  it("supports /* */ block comments in Rust", () => {
+    const tokens = tokenize("/* doc */ fn x() {}", "rust");
+    expect(tokens[0]).toEqual({ kind: "comment", text: "/* doc */" });
   });
 });
 

--- a/apps/web/src/features/playbook/engine/renderers/codeTokenizer.ts
+++ b/apps/web/src/features/playbook/engine/renderers/codeTokenizer.ts
@@ -49,6 +49,24 @@ const C_KEYWORDS = new Set([
   "union", "unsigned", "using", "virtual", "void", "volatile", "while",
 ]);
 
+const RUST_KEYWORDS = new Set([
+  "as", "async", "await", "break", "const", "continue", "crate", "dyn", "else",
+  "enum", "extern", "false", "fn", "for", "if", "impl", "in", "let", "loop",
+  "match", "mod", "move", "mut", "pub", "ref", "return", "self", "Self",
+  "static", "struct", "super", "trait", "true", "type", "unsafe", "use",
+  "where", "while", "box", "do", "final", "macro", "override", "priv",
+  "typeof", "unsized", "virtual", "yield", "try",
+  // Common macros (matched without trailing `!`)
+  "println", "print", "eprintln", "eprint", "format", "write", "writeln",
+  "vec", "assert", "assert_eq", "assert_ne", "debug_assert", "panic",
+  "dbg", "todo", "unimplemented", "unreachable", "include", "include_str",
+  "include_bytes", "env",
+  // Common stdlib types frequently treated as keyword-like for highlighting
+  "Option", "Result", "Some", "None", "Ok", "Err", "Box", "Vec", "String",
+  "str", "bool", "char", "i8", "i16", "i32", "i64", "i128", "isize",
+  "u8", "u16", "u32", "u64", "u128", "usize", "f32", "f64",
+]);
+
 const KEYWORDS_BY_LANG: Record<string, Set<string>> = {
   javascript: JS_KEYWORDS,
   typescript: JS_KEYWORDS,
@@ -63,12 +81,22 @@ const KEYWORDS_BY_LANG: Record<string, Set<string>> = {
   cpp: C_KEYWORDS,
   "c++": C_KEYWORDS,
   "c/c++": C_KEYWORDS,
+  rust: RUST_KEYWORDS,
+  rs: RUST_KEYWORDS,
 };
 
-function langComment(lang: string): RegExp {
-  return lang === "python" || lang === "py"
-    ? /^#.*/
-    : /^\/\/.*/;
+function isPythonLang(lang: string): boolean {
+  return lang === "python" || lang === "py";
+}
+
+function supportsBlockComment(lang: string): boolean {
+  // Python uses # only; everything else we support has /* */
+  return !isPythonLang(lang);
+}
+
+function lineCommentRe(lang: string): RegExp | null {
+  if (isPythonLang(lang)) return /^#.*/;
+  return /^\/\/.*/;
 }
 
 const RE_STRING_DOUBLE = /^"(?:[^"\\]|\\.)*"/;
@@ -76,90 +104,134 @@ const RE_STRING_SINGLE = /^'(?:[^'\\]|\\.)*'/;
 const RE_STRING_TRIPLE = /^"""[\s\S]*?"""/;
 const RE_NUMBER = /^\b\d+(?:\.\d+)?\b/;
 const RE_OPERATOR = /^[=+\-*/<>!&|^%~?:]+/;
-const RE_IDENT = /^[A-Za-z_][A-Za-z0-9_]*/;
+const RE_IDENT = /^[A-Za-z_][A-Za-z0-9_]*!?/;
 const RE_PUNCT = /^[^\w\s"'#/=+\-*<>!&|^%~?:]+/;
 const RE_WS = /^\s+/;
+const RE_BLOCK_COMMENT_OPEN = /^\/\*/;
 
-export function tokenize(line: string, language: string): Token[] {
+interface TokenizeState {
+  inBlockComment: boolean;
+}
+
+function tokenizeLine(line: string, language: string, state: TokenizeState): Token[] {
   const lang = language.toLowerCase().trim();
   const keywords = KEYWORDS_BY_LANG[lang] ?? new Set<string>();
-  const commentRe = langComment(lang);
-  const isPython = lang === "python" || lang === "py";
+  const commentRe = lineCommentRe(lang);
+  const hasBlock = supportsBlockComment(lang);
+  const isPython = isPythonLang(lang);
 
   const tokens: Token[] = [];
   let rest = line;
 
+  // If we entered this line inside a block comment, consume until */ or end-of-line
+  if (state.inBlockComment) {
+    const closeIdx = rest.indexOf("*/");
+    if (closeIdx === -1) {
+      if (rest.length > 0) tokens.push({ kind: "comment", text: rest });
+      return tokens;
+    }
+    tokens.push({ kind: "comment", text: rest.slice(0, closeIdx + 2) });
+    rest = rest.slice(closeIdx + 2);
+    state.inBlockComment = false;
+  }
+
   while (rest.length > 0) {
     let m: RegExpExecArray | null;
 
-    // Whitespace — preserve as text
     if ((m = RE_WS.exec(rest))) {
       tokens.push({ kind: "text", text: m[0] });
       rest = rest.slice(m[0].length);
       continue;
     }
 
-    // Comment
-    if ((m = commentRe.exec(rest))) {
+    // Block comment open (C-family) — must precede operator match because `/` overlaps
+    if (hasBlock && RE_BLOCK_COMMENT_OPEN.test(rest)) {
+      const closeIdx = rest.indexOf("*/", 2);
+      if (closeIdx === -1) {
+        tokens.push({ kind: "comment", text: rest });
+        state.inBlockComment = true;
+        return tokens;
+      }
+      tokens.push({ kind: "comment", text: rest.slice(0, closeIdx + 2) });
+      rest = rest.slice(closeIdx + 2);
+      continue;
+    }
+
+    if (commentRe && (m = commentRe.exec(rest))) {
       tokens.push({ kind: "comment", text: m[0] });
       rest = rest.slice(m[0].length);
       continue;
     }
 
-    // Triple-quoted string (Python)
     if (isPython && (m = RE_STRING_TRIPLE.exec(rest))) {
       tokens.push({ kind: "string", text: m[0] });
       rest = rest.slice(m[0].length);
       continue;
     }
 
-    // Double-quoted string
     if ((m = RE_STRING_DOUBLE.exec(rest))) {
       tokens.push({ kind: "string", text: m[0] });
       rest = rest.slice(m[0].length);
       continue;
     }
 
-    // Single-quoted string
     if ((m = RE_STRING_SINGLE.exec(rest))) {
       tokens.push({ kind: "string", text: m[0] });
       rest = rest.slice(m[0].length);
       continue;
     }
 
-    // Number
     if ((m = RE_NUMBER.exec(rest))) {
       tokens.push({ kind: "number", text: m[0] });
       rest = rest.slice(m[0].length);
       continue;
     }
 
-    // Identifier or keyword
     if ((m = RE_IDENT.exec(rest))) {
-      const kind: TokenKind = keywords.has(m[0]) ? "keyword" : "text";
-      tokens.push({ kind, text: m[0] });
-      rest = rest.slice(m[0].length);
+      const raw = m[0];
+      // Rust macros: `println!`, `vec!` — keep trailing `!` as part of token if recognized
+      const lookup = keywords.has(raw)
+        ? raw
+        : raw.endsWith("!") && keywords.has(raw.slice(0, -1))
+          ? raw.slice(0, -1)
+          : raw;
+      const kind: TokenKind = keywords.has(lookup) ? "keyword" : "text";
+      tokens.push({ kind, text: raw });
+      rest = rest.slice(raw.length);
       continue;
     }
 
-    // Operator
     if ((m = RE_OPERATOR.exec(rest))) {
       tokens.push({ kind: "operator", text: m[0] });
       rest = rest.slice(m[0].length);
       continue;
     }
 
-    // Punctuation / other — consume one char
     if ((m = RE_PUNCT.exec(rest))) {
       tokens.push({ kind: "text", text: m[0] });
       rest = rest.slice(m[0].length);
       continue;
     }
 
-    // Fallback: consume one char to avoid infinite loop
     tokens.push({ kind: "text", text: rest[0] });
     rest = rest.slice(1);
   }
 
   return tokens;
+}
+
+/**
+ * Stateless single-line tokenizer. Block comments closed on the same line are
+ * recognized; an unclosed `/*` is treated as comment-to-end-of-line.
+ */
+export function tokenize(line: string, language: string): Token[] {
+  return tokenizeLine(line, language, { inBlockComment: false });
+}
+
+/**
+ * Tokenize a list of lines preserving multi-line block-comment state.
+ */
+export function tokenizeLines(lines: readonly string[], language: string): Token[][] {
+  const state: TokenizeState = { inBlockComment: false };
+  return lines.map((line) => tokenizeLine(line, language, state));
 }

--- a/apps/web/src/features/playbook/engine/replay/__tests__/sortingAlgorithms.test.ts
+++ b/apps/web/src/features/playbook/engine/replay/__tests__/sortingAlgorithms.test.ts
@@ -68,6 +68,16 @@ describe.each(ALGORITHMS)("%s replay", (name, sort) => {
     }
   });
 
+  it.each(CASES)("sorted_indices is always ascending — %s (#35)", (_label, input) => {
+    const steps = sort([...input]);
+    for (const step of steps) {
+      const idxs = step.snapshot.sorted_indices;
+      for (let i = 1; i < idxs.length; i++) {
+        expect(idxs[i]).toBeGreaterThan(idxs[i - 1]);
+      }
+    }
+  });
+
   it(`${name}: does not mutate the caller's input array`, () => {
     const input = ["3", "1", "2"];
     const snapshot = [...input];

--- a/apps/web/src/features/playbook/engine/replay/algorithms/_helpers.ts
+++ b/apps/web/src/features/playbook/engine/replay/algorithms/_helpers.ts
@@ -1,5 +1,26 @@
 import type { AlgorithmArraySnapshot, AlgorithmBarsSnapshot } from "../../types";
 
+/**
+ * Insert `idx` into `sorted` keeping the array in ascending order (no duplicates).
+ * Mutates and returns `sorted` for ergonomic call-site chaining inside replay loops.
+ *
+ * Why: replay algorithms must emit `sorted_indices` in a deterministic ascending
+ * order. Using `Set<number>` and relying on insertion order is a latent bug — see
+ * issue #35. Callers should hold a `number[]` and use this helper.
+ */
+export function addSortedIndex(sorted: number[], idx: number): number[] {
+  let lo = 0;
+  let hi = sorted.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (sorted[mid] < idx) lo = mid + 1;
+    else hi = mid;
+  }
+  if (sorted[lo] === idx) return sorted;
+  sorted.splice(lo, 0, idx);
+  return sorted;
+}
+
 export function range(lo: number, hi: number): number[] {
   const out: number[] = [];
   for (let i = lo; i < hi; i++) out.push(i);

--- a/apps/web/src/features/playbook/engine/replay/algorithms/quickSort.ts
+++ b/apps/web/src/features/playbook/engine/replay/algorithms/quickSort.ts
@@ -1,11 +1,11 @@
 import type { ReplayedStep } from "../types";
-import { compareValues, range, snapshot } from "./_helpers";
+import { addSortedIndex, compareValues, range, snapshot } from "./_helpers";
 
 export function quickSort(input: string[]): ReplayedStep[] {
   const arr = [...input];
   const n = arr.length;
   const steps: ReplayedStep[] = [];
-  const sortedAccum = new Set<number>();
+  const sortedAccum: number[] = [];
 
   if (n <= 1) {
     steps.push({ snapshot: snapshot(arr, [], range(0, n)), hint: "已有序" });
@@ -18,12 +18,12 @@ export function quickSort(input: string[]): ReplayedStep[] {
     const pivot = arr[hi];
     let i = lo - 1;
     steps.push({
-      snapshot: snapshot(arr, [hi], Array.from(sortedAccum), [], { lo, hi, pivot: hi }),
+      snapshot: snapshot(arr, [hi], [...sortedAccum], [], { lo, hi, pivot: hi }),
       hint: `选定 pivot = A[${hi}] = ${pivot}`,
     });
     for (let j = lo; j < hi; j++) {
       steps.push({
-        snapshot: snapshot(arr, [j, hi], Array.from(sortedAccum), [], { lo, hi, i, j }),
+        snapshot: snapshot(arr, [j, hi], [...sortedAccum], [], { lo, hi, i, j }),
         hint: `比较 A[${j}] 与 pivot`,
       });
       if (compareValues(arr[j], pivot) <= 0) {
@@ -31,7 +31,7 @@ export function quickSort(input: string[]): ReplayedStep[] {
         if (i !== j) {
           [arr[i], arr[j]] = [arr[j], arr[i]];
           steps.push({
-            snapshot: snapshot(arr, [i, j], Array.from(sortedAccum), [i, j], { lo, hi, i, j }),
+            snapshot: snapshot(arr, [i, j], [...sortedAccum], [i, j], { lo, hi, i, j }),
             hint: `交换 A[${i}] 与 A[${j}]`,
           });
         }
@@ -40,18 +40,18 @@ export function quickSort(input: string[]): ReplayedStep[] {
     if (i + 1 !== hi) {
       [arr[i + 1], arr[hi]] = [arr[hi], arr[i + 1]];
       steps.push({
-        snapshot: snapshot(arr, [i + 1, hi], Array.from(sortedAccum), [i + 1, hi], { lo, hi, i }),
+        snapshot: snapshot(arr, [i + 1, hi], [...sortedAccum], [i + 1, hi], { lo, hi, i }),
         hint: `pivot 归位至 A[${i + 1}]`,
       });
     }
-    sortedAccum.add(i + 1);
+    addSortedIndex(sortedAccum, i + 1);
     return i + 1;
   };
 
   const recurse = (lo: number, hi: number): void => {
     if (lo > hi) return;
     if (lo === hi) {
-      sortedAccum.add(lo);
+      addSortedIndex(sortedAccum, lo);
       return;
     }
     const p = partition(lo, hi);

--- a/apps/web/src/features/playbook/engine/replay/mergeSort.ts
+++ b/apps/web/src/features/playbook/engine/replay/mergeSort.ts
@@ -1,11 +1,11 @@
 import type { ReplayedStep } from "./types";
-import { compareValues, range, snapshot } from "./algorithms/_helpers";
+import { addSortedIndex, compareValues, range, snapshot } from "./algorithms/_helpers";
 
 export function mergeSort(input: string[]): ReplayedStep[] {
   const arr = [...input];
   const n = arr.length;
   const steps: ReplayedStep[] = [];
-  const sortedAccum = new Set<number>();
+  const sortedAccum: number[] = [];
 
   if (n <= 1) {
     steps.push({ snapshot: snapshot(arr, [], range(0, n)), hint: "已有序" });
@@ -22,7 +22,7 @@ export function mergeSort(input: string[]): ReplayedStep[] {
     const mid = (lo + hi) >> 1;
 
     steps.push({
-      snapshot: snapshot(arr, range(lo, hi), Array.from(sortedAccum)),
+      snapshot: snapshot(arr, range(lo, hi), [...sortedAccum]),
       hint: `划分 [${lo}, ${hi})`,
     });
 
@@ -42,12 +42,12 @@ export function mergeSort(input: string[]): ReplayedStep[] {
         arr[k] = right[j];
         j += 1;
       }
-      sortedAccum.add(k);
+      addSortedIndex(sortedAccum, k);
       steps.push({
         snapshot: snapshot(
           arr,
           range(lo, hi),
-          Array.from(sortedAccum),
+          [...sortedAccum],
           [k],
           { i: lo + i, j: mid + j, k: k + 1 },
         ),
@@ -57,9 +57,9 @@ export function mergeSort(input: string[]): ReplayedStep[] {
     }
     while (i < left.length) {
       arr[k] = left[i];
-      sortedAccum.add(k);
+      addSortedIndex(sortedAccum, k);
       steps.push({
-        snapshot: snapshot(arr, range(lo, hi), Array.from(sortedAccum), [k]),
+        snapshot: snapshot(arr, range(lo, hi), [...sortedAccum], [k]),
         hint: `合并 [${lo}, ${hi})`,
       });
       i += 1;
@@ -67,9 +67,9 @@ export function mergeSort(input: string[]): ReplayedStep[] {
     }
     while (j < right.length) {
       arr[k] = right[j];
-      sortedAccum.add(k);
+      addSortedIndex(sortedAccum, k);
       steps.push({
-        snapshot: snapshot(arr, range(lo, hi), Array.from(sortedAccum), [k]),
+        snapshot: snapshot(arr, range(lo, hi), [...sortedAccum], [k]),
         hint: `合并 [${lo}, ${hi})`,
       });
       j += 1;

--- a/apps/web/src/features/playbook/engine/replay/types.ts
+++ b/apps/web/src/features/playbook/engine/replay/types.ts
@@ -1,8 +1,31 @@
-import type { AlgorithmArraySnapshot, AlgorithmBarsSnapshot } from "../types";
+import type {
+  AlgorithmArraySnapshot,
+  AlgorithmBarsSnapshot,
+  CodeHighlightOverlay,
+  NarrationTemplate,
+} from "../types";
 
+/**
+ * A single step emitted by a replay algorithm. The required fields (snapshot,
+ * hint) describe the visual state and minimal narration. The optional fields
+ * mirror the corresponding fields on `MetaStep` and allow a replay step to
+ * carry richer metadata when an algorithm wants to drive TTS rate, frame
+ * duration, code-highlight overlay, or a structured narration template.
+ *
+ * Why: see issue #34 — the previous narrow type blocked composing replay-driven
+ * animation with LLM-supplied narration / pacing / code overlays.
+ */
 export interface ReplayedStep {
   snapshot: AlgorithmArraySnapshot | AlgorithmBarsSnapshot;
   hint?: string;
+  /** Optional override for TTS rate (0.5–2.0). When omitted, player uses config default. */
+  tts_rate?: number | null;
+  /** Optional frame duration for this step. Resolver may scale to fit overall script length. */
+  durationFrames?: number | null;
+  /** Optional code-highlight overlay synchronized with this step. */
+  codeHighlight?: CodeHighlightOverlay | null;
+  /** Optional structured narration template for LLM-augmented pipelines. */
+  narrationTemplate?: NarrationTemplate | null;
 }
 
 export type AlgorithmReplay = (input: string[]) => ReplayedStep[];


### PR DESCRIPTION
Closes #27, #32, #33, #34, #35, #36, #37.

## Summary

Seven backlog issues across CI, frontend renderers, replay algorithms, TTS, and backend test coverage — plus a follow-up pass on the bar-block renderer to match the studio's subdued palette and react to live theme/accent changes.

## What changed

### CI
- **#27** — `check.yml` now runs on `push` to `feat/**`, `fix/**`, `claude/**` (not just `main`/`dev`) and adds workflow-level concurrency so rapid pushes cancel in-flight runs. AI-driven `claude/*` branches finally get pre-PR feedback.

### Frontend — `codeTokenizer`
- **#32** — Added stateful `tokenizeLines()` that carries `/* ... */` state across lines. Inline and multi-line block comments now render as comments instead of mis-tokenizing into operators + identifiers.
- **#37** — Added the Rust keyword set (control flow, declarations, common stdlib types) plus macro detection (`println!`, `vec!`, etc.) and `rust` / `rs` language aliases. `CodeHighlightRenderer` switched to `tokenizeLines` so multi-line state is preserved across the whole file.

### Frontend — replay
- **#35** — `quickSort.ts` and `mergeSort.ts` no longer rely on `Set<number>` insertion order to deliver `sorted_indices`. New `addSortedIndex()` helper keeps a `number[]` in ascending order via binary insertion. Per-step ascending-order assertion added across all five sort algorithms.
- **#34** — Widened `ReplayedStep` with optional `tts_rate`, `durationFrames`, `codeHighlight`, `narrationTemplate` so replay algorithms can carry the same metadata as `MetaStep`. `useResolvedScript` forwards populated fields onto the resolved step.

### Frontend — TTS
- **#33** — Extracted the module-level `Map` cache into a `TTSAudioCache` class: byte-bounded (default 64 MB instead of "50 entries"), exposes `stats()` for hit/miss observability, supports `clear()` and `delete(key)`, and is constructible so tests don't share state. `useTTS` consumes the shared singleton and surfaces `cacheStats` / `clearCache`.

### Frontend — bar block renderer (follow-up to user feedback)
- **#31** — Removed the fake 3-D top/side faces; bars are now flat 2D with a 1 px outline and minimal shadow.
- Replaced the hsl heatmap (210° → 0°) with a single-hue palette driven by the studio's CSS variables (`--accent`, `--line-2`, `--ink-*`, `--surface-2`, `--warn`, `--line`). Bars repaint instantly when the user toggles theme or changes accent at the root — no React re-render needed (verified by changing `--accent` from `#10b981` to `#8b5cf6` on the live root; bars + pointers switched immediately).
- Theme-specific hex fallbacks kept inline for SSR / no-CSS-var environments.

### Backend
- **#36** — `test_playbook_builder.py` gains a `TestEdgeCases` class with 17 tests covering empty CIR, missing/zero/negative execution_map, user-source > library > LLM source priority chain, out-of-range and negative `code_lines` filtering, `algorithm_id` inference fallback and override, edgeless / explicit-edge tree snapshots, the swap-title heuristic, and single-step animation hint contract.

## Verification

- Frontend: **249 tests pass** (vitest)
- Backend: **73 tests pass** (pytest)
- Browser: app loads, no console errors, modules `import()` cleanly, live verification of:
  - block comments + Rust + `println!` tokenizing
  - `TTSAudioCache` byte eviction + hit/miss stats
  - quickSort/mergeSort `sorted_indices` strictly ascending every step
  - flat 2D bars in both dark and light theme
  - real-time accent swap (`#10b981` → `#8b5cf6`) without re-render

## Notes for reviewers

- The bar renderer rewrite changed the palette contract from theme-specific hex constants to CSS-var references. Server-rendered output still includes theme-appropriate hex fallbacks via `var(name, fallback)`, so non-browser consumers (test snapshots, export pipelines) still get a sane color.
- `ReplayedStep` new fields are all optional — existing replay algorithms are unchanged. The widened type is a one-way ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)