### PR TITLE
[codex] Add quadratic transform skill

### DIFF
--- a/apps/api/app/domain/skills/quadratic_transform/__init__.py
+++ b/apps/api/app/domain/skills/quadratic_transform/__init__.py
@@ -1,0 +1,3 @@
+from app.domain.skills.quadratic_transform.skill_pack import QuadraticTransformSkillPack
+
+__all__ = ["QuadraticTransformSkillPack"]

--- a/apps/api/app/domain/skills/quadratic_transform/manifest.py
+++ b/apps/api/app/domain/skills/quadratic_transform/manifest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from app.domain.skills.base import SkillCapability, SkillManifest
+
+QUADRATIC_TRANSFORM_MANIFEST = SkillManifest(
+    skill_id="quadratic_transform",
+    domain="math",
+    name="Quadratic Transform",
+    description=(
+        "Deterministic visual explanations for quadratic graph transformations "
+        "in vertex form y=a(x-h)^2+k."
+    ),
+    execution_mode="deterministic",
+    capabilities=[
+        SkillCapability(
+            capability_id="quadratic_transform.vertex_form",
+            description=(
+                "Explain graph transformations from y=x^2 to vertex-form "
+                "quadratics y=a(x-h)^2+k."
+            ),
+            supported=True,
+            examples=[
+                "解释 y=(x-2)^2+1 的图像变换",
+                "讲一下 y=2(x+1)^2-3 是怎么从 y=x^2 变来的",
+                "解释 y=-(x-1)^2 的开口和平移",
+            ],
+            output_schema="QuadraticTransformProblemSpec",
+        ),
+    ],
+    unsupported_notes=[
+        "V1 only supports vertex-form quadratics.",
+        "Expanded forms such as y=x^2+2x+1 should fall back to the generic pipeline.",
+    ],
+)

--- a/apps/api/app/domain/skills/quadratic_transform/playbook_adapter.py
+++ b/apps/api/app/domain/skills/quadratic_transform/playbook_adapter.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from app.domain.models.playbook import (
+    Layer,
+    LayerTiming,
+    MathPlotCurve,
+    MathPlotSnapshot,
+    MetaStep,
+    PlaybookScript,
+)
+from app.domain.models.topic import TopicDomain
+from app.domain.skills.quadratic_transform.problem_spec import (
+    QuadraticTransformProblemSpec,
+    build_quadratic_expression,
+    build_quadratic_latex,
+    format_number,
+)
+from app.domain.skills.quadratic_transform.transform_kernel import derive_transforms
+
+_FPS = 30
+_STEP_FRAMES = 120
+
+
+def build_quadratic_transform_playbook(
+    run_id: str,  # noqa: ARG001 - reserved for future trace metadata.
+    spec: QuadraticTransformProblemSpec,
+) -> PlaybookScript:
+    transforms = {transform.kind: transform.explanation for transform in derive_transforms(spec)}
+    shifted_expression = build_quadratic_expression(1.0, spec.h, 0.0)
+    scaled_expression = build_quadratic_expression(spec.a, spec.h, 0.0)
+
+    steps: list[MetaStep] = []
+
+    def add_step(
+        title: str,
+        voiceover_text: str,
+        curves: list[MathPlotCurve],
+        formula_latex: str,
+        marker_x: float | None = None,
+    ) -> None:
+        snapshot = MathPlotSnapshot(
+            curves=curves,
+            x_min=spec.x_min,
+            x_max=spec.x_max,
+            marker_x=marker_x,
+            formula_latex=formula_latex,
+        )
+        steps.append(
+            MetaStep(
+                step_id=f"quadratic_transform_{len(steps) + 1:02d}",
+                end_frame=(len(steps) + 1) * _STEP_FRAMES,
+                title=title,
+                voiceover_text=voiceover_text,
+                animation_hint="math_plot_transform",
+                snapshot=snapshot,
+                layers=[Layer(timing=LayerTiming(), body=snapshot)],
+                tokens=[],
+            )
+        )
+
+    add_step(
+        "从母函数开始",
+        "先看母函数 y 等于 x 的平方。它的顶点在原点，开口向上，是后续变换的参照。",
+        [_curve("x^2", "y=x^2", "primary")],
+        "y = x^2",
+        marker_x=0.0,
+    )
+    add_step(
+        "识别顶点式",
+        (
+            "目标函数写成 y 等于 a 乘以 x 减 h 的平方再加 k。"
+            "a 控制开口和纵向伸缩，h 和 k 控制顶点位置。"
+        ),
+        [
+            _curve("x^2", "母函数", "secondary"),
+            _curve(spec.target_expression, "目标函数", "accent"),
+        ],
+        spec.target_latex,
+        marker_x=spec.h,
+    )
+    add_step(
+        "水平平移",
+        transforms["horizontal_shift"],
+        [
+            _curve("x^2", "母函数", "secondary"),
+            _curve(shifted_expression, "水平平移后", "primary"),
+        ],
+        build_quadratic_latex(1.0, spec.h, 0.0),
+        marker_x=spec.h,
+    )
+    add_step(
+        "纵向伸缩与开口",
+        transforms["vertical_scale"],
+        [
+            _curve(shifted_expression, "平移后参照", "secondary"),
+            _curve(scaled_expression, "调整开口后", "primary"),
+        ],
+        build_quadratic_latex(spec.a, spec.h, 0.0),
+        marker_x=spec.h,
+    )
+    add_step(
+        "竖直平移",
+        transforms["vertical_shift"],
+        [
+            _curve(scaled_expression, "竖直平移前", "secondary"),
+            _curve(spec.target_expression, "目标函数", "primary"),
+        ],
+        spec.target_latex,
+        marker_x=spec.h,
+    )
+    add_step(
+        "最终对比与顶点",
+        (
+            f"最终图像的顶点是 ({format_number(spec.h)}, {format_number(spec.k)})。"
+            f"a={format_number(spec.a)} 决定开口方向和宽窄，目标函数是 {spec.target_latex}。"
+        ),
+        [
+            _curve("x^2", "母函数", "secondary"),
+            _curve(spec.target_expression, "目标函数", "accent"),
+        ],
+        (
+            f"a={format_number(spec.a)},\\ "
+            f"(h,k)=({format_number(spec.h)}, {format_number(spec.k)})"
+        ),
+        marker_x=spec.h,
+    )
+
+    return PlaybookScript(
+        fps=_FPS,
+        total_frames=len(steps) * _STEP_FRAMES,
+        domain=TopicDomain.MATH,
+        title="二次函数图像变换",
+        summary="用确定性的函数图像步骤解释顶点式二次函数的平移、伸缩和开口变化。",
+        steps=steps,
+        parameter_controls=[],
+        algorithm_id=None,
+        initial_data={},
+    )
+
+
+def _curve(expression: str, label: str, emphasis: str) -> MathPlotCurve:
+    return MathPlotCurve(expression=expression, label=label, emphasis=emphasis)

--- a/apps/api/app/domain/skills/quadratic_transform/problem_spec.py
+++ b/apps/api/app/domain/skills/quadratic_transform/problem_spec.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class QuadraticTransformProblemSpec(BaseModel):
+    language: str = "zh-CN"
+    original_prompt: str
+    a: float = 1.0
+    h: float = 0.0
+    k: float = 0.0
+    target_expression: str
+    target_latex: str
+    x_min: float = -6.0
+    x_max: float = 6.0
+
+
+def format_number(value: float) -> str:
+    if value == 0:
+        return "0"
+    if float(value).is_integer():
+        return str(int(value))
+    return f"{value:.6g}"
+
+
+def build_quadratic_expression(a: float, h: float, k: float) -> str:
+    body = _quadratic_body(h)
+    prefix = _coefficient_prefix(a)
+    expr = f"{prefix}{body}"
+    if k > 0:
+        expr += f"+{format_number(k)}"
+    elif k < 0:
+        expr += f"-{format_number(abs(k))}"
+    return expr
+
+
+def build_quadratic_latex(a: float, h: float, k: float) -> str:
+    body = _quadratic_body(h, latex=True)
+    if a == 1:
+        expr = body
+    elif a == -1:
+        expr = f"-{body}"
+    else:
+        expr = f"{format_number(a)}{body}"
+    if k > 0:
+        expr += f" + {format_number(k)}"
+    elif k < 0:
+        expr += f" - {format_number(abs(k))}"
+    return f"y = {expr}"
+
+
+def _quadratic_body(h: float, *, latex: bool = False) -> str:
+    exponent = "^{2}" if latex else "^2"
+    if h == 0:
+        return f"x{exponent}"
+    sign = "-" if h > 0 else "+"
+    return f"(x{sign}{format_number(abs(h))}){exponent}"
+
+
+def _coefficient_prefix(a: float) -> str:
+    if a == 1:
+        return ""
+    if a == -1:
+        return "-"
+    return f"{format_number(a)}*"

--- a/apps/api/app/domain/skills/quadratic_transform/skill_pack.py
+++ b/apps/api/app/domain/skills/quadratic_transform/skill_pack.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel
+
+from app.domain.skills.base import (
+    SkillExecutionContext,
+    SkillExecutionResult,
+    SkillRouteInput,
+    SkillRouteMatch,
+)
+from app.domain.skills.quadratic_transform.manifest import QUADRATIC_TRANSFORM_MANIFEST
+from app.domain.skills.quadratic_transform.playbook_adapter import (
+    build_quadratic_transform_playbook,
+)
+from app.domain.skills.quadratic_transform.problem_spec import QuadraticTransformProblemSpec
+from app.domain.skills.quadratic_transform.spec_extractor import (
+    try_extract_quadratic_transform,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class QuadraticTransformSkillPack:
+    manifest = QUADRATIC_TRANSFORM_MANIFEST
+
+    def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
+        spec = try_extract_quadratic_transform(request.prompt)
+        if spec is None:
+            return None
+        return SkillRouteMatch(
+            skill_id=self.manifest.skill_id,
+            domain=self.manifest.domain,
+            confidence=0.88,
+            capability_id="quadratic_transform.vertex_form",
+            reason="Detected supported quadratic vertex-form graph transformation.",
+            problem_spec=spec.model_dump(mode="json"),
+        )
+
+    def validate_problem_spec(self, data: dict[str, Any]) -> QuadraticTransformProblemSpec | None:
+        try:
+            return QuadraticTransformProblemSpec.model_validate(data)
+        except Exception:  # noqa: BLE001 - invalid router specs should fall back.
+            return None
+
+    async def execute(
+        self,
+        context: SkillExecutionContext,
+        problem_spec: BaseModel | None,
+    ) -> SkillExecutionResult:
+        if problem_spec is None:
+            spec = try_extract_quadratic_transform(context.prompt)
+            if spec is None:
+                return SkillExecutionResult(
+                    handled=False,
+                    fallback_reason="unsupported_quadratic_transform_form",
+                )
+        else:
+            spec = _coerce_spec(problem_spec)
+
+        try:
+            playbook = build_quadratic_transform_playbook(context.run_id, spec)
+        except ValueError as exc:
+            logger.warning("Quadratic transform skill rejected spec: %s", exc)
+            return SkillExecutionResult(
+                handled=False,
+                fallback_reason="quadratic_transform_value_error",
+            )
+
+        return SkillExecutionResult(
+            handled=True,
+            playbook_json=playbook.model_dump_json(),
+            review_actions=[
+                "skill:quadratic_transform",
+                "skill_capability:quadratic_transform.vertex_form",
+            ],
+        )
+
+
+def _coerce_spec(problem_spec: BaseModel) -> QuadraticTransformProblemSpec:
+    if isinstance(problem_spec, QuadraticTransformProblemSpec):
+        return problem_spec
+    return QuadraticTransformProblemSpec.model_validate(problem_spec.model_dump(mode="json"))

--- a/apps/api/app/domain/skills/quadratic_transform/spec_extractor.py
+++ b/apps/api/app/domain/skills/quadratic_transform/spec_extractor.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import re
+
+from app.domain.skills.quadratic_transform.problem_spec import (
+    QuadraticTransformProblemSpec,
+    build_quadratic_expression,
+    build_quadratic_latex,
+)
+
+_NUMBER = r"(?:\d+(?:\.\d*)?|\.\d+)"
+_EQUATION_RE = re.compile(r"(?:y|f\(x\))=(?P<rhs>[0-9x+\-*/().^]+)")
+_VERTEX_QUADRATIC_RE = re.compile(
+    rf"^(?P<a>[+-]?(?:{_NUMBER})?)\*?"
+    rf"(?:\((?P<inner_paren>x(?P<shift_paren>[+-]{_NUMBER})?)\)"
+    rf"|(?P<inner_plain>x))"
+    rf"\^2(?P<k>[+-]{_NUMBER})?$"
+)
+_NEGATIVE_INTENT_KEYWORDS = (
+    "求导",
+    "导数",
+    "积分",
+    "极限",
+    "切线",
+    "斜率",
+    "解方程",
+    "零点",
+)
+
+
+def try_extract_quadratic_transform(prompt: str) -> QuadraticTransformProblemSpec | None:
+    normalized = _normalize(prompt)
+    if not normalized or any(keyword in normalized for keyword in _NEGATIVE_INTENT_KEYWORDS):
+        return None
+
+    rhs = _extract_rhs(normalized)
+    if rhs is None:
+        return None
+    return _extract_vertex_quadratic(rhs, prompt)
+
+
+def _normalize(prompt: str) -> str:
+    replacements = {
+        " ": "",
+        "\t": "",
+        "\n": "",
+        "（": "(",
+        "）": ")",
+        "＝": "=",
+        "＋": "+",
+        "－": "-",
+        "−": "-",
+        "﹣": "-",
+        "＊": "*",
+        "×": "*",
+        "＾": "^",
+        "²": "^2",
+        "**": "^",
+        "X": "x",
+    }
+    out = prompt.strip()
+    for old, new in replacements.items():
+        out = out.replace(old, new)
+    return out
+
+
+def _extract_rhs(normalized: str) -> str | None:
+    match = _EQUATION_RE.search(normalized)
+    if match is None:
+        return None
+    return match.group("rhs").strip()
+
+
+def _extract_vertex_quadratic(
+    rhs: str,
+    prompt: str,
+) -> QuadraticTransformProblemSpec | None:
+    match = _VERTEX_QUADRATIC_RE.match(rhs)
+    if match is None:
+        return None
+
+    a = _parse_coefficient(match.group("a"))
+    h = _parse_shift(match.group("shift_paren"))
+    k = _parse_signed_number(match.group("k"))
+    target_expression = build_quadratic_expression(a, h, k)
+    x_min = min(-6.0, h - 4.0)
+    x_max = max(6.0, h + 4.0)
+
+    return QuadraticTransformProblemSpec(
+        original_prompt=prompt,
+        a=a,
+        h=h,
+        k=k,
+        target_expression=target_expression,
+        target_latex=build_quadratic_latex(a, h, k),
+        x_min=x_min,
+        x_max=x_max,
+    )
+
+
+def _parse_coefficient(raw: str | None) -> float:
+    if raw in (None, "", "+"):
+        return 1.0
+    if raw == "-":
+        return -1.0
+    return float(raw)
+
+
+def _parse_shift(raw: str | None) -> float:
+    if not raw:
+        return 0.0
+    return -float(raw)
+
+
+def _parse_signed_number(raw: str | None) -> float:
+    if not raw:
+        return 0.0
+    return float(raw)

--- a/apps/api/app/domain/skills/quadratic_transform/transform_kernel.py
+++ b/apps/api/app/domain/skills/quadratic_transform/transform_kernel.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from app.domain.skills.quadratic_transform.problem_spec import (
+    QuadraticTransformProblemSpec,
+    format_number,
+)
+
+TransformKind = Literal["horizontal_shift", "vertical_scale", "vertical_shift"]
+
+
+@dataclass(frozen=True)
+class QuadraticTransform:
+    kind: TransformKind
+    explanation: str
+
+
+def derive_transforms(spec: QuadraticTransformProblemSpec) -> list[QuadraticTransform]:
+    return [
+        QuadraticTransform(
+            kind="horizontal_shift",
+            explanation=_horizontal_explanation(spec),
+        ),
+        QuadraticTransform(
+            kind="vertical_scale",
+            explanation=_scale_explanation(spec),
+        ),
+        QuadraticTransform(
+            kind="vertical_shift",
+            explanation=_vertical_explanation(spec),
+        ),
+    ]
+
+
+def _horizontal_explanation(spec: QuadraticTransformProblemSpec) -> str:
+    if spec.h == 0:
+        return "括号里没有水平平移量，所以图像在水平方向保持不变。"
+    direction = "右" if spec.h > 0 else "左"
+    return f"图像整体向{direction}平移 {format_number(abs(spec.h))} 个单位。"
+
+
+def _scale_explanation(spec: QuadraticTransformProblemSpec) -> str:
+    if spec.a == 1:
+        return "a 等于 1，开口方向和宽窄与母函数 y=x^2 一致。"
+    if spec.a == -1:
+        return "a 等于 -1，图像关于 x 轴翻折，开口向下，宽窄不变。"
+    if spec.a < 0:
+        return (
+            f"a 等于 {format_number(spec.a)}，图像关于 x 轴翻折，"
+            "并按 |a| 做纵向伸缩。"
+        )
+    return f"a 等于 {format_number(spec.a)}，图像按这个系数做纵向伸缩。"
+
+
+def _vertical_explanation(spec: QuadraticTransformProblemSpec) -> str:
+    if spec.k == 0:
+        return "末尾没有常数 k，所以图像在竖直方向保持不变。"
+    direction = "上" if spec.k > 0 else "下"
+    return f"图像整体向{direction}平移 {format_number(abs(spec.k))} 个单位。"

--- a/apps/api/app/domain/skills/registry.py
+++ b/apps/api/app/domain/skills/registry.py
@@ -33,10 +33,12 @@ class SkillRegistry:
 
 
 def build_default_skill_registry() -> SkillRegistry:
+    from app.domain.skills.quadratic_transform.skill_pack import QuadraticTransformSkillPack
     from app.domain.skills.solid_geometry.skill_pack import SolidGeometrySkillPack
 
     return SkillRegistry([
         SolidGeometrySkillPack(),
+        QuadraticTransformSkillPack(),
     ])
 
 

--- a/apps/api/tests/test_quadratic_transform_skill.py
+++ b/apps/api/tests/test_quadratic_transform_skill.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from app.application.dto.pipeline_dto import PipelineRequest
+from app.application.use_cases.run_pipeline import RunPipelineUseCase
+from app.domain.models.pipeline_run import PipelineRunStatus
+from app.domain.models.playbook import PlaybookScript
+from app.domain.models.topic import TopicDomain
+from app.domain.skills.base import SkillExecutionContext, SkillRouteInput
+from app.domain.skills.quadratic_transform.manifest import QUADRATIC_TRANSFORM_MANIFEST
+from app.domain.skills.quadratic_transform.skill_pack import QuadraticTransformSkillPack
+from app.domain.skills.quadratic_transform.spec_extractor import (
+    try_extract_quadratic_transform,
+)
+from app.domain.skills.registry import build_default_skill_registry
+
+
+class _RecordingRepo:
+    def __init__(self) -> None:
+        self.updates: list[dict[str, Any]] = []
+
+    async def update(self, run_id: str, **kwargs: Any) -> None:
+        self.updates.append({"run_id": run_id, **kwargs})
+
+    @property
+    def final_status(self) -> PipelineRunStatus:
+        return self.updates[-1]["status"]
+
+
+class _FailingLLM:
+    async def complete(self, system: str, user: str) -> str:  # noqa: ARG002
+        raise AssertionError("LLM must not be called")
+
+
+def test_quadratic_transform_manifest_is_valid() -> None:
+    payload = QUADRATIC_TRANSFORM_MANIFEST.model_dump(mode="json")
+
+    assert payload["skill_id"] == "quadratic_transform"
+    assert payload["domain"] == "math"
+    assert payload["execution_mode"] == "deterministic"
+    assert payload["capabilities"][0]["capability_id"] == "quadratic_transform.vertex_form"
+    assert payload["capabilities"][0]["output_schema"] == "QuadraticTransformProblemSpec"
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected"),
+    [
+        ("解释 y=(x-2)^2+1 的图像变换", {"a": 1, "h": 2, "k": 1, "expr": "(x-2)^2+1"}),
+        (
+            "讲一下 y=2(x+1)^2-3 是怎么从 y=x^2 变来的",
+            {"a": 2, "h": -1, "k": -3, "expr": "2*(x+1)^2-3"},
+        ),
+        ("解释 y=-(x-1)^2 的开口和平移", {"a": -1, "h": 1, "k": 0, "expr": "-(x-1)^2"}),
+        ("解释 y=x^2 的图像", {"a": 1, "h": 0, "k": 0, "expr": "x^2"}),
+        ("解释 y=x² 的图像", {"a": 1, "h": 0, "k": 0, "expr": "x^2"}),
+    ],
+)
+def test_extractor_parses_supported_vertex_forms(prompt: str, expected: dict[str, Any]) -> None:
+    spec = try_extract_quadratic_transform(prompt)
+
+    assert spec is not None
+    assert spec.a == expected["a"]
+    assert spec.h == expected["h"]
+    assert spec.k == expected["k"]
+    assert spec.target_expression == expected["expr"]
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "解释 y=x^2+2x+1 的图像变换",
+        "求导 y=(x-2)^2+1",
+        "解释 y=3sin(x)+1 的图像变化",
+        "解释概率密度函数",
+    ],
+)
+def test_heuristic_match_ignores_unsupported_prompts(prompt: str) -> None:
+    skill = QuadraticTransformSkillPack()
+
+    assert skill.heuristic_match(SkillRouteInput(prompt=prompt)) is None
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "解释 y=(x-2)^2+1 的图像变换",
+        "讲一下 y=2(x+1)^2-3 是怎么从 y=x^2 变来的",
+        "解释 y=-(x-1)^2 的开口和平移",
+        "解释 y=x² 的图像",
+    ],
+)
+def test_heuristic_match_detects_supported_prompts(prompt: str) -> None:
+    skill = QuadraticTransformSkillPack()
+    match = skill.heuristic_match(SkillRouteInput(prompt=prompt))
+
+    assert match is not None
+    assert match.skill_id == "quadratic_transform"
+    assert match.domain == "math"
+    assert match.capability_id == "quadratic_transform.vertex_form"
+    assert match.problem_spec is not None
+    assert "answer" not in json.dumps(match.problem_spec)
+    assert "solution" not in json.dumps(match.problem_spec)
+    assert "final_answer" not in json.dumps(match.problem_spec)
+
+
+@pytest.mark.asyncio
+async def test_validate_and_execute_outputs_six_math_plot_steps() -> None:
+    skill = QuadraticTransformSkillPack()
+    prompt = "解释 y=(x-2)^2+1 的图像变换"
+    match = skill.heuristic_match(SkillRouteInput(prompt=prompt))
+
+    assert match is not None
+    assert match.problem_spec is not None
+    spec = skill.validate_problem_spec(match.problem_spec)
+    assert spec is not None
+
+    result = await skill.execute(
+        SkillExecutionContext(run_id="test", prompt=prompt, route_match=match),
+        spec,
+    )
+
+    assert result.handled is True
+    assert "skill:quadratic_transform" in result.review_actions
+    assert result.playbook_json is not None
+    assert "algorithm_array" not in result.playbook_json
+
+    playbook = PlaybookScript.model_validate_json(result.playbook_json)
+    assert playbook.domain == TopicDomain.MATH
+    assert len(playbook.steps) == 6
+    assert all(step.snapshot.kind == "math_plot" for step in playbook.steps)
+    assert all(step.layers for step in playbook.steps)
+    assert all(step.layers[0].body.kind == "math_plot" for step in playbook.steps)
+
+    expressions = [
+        curve.expression
+        for step in playbook.steps
+        if step.snapshot.kind == "math_plot"
+        for curve in step.snapshot.curves
+    ]
+    assert "x^2" in expressions
+    assert "(x-2)^2+1" in expressions
+
+
+def test_default_registry_routes_quadratic_transform() -> None:
+    registry = build_default_skill_registry()
+    manifests = {manifest.skill_id for manifest in registry.manifests()}
+    route = registry.heuristic_match(
+        SkillRouteInput(prompt="讲一下 y=2(x+1)^2-3 是怎么从 y=x^2 变来的")
+    )
+
+    assert {"solid_geometry", "quadratic_transform"} <= manifests
+    assert "function_transform" not in manifests
+    assert route is not None
+    assert route.skill_id == "quadratic_transform"
+    assert route.problem_spec is not None
+
+
+@pytest.mark.asyncio
+async def test_quadratic_transform_runs_through_pipeline_registry() -> None:
+    repo = _RecordingRepo()
+    use_case = RunPipelineUseCase(repo, _FailingLLM())
+
+    await use_case.execute(
+        "run-quadratic-transform",
+        PipelineRequest(prompt="解释 y=(x-2)^2+1 的图像变换"),
+    )
+
+    assert repo.final_status == PipelineRunStatus.SUCCEEDED
+    playbook = json.loads(repo.updates[-1]["playbook_json"])
+    assert playbook["domain"] == "math"
+    assert len(playbook["steps"]) == 6
+    assert all(step["snapshot"]["kind"] == "math_plot" for step in playbook["steps"])
+    assert all(step["layers"] for step in playbook["steps"])


### PR DESCRIPTION
## Summary

Adds a narrow deterministic `quadratic_transform` SkillPack for vertex-form quadratic graph transformations.

## Changes

- Adds `QuadraticTransformSkillPack` plus manifest, problem spec, deterministic extractor, transform kernel, and direct `PlaybookScript` adapter.
- Registers the skill through `build_default_skill_registry()` without adding skill-specific imports to `RunPipelineUseCase`.
- Adds tests for supported vertex forms, expanded-form fallback, PlaybookScript validation, math_plot snapshots, layers, and registry/pipeline routing.

## Validation

- `git diff --cached --check`
- `ruff check apps/api/app/domain/skills/quadratic_transform apps/api/app/domain/skills/registry.py apps/api/tests/test_quadratic_transform_skill.py`
- `PYTHONPATH=apps/api pytest apps/api/tests` -> 374 passed

## Notes

Unrelated frontend worktree changes were left unstaged and are not part of this PR.