### PR TITLE
[codex] Add animation tool schemas and split playbook player UI

### DIFF
--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -48,7 +48,8 @@ Workflow you MUST follow:
       areas, parametric curves, graph traversal, force diagrams, projectile
       motion, stoichiometry tables, distributions, inheritance grids), call
       \`animation_tool_list\` / \`animation_tool_expand\` before manually
-      composing raw visual layers. Treat the expanded \`layers\` as the
+      composing raw visual layers. Read each tool's \`args_schema\` before
+      calling \`animation_tool_expand\`. Treat the expanded \`layers\` as the
       deterministic reference; do not invent raw LayerSpec JSON when a
       registry tool covers the pattern.
    b. If an L2 \`template_*\` tool matches the step's pedagogical intent

--- a/apps/agent/src/tools/animationTools.ts
+++ b/apps/agent/src/tools/animationTools.ts
@@ -19,6 +19,7 @@ export interface AnimationToolDeps {
 interface AnimationToolInfo {
   name: string;
   description: string;
+  args_schema: unknown;
 }
 
 interface AnimationToolIssue {

--- a/apps/agent/test/animationTools.test.ts
+++ b/apps/agent/test/animationTools.test.ts
@@ -22,7 +22,20 @@ describe("animation tool bridge", () => {
     const fetchMock = vi.fn(async () =>
       new Response(
         JSON.stringify({
-          tools: [{ name: "math.show_function", description: "Show a function." }],
+          tools: [
+            {
+              name: "math.show_function",
+              description: "Show a function.",
+              args_schema: {
+                type: "object",
+                properties: {
+                  expression: { type: "string" },
+                  x_min: { type: "number" },
+                  x_max: { type: "number" },
+                },
+              },
+            },
+          ],
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       ),
@@ -31,10 +44,16 @@ describe("animation tool bridge", () => {
 
     const result = await getTool("animation_tool_list").execute("test", {});
     const details = result.details as {
-      tools: Array<{ name: string; description: string }>;
+      tools: Array<{
+        name: string;
+        description: string;
+        args_schema: { properties: Record<string, unknown> };
+      }>;
     };
 
     expect(details.tools[0].name).toBe("math.show_function");
+    expect(details.tools[0].args_schema.properties).toHaveProperty("expression");
+    expect(details.tools[0].args_schema.properties).toHaveProperty("x_min");
     expect(fetchMock).toHaveBeenCalledWith(
       "http://api.test/api/v1/agent/animation-tools",
       expect.objectContaining({
@@ -85,9 +104,87 @@ describe("animation tool bridge", () => {
     );
   });
 
+  it("covers the quadratic tangent golden fixture without a model call", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (!init || init.method === "GET") {
+        return new Response(
+          JSON.stringify({
+            tools: [
+              {
+                name: "math.show_tangent",
+                description: "Show a function and tangent line at a selected x value.",
+                args_schema: {
+                  type: "object",
+                  properties: {
+                    expression: { type: "string", minLength: 1 },
+                    x0: { type: "number" },
+                    tangent_expression: { type: "string", minLength: 1 },
+                    x_min: { type: "number" },
+                    x_max: { type: "number" },
+                  },
+                  required: ["expression", "x0", "tangent_expression"],
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          layers: [
+            {
+              kind: "math_plot",
+              plot: {
+                curves: [
+                  { expression: "x^2", label: "f(x)", emphasis: "primary" },
+                  { expression: "4*x - 4", label: "tangent", emphasis: "secondary" },
+                ],
+                marker_x: 2,
+              },
+            },
+          ],
+          issues: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const listResult = await getTool("animation_tool_list").execute("list", {});
+    const listDetails = listResult.details as {
+      tools: Array<{ name: string; args_schema: { properties: Record<string, unknown> } }>;
+    };
+
+    expect(SYSTEM_PROMPT).toContain("function plots, tangents");
+    expect(listDetails.tools[0].name).toBe("math.show_tangent");
+    expect(listDetails.tools[0].args_schema.properties).toHaveProperty("tangent_expression");
+
+    const expandResult = await getTool("animation_tool_expand").execute("expand", {
+      tool: "math.show_tangent",
+      args: {
+        expression: "x^2",
+        x0: 2,
+        tangent_expression: "4*x - 4",
+        x_min: -3,
+        x_max: 5,
+      },
+    });
+    const expandDetails = expandResult.details as {
+      layers: Array<{ kind: string; plot: { marker_x: number } }>;
+      issues: unknown[];
+    };
+
+    expect(expandDetails.issues).toEqual([]);
+    expect(expandDetails.layers[0].kind).toBe("math_plot");
+    expect(expandDetails.layers[0].plot.marker_x).toBe(2);
+  });
+
   it("tells the model to prefer animation tools for common animations", () => {
     expect(SYSTEM_PROMPT).toContain("animation_tool_list");
     expect(SYSTEM_PROMPT).toContain("animation_tool_expand");
+    expect(SYSTEM_PROMPT).toContain("args_schema");
     expect(SYSTEM_PROMPT).toContain("do not invent raw LayerSpec JSON");
   });
 });

--- a/apps/api/app/domain/animation_tools/algorithm_tools.py
+++ b/apps/api/app/domain/animation_tools/algorithm_tools.py
@@ -26,7 +26,7 @@ class AlgorithmGraphTraversalArgs(BaseModel):
     caption: str | None = None
 
 
-@register("algorithm.graph_traversal")
+@register("algorithm.graph_traversal", AlgorithmGraphTraversalArgs)
 def graph_traversal(args: dict) -> list[LayerSpec]:
     parsed = AlgorithmGraphTraversalArgs.model_validate(args)
     snapshot = GraphSceneSnapshot(

--- a/apps/api/app/domain/animation_tools/biology_tools.py
+++ b/apps/api/app/domain/animation_tools/biology_tools.py
@@ -17,7 +17,7 @@ class BiologyPunnettSquareArgs(BaseModel):
     phenotype_counts: dict[str, float] = Field(default_factory=dict)
 
 
-@register("biology.punnett_square")
+@register("biology.punnett_square", BiologyPunnettSquareArgs)
 def punnett_square(args: dict) -> list[LayerSpec]:
     parsed = BiologyPunnettSquareArgs.model_validate(args)
     table = TableSceneSnapshot(

--- a/apps/api/app/domain/animation_tools/chemistry_tools.py
+++ b/apps/api/app/domain/animation_tools/chemistry_tools.py
@@ -29,7 +29,7 @@ class ChemistryStoichiometryTableArgs(BaseModel):
     caption: str | None = None
 
 
-@register("chemistry.stoichiometry_table")
+@register("chemistry.stoichiometry_table", ChemistryStoichiometryTableArgs)
 def stoichiometry_table(args: dict) -> list[LayerSpec]:
     parsed = ChemistryStoichiometryTableArgs.model_validate(args)
     table = TableSceneSnapshot(

--- a/apps/api/app/domain/animation_tools/math_tools.py
+++ b/apps/api/app/domain/animation_tools/math_tools.py
@@ -91,7 +91,7 @@ class MathShowRegionBoundaryArgs(BaseModel):
     caption: str | None = None
 
 
-@register("math.show_tangent")
+@register("math.show_tangent", MathShowTangentArgs)
 def show_tangent(args: dict) -> list[LayerSpec]:
     parsed = MathShowTangentArgs.model_validate(args)
     layers = _plot_layers(
@@ -121,7 +121,7 @@ def show_tangent(args: dict) -> list[LayerSpec]:
     return layers
 
 
-@register("math.show_function")
+@register("math.show_function", MathShowFunctionArgs)
 def show_function(args: dict) -> list[LayerSpec]:
     parsed = MathShowFunctionArgs.model_validate(args)
     curves = [
@@ -151,7 +151,7 @@ def show_function(args: dict) -> list[LayerSpec]:
     )
 
 
-@register("math.show_integral_area")
+@register("math.show_integral_area", MathShowIntegralAreaArgs)
 def show_integral_area(args: dict) -> list[LayerSpec]:
     parsed = MathShowIntegralAreaArgs.model_validate(args)
     return _plot_layers(
@@ -175,7 +175,7 @@ def show_integral_area(args: dict) -> list[LayerSpec]:
     )
 
 
-@register("math.show_derivative_compare")
+@register("math.show_derivative_compare", MathShowDerivativeCompareArgs)
 def show_derivative_compare(args: dict) -> list[LayerSpec]:
     parsed = MathShowDerivativeCompareArgs.model_validate(args)
     return _plot_layers(
@@ -203,7 +203,7 @@ def show_derivative_compare(args: dict) -> list[LayerSpec]:
     )
 
 
-@register("math.show_function_transform")
+@register("math.show_function_transform", MathShowFunctionTransformArgs)
 def show_function_transform(args: dict) -> list[LayerSpec]:
     parsed = MathShowFunctionTransformArgs.model_validate(args)
     return _plot_layers(
@@ -231,7 +231,7 @@ def show_function_transform(args: dict) -> list[LayerSpec]:
     )
 
 
-@register("math.show_parametric_curve")
+@register("math.show_parametric_curve", MathShowParametricCurveArgs)
 def show_parametric_curve(args: dict) -> list[LayerSpec]:
     parsed = MathShowParametricCurveArgs.model_validate(args)
     scene = SceneSpec(
@@ -256,7 +256,7 @@ def show_parametric_curve(args: dict) -> list[LayerSpec]:
     return _scene_layers(scene, parsed.formula_latex, parsed.caption)
 
 
-@register("math.show_region_boundary")
+@register("math.show_region_boundary", MathShowRegionBoundaryArgs)
 def show_region_boundary(args: dict) -> list[LayerSpec]:
     parsed = MathShowRegionBoundaryArgs.model_validate(args)
     closed = [*parsed.vertices, parsed.vertices[0]]

--- a/apps/api/app/domain/animation_tools/physics_tools.py
+++ b/apps/api/app/domain/animation_tools/physics_tools.py
@@ -57,7 +57,7 @@ class PhysicsProjectileMotionArgs(BaseModel):
     caption: str | None = None
 
 
-@register("physics.force_diagram")
+@register("physics.force_diagram", PhysicsForceDiagramArgs)
 def force_diagram(args: dict) -> list[LayerSpec]:
     parsed = PhysicsForceDiagramArgs.model_validate(args)
     segments: list[SceneSegment] = []
@@ -105,7 +105,7 @@ def force_diagram(args: dict) -> list[LayerSpec]:
     ]
 
 
-@register("physics.projectile_motion")
+@register("physics.projectile_motion", PhysicsProjectileMotionArgs)
 def projectile_motion(args: dict) -> list[LayerSpec]:
     parsed = PhysicsProjectileMotionArgs.model_validate(args)
     angle = math.radians(parsed.angle_deg)

--- a/apps/api/app/domain/animation_tools/registry.py
+++ b/apps/api/app/domain/animation_tools/registry.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, ValidationError
 
@@ -18,6 +18,7 @@ from app.domain.models.cir import CirDocument, LayerSpec
 logger = logging.getLogger(__name__)
 
 _REGISTRY: dict[str, AnimationTool] = {}
+_TOOL_ARGS_MODELS: dict[str, type[BaseModel]] = {}
 _TOOL_DESCRIPTIONS: dict[str, str] = {
     "algorithm.graph_traversal": "Build graph traversal layers with active nodes and edges.",
     "biology.punnett_square": "Build a Punnett square for simple inheritance explanations.",
@@ -64,6 +65,7 @@ class AnimationToolExpansionResult(BaseModel):
 class AnimationToolInfo(BaseModel):
     name: str
     description: str
+    args_schema: dict[str, Any] = Field(default_factory=dict)
 
 
 class CirAnimationToolExpansionResult(BaseModel):
@@ -71,7 +73,10 @@ class CirAnimationToolExpansionResult(BaseModel):
     issues: list[AnimationToolIssue] = Field(default_factory=list)
 
 
-def register(name: str) -> Callable[[AnimationTool], AnimationTool]:
+def register(
+    name: str,
+    args_model: type[BaseModel] | None = None,
+) -> Callable[[AnimationTool], AnimationTool]:
     """Decorator that registers an animation tool under ``name``.
 
     Usage::
@@ -85,6 +90,8 @@ def register(name: str) -> Callable[[AnimationTool], AnimationTool]:
         if name in _REGISTRY:
             logger.warning("Animation tool %r already registered; overwriting", name)
         _REGISTRY[name] = fn
+        if args_model is not None:
+            _TOOL_ARGS_MODELS[name] = args_model
         return fn
 
     return deco
@@ -96,9 +103,17 @@ def list_animation_tools() -> list[AnimationToolInfo]:
         AnimationToolInfo(
             name=name,
             description=_TOOL_DESCRIPTIONS.get(name, _description_from_name(name)),
+            args_schema=_args_schema_for_name(name),
         )
         for name in sorted(_REGISTRY)
     ]
+
+
+def _args_schema_for_name(name: str) -> dict[str, Any]:
+    model = _TOOL_ARGS_MODELS.get(name)
+    if model is None:
+        return {"type": "object", "properties": {}}
+    return model.model_json_schema()
 
 
 def _description_from_name(name: str) -> str:

--- a/apps/api/app/domain/animation_tools/stats_tools.py
+++ b/apps/api/app/domain/animation_tools/stats_tools.py
@@ -27,7 +27,7 @@ class StatsDistributionChartArgs(BaseModel):
     caption: str | None = None
 
 
-@register("stats.distribution_chart")
+@register("stats.distribution_chart", StatsDistributionChartArgs)
 def distribution_chart(args: dict) -> list[LayerSpec]:
     parsed = StatsDistributionChartArgs.model_validate(args)
     snapshot = StatsChartSceneSnapshot(

--- a/apps/api/tests/test_animation_tool_golden_fixture.py
+++ b/apps/api/tests/test_animation_tool_golden_fixture.py
@@ -1,0 +1,55 @@
+"""Golden fixture for a deterministic Animation Tool Registry generation path."""
+
+from app.domain.animation_tools import safe_expand_cir_animation_calls_with_issues
+from app.domain.models.cir import AnimationCall, CirDocument, CirStep, LayerKind, VisualKind
+from app.domain.models.topic import TopicDomain
+from app.domain.services.playbook_builder import build_playbook
+
+
+def test_quadratic_tangent_fixture_expands_to_renderable_playbook_layer() -> None:
+    cir = CirDocument(
+        title="y=x^2 的图像和 x=2 处切线",
+        domain=TopicDomain.MATH,
+        summary="解释二次函数图像，并在 x=2 处观察切线斜率。",
+        steps=[
+            CirStep(
+                id="quadratic-tangent",
+                title="画出函数和切线",
+                narration="先画出 y=x^2，再叠加 x=2 处的切线 y=4x-4。",
+                visual_kind=VisualKind.FUNCTION,
+                animation_calls=[
+                    AnimationCall(
+                        tool="math.show_tangent",
+                        args={
+                            "expression": "x^2",
+                            "x0": 2,
+                            "tangent_expression": "4*x - 4",
+                            "formula_latex": "y=x^2,\\ y=4x-4",
+                            "caption": "切线在 x=2 处贴住曲线，斜率为 4。",
+                            "x_min": -3,
+                            "x_max": 5,
+                        },
+                    )
+                ],
+            )
+        ],
+    )
+
+    expanded = safe_expand_cir_animation_calls_with_issues(cir)
+
+    assert expanded.issues == []
+    expanded_step = expanded.cir.steps[0]
+    assert expanded_step.animation_calls == []
+    assert expanded_step.layers[0].kind == LayerKind.MATH_PLOT
+    assert expanded_step.layers[0].plot is not None
+    assert [curve.expression for curve in expanded_step.layers[0].plot.curves] == [
+        "x^2",
+        "4*x - 4",
+    ]
+
+    playbook = build_playbook(cir, execution_map=None)
+    layer = playbook.steps[0].layers[0]
+
+    assert layer.body.kind == "math_plot"
+    assert layer.body.marker_x == 2
+    assert [curve.expression for curve in layer.body.curves] == ["x^2", "4*x - 4"]

--- a/apps/api/tests/test_animation_tools.py
+++ b/apps/api/tests/test_animation_tools.py
@@ -6,7 +6,7 @@ from app.domain.animation_tools import (
     safe_expand_animation_call,
     safe_expand_cir_animation_calls_with_issues,
 )
-from app.domain.animation_tools.registry import _REGISTRY
+from app.domain.animation_tools.registry import _REGISTRY, list_animation_tools
 from app.domain.models.cir import (
     AnimationCall,
     CirDocument,
@@ -417,3 +417,14 @@ class TestRegistry:
         # Expect at least 3 math tools
         math_tools = [k for k in _REGISTRY if k.startswith("math.")]
         assert len(math_tools) >= 7
+
+    def test_list_includes_args_schema_for_math_function(self):
+        tools = {tool.name: tool for tool in list_animation_tools()}
+
+        schema = tools["math.show_function"].args_schema
+
+        assert tools["math.show_function"].description
+        assert schema["type"] == "object"
+        assert schema["properties"]["expression"]["minLength"] == 1
+        assert "x_min" in schema["properties"]
+        assert "x_max" in schema["properties"]

--- a/apps/api/tests/test_router_agent.py
+++ b/apps/api/tests/test_router_agent.py
@@ -133,10 +133,31 @@ def test_animation_tool_list_requires_shared_token(monkeypatch: pytest.MonkeyPat
     assert wrong.status_code == 401
     assert ok.status_code == 200
     tools = ok.json()["tools"]
-    assert {
-        "name": "math.show_tangent",
-        "description": "Show a function and tangent line at a selected x value.",
-    } in tools
+    tangent = next(tool for tool in tools if tool["name"] == "math.show_tangent")
+    assert tangent["description"] == "Show a function and tangent line at a selected x value."
+    assert tangent["args_schema"]["properties"]["expression"]["minLength"] == 1
+
+
+def test_animation_tool_list_returns_args_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("METAVIEW_AGENT_SHARED_TOKEN", "secret")
+    get_settings.cache_clear()
+    client = TestClient(create_app())
+
+    response = client.get(
+        "/api/v1/agent/animation-tools",
+        headers={"X-MetaView-Agent-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+    tools = response.json()["tools"]
+    show_function = next(tool for tool in tools if tool["name"] == "math.show_function")
+    schema = show_function["args_schema"]
+    assert schema["type"] == "object"
+    assert schema["properties"]["expression"]["minLength"] == 1
+    assert "x_min" in schema["properties"]
+    assert "x_max" in schema["properties"]
 
 
 def test_animation_tool_expand_returns_layers_with_issues_empty(

--- a/apps/web/src/features/playbook/engine/player/MobileSheet.tsx
+++ b/apps/web/src/features/playbook/engine/player/MobileSheet.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect } from "react";
+
+const CloseSVG = () => (
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </svg>
+);
+
+interface MobileSheetProps {
+  title: string;
+  children: React.ReactNode;
+  onClose: () => void;
+}
+
+export function MobileSheet({ title, children, onClose }: MobileSheetProps) {
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <div className="playbook-player__mobile-sheet" role="dialog" aria-modal="true" aria-label={title}>
+      <button
+        type="button"
+        className="playbook-player__mobile-sheet-backdrop"
+        aria-label="关闭面板"
+        onClick={onClose}
+      />
+      <div className="playbook-player__mobile-sheet-panel">
+        <div className="playbook-player__mobile-sheet-head">
+          <strong>{title}</strong>
+          <button type="button" className="playbook-player__mobile-icon-btn" onClick={onClose} aria-label="关闭面板">
+            <CloseSVG />
+          </button>
+        </div>
+        <div className="playbook-player__mobile-sheet-body">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/playbook/engine/player/ParamPanelSlot.tsx
+++ b/apps/web/src/features/playbook/engine/player/ParamPanelSlot.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+import { getParamPanel } from "../param-panels/registry";
+import type { ParamPanelProps } from "../param-panels/types";
+
+export function ParamPanelSlot({ domain, ...props }: ParamPanelProps & { domain: string }) {
+  const Panel = getParamPanel(domain);
+  if (!Panel) return null;
+  return React.createElement(Panel, props);
+}

--- a/apps/web/src/features/playbook/engine/player/PlaybookLearningConsole.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookLearningConsole.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+
+import type { CodeHighlightOverlay, PlaybookScript } from "../types";
+import { CodeHighlightRenderer } from "../renderers/CodeHighlightRenderer";
+import type { ScriptOverrides } from "./useResolvedScript";
+import { ParamPanelSlot } from "./ParamPanelSlot";
+
+interface PlaybookLearningConsoleProps {
+  showCodePanelSlot: boolean;
+  codeOverlay: CodeHighlightOverlay | null;
+  theme: "dark" | "light";
+  hasDomainPanel: boolean;
+  baseScript: PlaybookScript;
+  overrides: ScriptOverrides;
+  onOverridesChange: (next: ScriptOverrides) => void;
+  followupSlot?: React.ReactNode;
+  relatedSlot?: React.ReactNode;
+  relatedAlgorithmId?: string | null;
+}
+
+export function PlaybookLearningConsole({
+  showCodePanelSlot,
+  codeOverlay,
+  theme,
+  hasDomainPanel,
+  baseScript,
+  overrides,
+  onOverridesChange,
+  followupSlot,
+  relatedSlot,
+  relatedAlgorithmId,
+}: PlaybookLearningConsoleProps) {
+  return (
+    <aside className="playbook-player__console" aria-label="Learning console">
+      {showCodePanelSlot && (
+        <section className="playbook-player__console-card playbook-player__code-card">
+          <div className="playbook-player__console-head">
+            <span>Code Sync</span>
+            <small>{codeOverlay?.language ?? "source"}</small>
+          </div>
+          <div className="playbook-player__code-body">
+            {codeOverlay ? (
+              <CodeHighlightRenderer overlay={codeOverlay} theme={theme} />
+            ) : (
+              <div className="playbook-player__code-empty">
+                <span>{"</>"}</span>
+                <p>Code highlights will sync here.</p>
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {hasDomainPanel && (
+        <section className="playbook-player__console-card playbook-player__params-card">
+          <div className="playbook-player__console-head">
+            <span>Params</span>
+            <small>{baseScript.domain}</small>
+          </div>
+          <div className="playbook-player__param-body">
+            <ParamPanelSlot
+              domain={baseScript.domain}
+              script={baseScript}
+              overrides={overrides}
+              onOverridesChange={onOverridesChange}
+              isDark={theme === "dark"}
+            />
+          </div>
+        </section>
+      )}
+
+      {followupSlot && (
+        <section className="playbook-player__console-card playbook-player__follow-card">
+          <div className="playbook-player__console-head">
+            <span>Follow-up</span>
+            <small>current step</small>
+          </div>
+          <div className="playbook-player__follow-body">{followupSlot}</div>
+        </section>
+      )}
+
+      {relatedSlot ? (
+        <section className="playbook-player__related-card" aria-label="Related study context">
+          {relatedSlot}
+        </section>
+      ) : (
+        <section className="playbook-player__related-row" aria-label="Related study context">
+          <span>Related</span>
+          <strong>{relatedAlgorithmId ?? "Study variants"}</strong>
+          <small>›</small>
+        </section>
+      )}
+    </aside>
+  );
+}

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Player } from "@remotion/player";
 import type { PlayerRef } from "@remotion/player";
-import type { CodeHighlightOverlay, DirectorScript, PlaybookScript } from "../types";
+import type { DirectorScript, PlaybookScript } from "../types";
 import { usePlaybookController } from "./usePlaybookController";
 import { PlaybookComposition } from "../composition/PlaybookComposition";
 import { PLAYBOOK_DEFAULTS } from "../../../../shared/config/constants";
@@ -19,6 +19,9 @@ import type { ParamPanelProps } from "../param-panels/types";
 import { hasReplayableAlgorithmParams } from "../param-panels/AlgorithmParamPanel";
 import { resolveDirectorVoiceover } from "../director";
 import { emitNativeEvent } from "../../../../shared/native/emitNativeEvent";
+import { MobileSheet } from "./MobileSheet";
+import { PlaybookPortraitShell, type MobileTabKey } from "./PlaybookPortraitShell";
+import { clipCodeOverlay } from "./mobileCodeOverlay";
 
 // ── ParamPanelSlot (static component — resolves domain panel from registry) ──
 
@@ -84,15 +87,6 @@ const MoreSVG = () => (
   </svg>
 );
 
-const CloseSVG = () => (
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="none"
-       stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-       aria-hidden="true">
-    <path d="M18 6 6 18" />
-    <path d="m6 6 12 12" />
-  </svg>
-);
-
 function TopbarFoldIcon({ collapsed }: { collapsed: boolean }) {
   return (
     <svg
@@ -120,18 +114,7 @@ function TopbarFoldIcon({ collapsed }: { collapsed: boolean }) {
 
 export type PlaybookLayoutMode = "desktop" | "portrait";
 
-type MobileTabKey = "narration" | "code" | "params" | "followup" | "more";
-
 const PORTRAIT_QUERY = "(max-width: 680px) and (orientation: portrait)";
-const CODE_CONTEXT_LINES = 2;
-
-const MOBILE_TABS: Array<{ key: MobileTabKey; label: string }> = [
-  { key: "narration", label: "讲解" },
-  { key: "code", label: "代码" },
-  { key: "params", label: "参数" },
-  { key: "followup", label: "追问" },
-  { key: "more", label: "更多" },
-];
 
 function resolveAutoLayoutMode(): PlaybookLayoutMode {
   if (typeof window === "undefined" || !window.matchMedia) return "desktop";
@@ -154,84 +137,6 @@ function useAutoLayoutMode(layoutMode?: PlaybookLayoutMode): PlaybookLayoutMode 
   }, [layoutMode]);
 
   return layoutMode ?? autoLayoutMode;
-}
-
-interface ClippedCodeOverlay {
-  overlay: CodeHighlightOverlay;
-  lineNumberOffset: number;
-  fromLine: number;
-  toLine: number;
-  totalLines: number;
-}
-
-function clipCodeOverlay(
-  overlay: CodeHighlightOverlay | null,
-  contextLines = CODE_CONTEXT_LINES,
-): ClippedCodeOverlay | null {
-  if (!overlay || overlay.lines.length === 0) return null;
-  const anchor = Math.max(
-    0,
-    Math.min(
-      overlay.lines.length - 1,
-      overlay.active_line >= 0 ? overlay.active_line : overlay.active_lines[0] ?? 0,
-    ),
-  );
-  const from = Math.max(0, anchor - contextLines);
-  const to = Math.min(overlay.lines.length - 1, anchor + contextLines);
-  const activeLines = overlay.active_lines
-    .filter((line) => line >= from && line <= to)
-    .map((line) => line - from);
-
-  return {
-    overlay: {
-      ...overlay,
-      lines: overlay.lines.slice(from, to + 1),
-      active_line: anchor - from,
-      active_lines: activeLines.length ? activeLines : [anchor - from],
-    },
-    lineNumberOffset: from,
-    fromLine: from + 1,
-    toLine: to + 1,
-    totalLines: overlay.lines.length,
-  };
-}
-
-function MobileSheet({
-  title,
-  children,
-  onClose,
-}: {
-  title: string;
-  children: React.ReactNode;
-  onClose: () => void;
-}) {
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [onClose]);
-
-  return (
-    <div className="playbook-player__mobile-sheet" role="dialog" aria-modal="true" aria-label={title}>
-      <button
-        type="button"
-        className="playbook-player__mobile-sheet-backdrop"
-        aria-label="关闭面板"
-        onClick={onClose}
-      />
-      <div className="playbook-player__mobile-sheet-panel">
-        <div className="playbook-player__mobile-sheet-head">
-          <strong>{title}</strong>
-          <button type="button" className="playbook-player__mobile-icon-btn" onClick={onClose} aria-label="关闭面板">
-            <CloseSVG />
-          </button>
-        </div>
-        <div className="playbook-player__mobile-sheet-body">{children}</div>
-      </div>
-    </div>
-  );
 }
 
 // ── Player Settings Popover ────────────────────────────────────────────────
@@ -721,73 +626,160 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
     setMobileSheet(sheet);
     emitNativeEvent("playbook.mobileSheetOpened", { sheet });
   };
-  const mobileTabPanel =
-    mobileTab === "code" ? (
-      <div className="playbook-player__mobile-panel playbook-player__mobile-code-panel">
-        {mobileCodeOverlay ? (
-          <>
-            <div className="playbook-player__mobile-panel-head">
-              <span>
-                Lines {mobileCodeOverlay.fromLine}-{mobileCodeOverlay.toLine} / {mobileCodeOverlay.totalLines}
-              </span>
-              <button type="button" onClick={() => openMobileSheet("code")}>
-                查看全部代码
-              </button>
-            </div>
-            <div className="playbook-player__mobile-code-snippet">
-              <CodeHighlightRenderer
-                overlay={mobileCodeOverlay.overlay}
-                theme={theme}
-                lineNumberOffset={mobileCodeOverlay.lineNumberOffset}
-              />
-            </div>
-          </>
-        ) : (
-          <div className="playbook-player__mobile-empty">当前步骤没有代码同步片段。</div>
-        )}
-      </div>
-    ) : mobileTab === "params" ? (
-      <div className="playbook-player__mobile-panel">
-        {hasDomainPanel ? (
-          <div className="playbook-player__mobile-param-panel">
-            <ParamPanelSlot
-              domain={baseScript.domain}
-              script={baseScript}
-              overrides={overrides}
-              onOverridesChange={setOverrides}
-              isDark={theme === "dark"}
-            />
+  const mobileParamsContent = (
+    <ParamPanelSlot
+      domain={baseScript.domain}
+      script={baseScript}
+      overrides={overrides}
+      onOverridesChange={setOverrides}
+      isDark={theme === "dark"}
+    />
+  );
+  const topbarAction =
+    isPortraitLayout && onToggleTopbar ? (
+      <button
+        type="button"
+        className="playbook-player__ghost-btn playbook-player__mobile-topbar-btn"
+        onClick={onToggleTopbar}
+        title={topbarCollapsed ? "显示顶部栏" : "返回导航"}
+        aria-label={topbarCollapsed ? "显示顶部栏" : "返回导航"}
+        aria-pressed={topbarCollapsed}
+      >
+        <TopbarFoldIcon collapsed={topbarCollapsed} />
+      </button>
+    ) : null;
+  const exportAction = onOpenExport ? (
+    <button
+      type="button"
+      className="playbook-player__ghost-btn playbook-player__export-btn"
+      onClick={onOpenExport}
+      title="导出 MP4"
+      aria-label="导出 MP4"
+    >
+      <ExportSVG />
+    </button>
+  ) : null;
+  const moreAction =
+    isPortraitLayout && showLearningConsole ? (
+      <button
+        type="button"
+        className="playbook-player__ghost-btn playbook-player__mobile-more-btn"
+        onClick={() => openMobileSheet("more")}
+        title="更多"
+        aria-label="更多"
+      >
+        <MoreSVG />
+      </button>
+    ) : null;
+  const stageSlot = (
+    <section className="playbook-player__stage-shell" aria-label="Lesson animation">
+      <div className="playbook-player__stage">
+        {capability.message && capability.support !== "full" && (
+          <div
+            className="playbook-player__capability"
+            title={capability.message}
+          >
+            <span>{capability.domain}</span>
+            <span>{capability.support}</span>
           </div>
-        ) : (
-          <div className="playbook-player__mobile-empty">当前步骤没有可调参数。</div>
         )}
+        <Player
+          key={playerTimelineKey}
+          ref={playerRef}
+          component={PlaybookComposition}
+          inputProps={{
+            script,
+            director,
+            theme,
+            showSubtitles: false,
+            swapDurationFrames,
+          }}
+          durationInFrames={script.total_frames}
+          fps={script.fps}
+          compositionWidth={PLAYBOOK_DEFAULTS.COMPOSITION_WIDTH}
+          compositionHeight={PLAYBOOK_DEFAULTS.COMPOSITION_HEIGHT}
+          initialFrame={initialPreviewFrame}
+          style={{ width: "100%", height: "100%" }}
+          playbackRate={playbackRate}
+          clickToPlay={false}
+        />
       </div>
-    ) : mobileTab === "followup" ? (
-      <div className="playbook-player__mobile-panel">
+    </section>
+  );
+  const controlsSlot = (
+    <div className="playbook-player__controls">
+      <button
+        className="playbook-ctrl-btn playbook-ctrl-btn--play"
+        onClick={handlePlayPause}
+        aria-label={isPlaying ? "暂停" : "播放"}
+      >
+        {isPlaying ? "⏸" : "▶"}
+      </button>
+
+      <div className="playbook-player__progress" role="group" aria-label="Lesson steps">
+        {script.steps.map((step, i) => (
+          <button
+            key={step.step_id}
+            type="button"
+            className={i === safeStepIndex ? "is-active" : ""}
+            onClick={() => goToStep(i)}
+            title={step.title}
+            aria-label={`Step ${i + 1}: ${step.title}`}
+          />
+        ))}
+      </div>
+
+      <div className="playbook-player__control-actions">
+        <div className="playbook-player__settings-anchor">
+          <button
+            className="playbook-ctrl-btn"
+            onClick={() => setShowPlayerSettings((v) => !v)}
+            title="播放器设置"
+            aria-label="播放器设置"
+            type="button"
+          >
+            <SettingsSVG />
+          </button>
+          {showPlayerSettings && (
+            <PlayerSettingsPopover
+              playbackRate={playbackRate}
+              onPlaybackRateChange={setPlaybackRate}
+              stepThrough={stepThrough}
+              onStepThroughChange={setStepThrough}
+              ttsEnabled={tts.enabled}
+              ttsSupported={tts.supported}
+              onToggleTTS={tts.toggle}
+              config={tts.config}
+              onUpdate={tts.updateConfig}
+              onClose={() => setShowPlayerSettings(false)}
+              isDark={isDark}
+              onPreview={handleVoicePreview}
+            />
+          )}
+        </div>
+
         <button
+          className="playbook-ctrl-btn"
+          onClick={prev}
+          disabled={!canGoPrev}
+          aria-label="上一步"
           type="button"
-          className="playbook-player__mobile-open-sheet"
-          onClick={() => openMobileSheet("followup")}
         >
-          打开追问面板
+          &#8249;
+        </button>
+
+        <button
+          className="playbook-ctrl-btn"
+          onClick={next}
+          disabled={!canGoNext}
+          aria-label="下一步"
+          type="button"
+        >
+          &#8250;
         </button>
       </div>
-    ) : mobileTab === "more" ? (
-      <div className="playbook-player__mobile-panel">
-        <button
-          type="button"
-          className="playbook-player__mobile-open-sheet"
-          onClick={() => openMobileSheet("more")}
-        >
-          打开更多操作
-        </button>
-      </div>
-    ) : (
-      <div className="playbook-player__mobile-panel playbook-player__mobile-narration">
-        <span>步骤 {safeStepIndex + 1} / {script.steps.length}</span>
-        <p>{currentNarration || currentStep.title}</p>
-      </div>
-    );
+    </div>
+  );
   const playerClassName = [
     "playbook-player",
     "playbook-player--minimal",
@@ -799,6 +791,29 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
 
   return (
     <div className={playerClassName} data-theme={theme}>
+      {isPortraitLayout && (
+        <PlaybookPortraitShell
+          domain={script.domain}
+          title={script.title}
+          currentStepTitle={currentStep.title}
+          currentNarration={currentNarration}
+          safeStepIndex={safeStepIndex}
+          stepCount={script.steps.length}
+          theme={theme}
+          topbarAction={topbarAction}
+          exportAction={exportAction}
+          moreAction={moreAction}
+          stageSlot={stageSlot}
+          controlsSlot={controlsSlot}
+          showMobileConsole={showMobileConsole}
+          activeTab={mobileTab}
+          onSelectTab={selectMobileTab}
+          onOpenSheet={openMobileSheet}
+          mobileCodeOverlay={mobileCodeOverlay}
+          hasDomainPanel={hasDomainPanel}
+          paramsContent={mobileParamsContent}
+        />
+      )}
       {!isPortraitLayout && (
       <aside className="playbook-player__rail" aria-label="Lesson steps">
         {onToggleTopbar ? (
@@ -846,6 +861,7 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
       </aside>
       )}
 
+      {!isPortraitLayout && (
       <div className="playbook-player__workspace">
         <header className="playbook-player__header">
           <div className="playbook-player__brand">
@@ -857,196 +873,20 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
             <strong>{script.title}</strong>
           </div>
           <div className="playbook-player__header-actions">
-            {isPortraitLayout && onToggleTopbar && (
-              <button
-                type="button"
-                className="playbook-player__ghost-btn playbook-player__mobile-topbar-btn"
-                onClick={onToggleTopbar}
-                title={topbarCollapsed ? "显示顶部栏" : "返回导航"}
-                aria-label={topbarCollapsed ? "显示顶部栏" : "返回导航"}
-                aria-pressed={topbarCollapsed}
-              >
-                <TopbarFoldIcon collapsed={topbarCollapsed} />
-              </button>
-            )}
-            {onOpenExport && (
-              <button
-                type="button"
-                className="playbook-player__ghost-btn playbook-player__export-btn"
-                onClick={onOpenExport}
-                title="导出 MP4"
-                aria-label="导出 MP4"
-              >
-                <ExportSVG />
-              </button>
-            )}
-            {isPortraitLayout && showLearningConsole && (
-              <button
-                type="button"
-                className="playbook-player__ghost-btn playbook-player__mobile-more-btn"
-                onClick={() => openMobileSheet("more")}
-                title="更多"
-                aria-label="更多"
-              >
-                <MoreSVG />
-              </button>
-            )}
+            {exportAction}
           </div>
         </header>
 
-        {isPortraitLayout && (
-          <div className="playbook-player__mobile-step">
-            <span>步骤 {safeStepIndex + 1} / {script.steps.length}</span>
-            <strong>{currentStep.title}</strong>
-          </div>
-        )}
+        {stageSlot}
 
-        <section className="playbook-player__stage-shell" aria-label="Lesson animation">
-          <div className="playbook-player__stage">
-            {capability.message && capability.support !== "full" && (
-              <div
-                className="playbook-player__capability"
-                title={capability.message}
-              >
-                <span>{capability.domain}</span>
-                <span>{capability.support}</span>
-              </div>
-            )}
-            <Player
-              key={playerTimelineKey}
-              ref={playerRef}
-              component={PlaybookComposition}
-              inputProps={{
-                script,
-                director,
-                theme,
-                showSubtitles: false,
-                swapDurationFrames,
-              }}
-              durationInFrames={script.total_frames}
-              fps={script.fps}
-              compositionWidth={PLAYBOOK_DEFAULTS.COMPOSITION_WIDTH}
-              compositionHeight={PLAYBOOK_DEFAULTS.COMPOSITION_HEIGHT}
-              initialFrame={initialPreviewFrame}
-              style={{ width: "100%", height: "100%" }}
-              playbackRate={playbackRate}
-              clickToPlay={false}
-            />
-          </div>
-        </section>
-
-        {!isPortraitLayout && (
-          <div className="playbook-player__caption">
-            <span aria-hidden="true" />
-            <p>{currentNarration || currentStep.title}</p>
-          </div>
-        )}
-
-        <div className="playbook-player__controls">
-          <button
-            className="playbook-ctrl-btn playbook-ctrl-btn--play"
-            onClick={handlePlayPause}
-            aria-label={isPlaying ? "暂停" : "播放"}
-          >
-            {isPlaying ? "⏸" : "▶"}
-          </button>
-
-          <div className="playbook-player__progress" role="group" aria-label="Lesson steps">
-            {script.steps.map((step, i) => (
-              <button
-                key={step.step_id}
-                type="button"
-                className={i === safeStepIndex ? "is-active" : ""}
-                onClick={() => goToStep(i)}
-                title={step.title}
-                aria-label={`Step ${i + 1}: ${step.title}`}
-              />
-            ))}
-          </div>
-
-          <div className="playbook-player__control-actions">
-            <div className="playbook-player__settings-anchor">
-              <button
-                className="playbook-ctrl-btn"
-                onClick={() => setShowPlayerSettings((v) => !v)}
-                title="播放器设置"
-                aria-label="播放器设置"
-                type="button"
-              >
-                <SettingsSVG />
-              </button>
-              {showPlayerSettings && (
-                <PlayerSettingsPopover
-                  playbackRate={playbackRate}
-                  onPlaybackRateChange={setPlaybackRate}
-                  stepThrough={stepThrough}
-                  onStepThroughChange={setStepThrough}
-                  ttsEnabled={tts.enabled}
-                  ttsSupported={tts.supported}
-                  onToggleTTS={tts.toggle}
-                  config={tts.config}
-                  onUpdate={tts.updateConfig}
-                  onClose={() => setShowPlayerSettings(false)}
-                  isDark={isDark}
-                  onPreview={handleVoicePreview}
-                />
-              )}
-            </div>
-
-            <button
-              className="playbook-ctrl-btn"
-              onClick={prev}
-              disabled={!canGoPrev}
-              aria-label="上一步"
-              type="button"
-            >
-              &#8249;
-            </button>
-
-            <button
-              className="playbook-ctrl-btn"
-              onClick={next}
-              disabled={!canGoNext}
-              aria-label="下一步"
-              type="button"
-            >
-              &#8250;
-            </button>
-          </div>
+        <div className="playbook-player__caption">
+          <span aria-hidden="true" />
+          <p>{currentNarration || currentStep.title}</p>
         </div>
 
-        {isPortraitLayout && (
-          <div className="playbook-player__caption playbook-player__caption--mobile">
-            <span aria-hidden="true" />
-            <p>{currentNarration || currentStep.title}</p>
-          </div>
-        )}
-
-        {showMobileConsole && (
-          <section className="playbook-player__mobile-console" aria-label="移动学习面板">
-            <div className="playbook-player__mobile-tabs" role="tablist" aria-label="移动学习面板">
-              {MOBILE_TABS.map((tab) => (
-                <button
-                  key={tab.key}
-                  type="button"
-                  role="tab"
-                  aria-selected={mobileTab === tab.key}
-                  className={mobileTab === tab.key ? "is-active" : ""}
-                  onClick={() => {
-                    selectMobileTab(tab.key);
-                    if (tab.key === "followup" || tab.key === "more") {
-                      openMobileSheet(tab.key);
-                    }
-                  }}
-                >
-                  {tab.label}
-                </button>
-              ))}
-            </div>
-            {mobileTabPanel}
-          </section>
-        )}
+        {controlsSlot}
       </div>
+      )}
 
       {showLearningConsole && !isPortraitLayout && (
         <aside className="playbook-player__console" aria-label="Learning console">

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
@@ -5,8 +5,7 @@ import type { DirectorScript, PlaybookScript } from "../types";
 import { usePlaybookController } from "./usePlaybookController";
 import { PlaybookComposition } from "../composition/PlaybookComposition";
 import { PLAYBOOK_DEFAULTS } from "../../../../shared/config/constants";
-import { useTTS, OPENAI_VOICES, AUTO_VOICE, resolveVoice } from "./useTTS";
-import type { TTSConfig } from "./useTTS";
+import { useTTS, resolveVoice } from "./useTTS";
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 import { resolveNarrationTemplate } from "./resolveNarrationTemplate";
 import { useResolvedScript, type ScriptOverrides } from "./useResolvedScript";
@@ -15,102 +14,17 @@ import { resolveInitialPreviewFrame, resolvePlayerTimelineKey } from "./previewF
 import { CodeHighlightRenderer } from "../renderers/CodeHighlightRenderer";
 import { domainCapability } from "../domainCapabilities";
 import { getParamPanel } from "../param-panels/registry";
-import type { ParamPanelProps } from "../param-panels/types";
 import { hasReplayableAlgorithmParams } from "../param-panels/AlgorithmParamPanel";
 import { resolveDirectorVoiceover } from "../director";
 import { emitNativeEvent } from "../../../../shared/native/emitNativeEvent";
 import { MobileSheet } from "./MobileSheet";
+import { ParamPanelSlot } from "./ParamPanelSlot";
+import { PlaybookLearningConsole } from "./PlaybookLearningConsole";
+import { PlayerSettingsPopover } from "./PlayerSettingsPopover";
+import { ExportSVG, MoreSVG, SettingsSVG, TopbarFoldIcon } from "./PlaybookPlayerIcons";
 import { PlaybookPortraitShell, type MobileTabKey } from "./PlaybookPortraitShell";
 import { clipCodeOverlay } from "./mobileCodeOverlay";
-
-// ── ParamPanelSlot (static component — resolves domain panel from registry) ──
-
-function ParamPanelSlot({ domain, ...props }: ParamPanelProps & { domain: string }) {
-  const Panel = getParamPanel(domain);
-  if (!Panel) return null;
-  return React.createElement(Panel, props);
-}
-
-// ── SVG icons ──────────────────────────────────────────────────────────────
-
-const SpeakerOnSVG = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
-       stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
-    <path d="M15.54 8.46a5 5 0 0 1 0 7.07"/>
-    <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
-  </svg>
-);
-
-const SpeakerOffSVG = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
-       stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
-    <line x1="23" y1="9" x2="17" y2="15"/>
-    <line x1="17" y1="9" x2="23" y2="15"/>
-  </svg>
-);
-
-const SettingsSVG = () => (
-  <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
-       stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <circle cx="12" cy="12" r="3"/>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06
-             a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09
-             A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83
-             l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09
-             A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83
-             l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09
-             a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83
-             l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09
-             a1.65 1.65 0 0 0-1.51 1z"/>
-  </svg>
-);
-
-const ExportSVG = () => (
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="none"
-       stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-       aria-hidden="true">
-    <path d="M12 3v12" />
-    <path d="m7 10 5 5 5-5" />
-    <path d="M5 21h14" />
-  </svg>
-);
-
-const MoreSVG = () => (
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="none"
-       stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-       aria-hidden="true">
-    <circle cx="5" cy="12" r="1" />
-    <circle cx="12" cy="12" r="1" />
-    <circle cx="19" cy="12" r="1" />
-  </svg>
-);
-
-function TopbarFoldIcon({ collapsed }: { collapsed: boolean }) {
-  return (
-    <svg
-      className="playbook-player__chrome-toggle-icon"
-      data-testid={
-        collapsed ? "topbar-toggle-icon-expand" : "topbar-toggle-icon-collapse"
-      }
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.55"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path className="playbook-player__chrome-toggle-bar" d="M7 7.5h10" />
-      {collapsed ? (
-        <path className="playbook-player__chrome-toggle-chevron" d="m7.5 11 4.5 4.5 4.5-4.5" />
-      ) : (
-        <path className="playbook-player__chrome-toggle-chevron" d="m7.5 14 4.5-4.5 4.5 4.5" />
-      )}
-    </svg>
-  );
-}
+import { SPEED_STEPS } from "./playbackRates";
 
 export type PlaybookLayoutMode = "desktop" | "portrait";
 
@@ -138,268 +52,6 @@ function useAutoLayoutMode(layoutMode?: PlaybookLayoutMode): PlaybookLayoutMode 
 
   return layoutMode ?? autoLayoutMode;
 }
-
-// ── Player Settings Popover ────────────────────────────────────────────────
-
-interface PlayerSettingsPopoverProps {
-  playbackRate: number;
-  onPlaybackRateChange: (rate: number) => void;
-  stepThrough: boolean;
-  onStepThroughChange: (next: boolean) => void;
-  ttsEnabled: boolean;
-  ttsSupported: boolean;
-  onToggleTTS: () => void;
-  config: TTSConfig;
-  onUpdate: (patch: Partial<TTSConfig>) => void;
-  onClose: () => void;
-  isDark: boolean;
-  onPreview: (voice: string, sampleText: string) => void;
-}
-
-const SAMPLE_TEXT_DEFAULT = "你好，这是一段试听文字。Hello, this is a preview.";
-const SPEED_STEPS = [0.5, 0.75, 1, 1.25, 1.5, 2];
-
-const PlayerSettingsPopover: React.FC<PlayerSettingsPopoverProps> = ({
-  playbackRate,
-  onPlaybackRateChange,
-  stepThrough,
-  onStepThroughChange,
-  ttsEnabled,
-  ttsSupported,
-  onToggleTTS,
-  config,
-  onUpdate,
-  onClose,
-  isDark,
-  onPreview,
-}) => {
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const [sampleText, setSampleText] = useState(SAMPLE_TEXT_DEFAULT);
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Element | null;
-      if (target?.closest(".playbook-player__settings-anchor")) return;
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [onClose]);
-
-  const bg = isDark ? "#161b22" : "#ffffff";
-  const border = isDark ? "#30363d" : "#d0d7de";
-  const text = isDark ? "#c9d1d9" : "#24292f";
-  const muted = isDark ? "#8b949e" : "#6e7781";
-  const inputBg = isDark ? "#0d1117" : "#f6f8fa";
-  const accent = isDark ? "#4de8b0" : "#00896e";
-
-  return (
-    <div
-      ref={popoverRef}
-      className="playbook-player__settings-popover"
-      style={{
-        "--player-settings-bg": bg,
-        "--player-settings-border": border,
-        "--player-settings-text": text,
-        "--player-settings-muted": muted,
-        "--player-settings-input": inputBg,
-        "--player-settings-accent": accent,
-      } as React.CSSProperties}
-    >
-      <div className="playbook-player__settings-section">
-        <div className="playbook-player__settings-label">播放速度</div>
-        <div className="playbook-player__settings-speed-row">
-          {SPEED_STEPS.map((s) => (
-            <button
-              key={s}
-              type="button"
-              onClick={() => onPlaybackRateChange(s)}
-              className={playbackRate === s ? "is-active" : ""}
-            >
-              {s}×
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="playbook-player__settings-section">
-        <div className="playbook-player__settings-row">
-          <span>播放模式</span>
-          <button
-            type="button"
-            className={`playbook-player__settings-toggle${stepThrough ? " is-active" : ""}`}
-            onClick={() => onStepThroughChange(!stepThrough)}
-          >
-            {stepThrough ? "步进" : "连播"}
-          </button>
-        </div>
-        <div className="playbook-player__settings-row">
-          <span>语音朗读</span>
-          <button
-            type="button"
-            className={`playbook-player__settings-toggle${ttsEnabled ? " is-active" : ""}`}
-            onClick={onToggleTTS}
-            disabled={!ttsSupported}
-          >
-            {ttsEnabled ? <SpeakerOnSVG /> : <SpeakerOffSVG />}
-            {ttsEnabled ? "开启" : "关闭"}
-          </button>
-        </div>
-      </div>
-
-      <div className="playbook-player__settings-section">
-        <div className="playbook-player__settings-label">语音后端</div>
-        <div className="playbook-player__settings-choice-row">
-          {(["system", "openai"] as const).map((b) => (
-            <button
-              key={b}
-              type="button"
-              onClick={() => onUpdate({ backend: b })}
-              className={config.backend === b ? "is-active" : ""}
-            >
-              {b === "system" ? "系统语音" : "OpenAI API"}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* OpenAI backend now routes through the server-side proxy
-         (POST /api/v1/tts/speech) so the player never stores an API key.
-         The Base URL / Model / Key inputs that used to live here are gone
-         on purpose — issue #40. */}
-      {config.backend === "openai" && (
-        <div
-          className="playbook-player__settings-note"
-          style={{
-            border: `1px dashed ${border}`,
-          }}
-        >
-          通过服务端代理调用，API Key 由管理员在后端配置（METAVIEW_TTS_API_KEY）。
-        </div>
-      )}
-
-      {/* Voice picker (OpenAI only) */}
-      {config.backend === "openai" && (
-        <div>
-          <div className="playbook-player__settings-label">
-            音色 <span style={{ color: text }}>{config.voice === AUTO_VOICE ? "跟随学科" : config.voice}</span>
-          </div>
-          <div style={{ display: "flex", flexDirection: "column", gap: 4, maxHeight: 180, overflowY: "auto" }}>
-            <button
-              type="button"
-              onClick={() => onUpdate({ voice: AUTO_VOICE })}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                padding: "5px 8px",
-                borderRadius: 5,
-                border: `1px solid ${config.voice === AUTO_VOICE ? accent : border}`,
-                background: config.voice === AUTO_VOICE ? `${accent}18` : "transparent",
-                color: config.voice === AUTO_VOICE ? accent : text,
-                fontSize: 12,
-                cursor: "pointer",
-                textAlign: "left",
-              }}
-            >
-              <span>跟随学科自动推荐</span>
-            </button>
-            {OPENAI_VOICES.map((v) => (
-              <div
-                key={v.id}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 6,
-                  padding: "4px 8px",
-                  borderRadius: 5,
-                  border: `1px solid ${config.voice === v.id ? accent : border}`,
-                  background: config.voice === v.id ? `${accent}18` : "transparent",
-                }}
-              >
-                <button
-                  type="button"
-                  onClick={() => onUpdate({ voice: v.id })}
-                  style={{
-                    flex: 1,
-                    background: "transparent",
-                    border: "none",
-                    color: config.voice === v.id ? accent : text,
-                    fontSize: 12,
-                    fontWeight: config.voice === v.id ? 600 : 400,
-                    textAlign: "left",
-                    cursor: "pointer",
-                    padding: 0,
-                  }}
-                  title={v.description}
-                >
-                  {v.label}
-                  <span style={{ color: muted, fontWeight: 400, marginLeft: 6 }}>{v.description}</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => onPreview(v.id, sampleText)}
-                  style={{
-                    background: "transparent",
-                    border: `1px solid ${border}`,
-                    borderRadius: 4,
-                    color: muted,
-                    fontSize: 11,
-                    padding: "2px 6px",
-                    cursor: "pointer",
-                  }}
-                >
-                  ⏵ 试听
-                </button>
-              </div>
-            ))}
-          </div>
-          <div style={{ marginTop: 6 }}>
-            <div style={{ fontSize: 11, color: muted, marginBottom: 3 }}>试听文字</div>
-            <input
-              type="text"
-              value={sampleText}
-              onChange={(e) => setSampleText(e.target.value)}
-              placeholder={SAMPLE_TEXT_DEFAULT}
-              style={{
-                width: "100%",
-                padding: "5px 8px",
-                background: inputBg,
-                border: `1px solid ${border}`,
-                borderRadius: 5,
-                color: text,
-                fontSize: 12,
-                outline: "none",
-                boxSizing: "border-box",
-              }}
-            />
-          </div>
-        </div>
-      )}
-
-      <div className="playbook-player__settings-section">
-        <div className="playbook-player__settings-label">
-          语速 <span style={{ color: text }}>{config.rate.toFixed(1)}×</span>
-        </div>
-        <input
-          type="range"
-          min="0.5"
-          max="2.0"
-          step="0.1"
-          value={config.rate}
-          onChange={(e) => onUpdate({ rate: parseFloat(e.target.value) })}
-          className="playbook-player__settings-range"
-        />
-      </div>
-
-      <div className="playbook-player__settings-footnote">
-        设置存储在本地浏览器中
-      </div>
-    </div>
-  );
-};
 
 // ── Main component ─────────────────────────────────────────────────────────
 
@@ -889,66 +541,18 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
       )}
 
       {showLearningConsole && !isPortraitLayout && (
-        <aside className="playbook-player__console" aria-label="Learning console">
-          {showCodePanelSlot && (
-            <section className="playbook-player__console-card playbook-player__code-card">
-              <div className="playbook-player__console-head">
-                <span>Code Sync</span>
-                <small>{codeOverlay?.language ?? "source"}</small>
-              </div>
-              <div className="playbook-player__code-body">
-                {codeOverlay ? (
-                  <CodeHighlightRenderer overlay={codeOverlay} theme={theme} />
-                ) : (
-                  <div className="playbook-player__code-empty">
-                    <span>{"</>"}</span>
-                    <p>Code highlights will sync here.</p>
-                  </div>
-                )}
-              </div>
-            </section>
-          )}
-
-          {hasDomainPanel && (
-            <section className="playbook-player__console-card playbook-player__params-card">
-              <div className="playbook-player__console-head">
-                <span>Params</span>
-                <small>{baseScript.domain}</small>
-              </div>
-              <div className="playbook-player__param-body">
-                <ParamPanelSlot
-                  domain={baseScript.domain}
-                  script={baseScript}
-                  overrides={overrides}
-                  onOverridesChange={setOverrides}
-                  isDark={theme === "dark"}
-                />
-              </div>
-            </section>
-          )}
-
-          {followupSlot && (
-            <section className="playbook-player__console-card playbook-player__follow-card">
-              <div className="playbook-player__console-head">
-                <span>Follow-up</span>
-                <small>current step</small>
-              </div>
-              <div className="playbook-player__follow-body">{followupSlot}</div>
-            </section>
-          )}
-
-          {relatedSlot ? (
-            <section className="playbook-player__related-card" aria-label="Related study context">
-              {relatedSlot}
-            </section>
-          ) : (
-            <section className="playbook-player__related-row" aria-label="Related study context">
-              <span>Related</span>
-              <strong>{script.algorithm_id ?? "Study variants"}</strong>
-              <small>›</small>
-            </section>
-          )}
-        </aside>
+        <PlaybookLearningConsole
+          showCodePanelSlot={showCodePanelSlot}
+          codeOverlay={codeOverlay}
+          theme={theme}
+          hasDomainPanel={hasDomainPanel}
+          baseScript={baseScript}
+          overrides={overrides}
+          onOverridesChange={setOverrides}
+          followupSlot={followupSlot}
+          relatedSlot={relatedSlot}
+          relatedAlgorithmId={script.algorithm_id}
+        />
       )}
 
       {showMobileConsole && mobileSheet && (

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayerIcons.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayerIcons.tsx
@@ -1,0 +1,78 @@
+export const SpeakerOnSVG = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+       stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
+    <path d="M15.54 8.46a5 5 0 0 1 0 7.07"/>
+    <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
+  </svg>
+);
+
+export const SpeakerOffSVG = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+       stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
+    <line x1="23" y1="9" x2="17" y2="15"/>
+    <line x1="17" y1="9" x2="23" y2="15"/>
+  </svg>
+);
+
+export const SettingsSVG = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+       stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="3"/>
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06
+             a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09
+             A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83
+             l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09
+             A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83
+             l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09
+             a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83
+             l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09
+             a1.65 1.65 0 0 0-1.51 1z"/>
+  </svg>
+);
+
+export const ExportSVG = () => (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none"
+       stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+       aria-hidden="true">
+    <path d="M12 3v12" />
+    <path d="m7 10 5 5 5-5" />
+    <path d="M5 21h14" />
+  </svg>
+);
+
+export const MoreSVG = () => (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none"
+       stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+       aria-hidden="true">
+    <circle cx="5" cy="12" r="1" />
+    <circle cx="12" cy="12" r="1" />
+    <circle cx="19" cy="12" r="1" />
+  </svg>
+);
+
+export function TopbarFoldIcon({ collapsed }: { collapsed: boolean }) {
+  return (
+    <svg
+      className="playbook-player__chrome-toggle-icon"
+      data-testid={
+        collapsed ? "topbar-toggle-icon-expand" : "topbar-toggle-icon-collapse"
+      }
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.55"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path className="playbook-player__chrome-toggle-bar" d="M7 7.5h10" />
+      {collapsed ? (
+        <path className="playbook-player__chrome-toggle-chevron" d="m7.5 11 4.5 4.5 4.5-4.5" />
+      ) : (
+        <path className="playbook-player__chrome-toggle-chevron" d="m7.5 14 4.5-4.5 4.5 4.5" />
+      )}
+    </svg>
+  );
+}

--- a/apps/web/src/features/playbook/engine/player/PlaybookPortraitShell.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPortraitShell.tsx
@@ -1,0 +1,228 @@
+import React from "react";
+
+import { CodeHighlightRenderer } from "../renderers/CodeHighlightRenderer";
+import type { ClippedCodeOverlay } from "./mobileCodeOverlay";
+
+export type MobileTabKey = "narration" | "code" | "params" | "followup" | "more";
+
+const MOBILE_TABS: Array<{ key: MobileTabKey; label: string }> = [
+  { key: "narration", label: "讲解" },
+  { key: "code", label: "代码" },
+  { key: "params", label: "参数" },
+  { key: "followup", label: "追问" },
+  { key: "more", label: "更多" },
+];
+
+interface MobileTabPanelProps {
+  activeTab: MobileTabKey;
+  currentNarration: string;
+  currentStepTitle: string;
+  safeStepIndex: number;
+  stepCount: number;
+  mobileCodeOverlay: ClippedCodeOverlay | null;
+  theme: "dark" | "light";
+  hasDomainPanel: boolean;
+  paramsContent: React.ReactNode;
+  onOpenSheet: (sheet: MobileTabKey) => void;
+}
+
+function MobileTabPanel({
+  activeTab,
+  currentNarration,
+  currentStepTitle,
+  safeStepIndex,
+  stepCount,
+  mobileCodeOverlay,
+  theme,
+  hasDomainPanel,
+  paramsContent,
+  onOpenSheet,
+}: MobileTabPanelProps) {
+  if (activeTab === "code") {
+    return (
+      <div className="playbook-player__mobile-panel playbook-player__mobile-code-panel">
+        {mobileCodeOverlay ? (
+          <>
+            <div className="playbook-player__mobile-panel-head">
+              <span>
+                Lines {mobileCodeOverlay.fromLine}-{mobileCodeOverlay.toLine} / {mobileCodeOverlay.totalLines}
+              </span>
+              <button type="button" onClick={() => onOpenSheet("code")}>
+                查看全部代码
+              </button>
+            </div>
+            <div className="playbook-player__mobile-code-snippet">
+              <CodeHighlightRenderer
+                overlay={mobileCodeOverlay.overlay}
+                theme={theme}
+                lineNumberOffset={mobileCodeOverlay.lineNumberOffset}
+              />
+            </div>
+          </>
+        ) : (
+          <div className="playbook-player__mobile-empty">当前步骤没有代码同步片段。</div>
+        )}
+      </div>
+    );
+  }
+
+  if (activeTab === "params") {
+    return (
+      <div className="playbook-player__mobile-panel">
+        {hasDomainPanel ? (
+          <div className="playbook-player__mobile-param-panel">{paramsContent}</div>
+        ) : (
+          <div className="playbook-player__mobile-empty">当前步骤没有可调参数。</div>
+        )}
+      </div>
+    );
+  }
+
+  if (activeTab === "followup") {
+    return (
+      <div className="playbook-player__mobile-panel">
+        <button
+          type="button"
+          className="playbook-player__mobile-open-sheet"
+          onClick={() => onOpenSheet("followup")}
+        >
+          打开追问面板
+        </button>
+      </div>
+    );
+  }
+
+  if (activeTab === "more") {
+    return (
+      <div className="playbook-player__mobile-panel">
+        <button
+          type="button"
+          className="playbook-player__mobile-open-sheet"
+          onClick={() => onOpenSheet("more")}
+        >
+          打开更多操作
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="playbook-player__mobile-panel playbook-player__mobile-narration">
+      <span>步骤 {safeStepIndex + 1} / {stepCount}</span>
+      <p>{currentNarration || currentStepTitle}</p>
+    </div>
+  );
+}
+
+interface PlaybookPortraitShellProps {
+  domain: string;
+  title: string;
+  currentStepTitle: string;
+  currentNarration: string;
+  safeStepIndex: number;
+  stepCount: number;
+  theme: "dark" | "light";
+  topbarAction?: React.ReactNode;
+  exportAction?: React.ReactNode;
+  moreAction?: React.ReactNode;
+  stageSlot: React.ReactNode;
+  controlsSlot: React.ReactNode;
+  showMobileConsole: boolean;
+  activeTab: MobileTabKey;
+  onSelectTab: (tab: MobileTabKey) => void;
+  onOpenSheet: (sheet: MobileTabKey) => void;
+  mobileCodeOverlay: ClippedCodeOverlay | null;
+  hasDomainPanel: boolean;
+  paramsContent: React.ReactNode;
+}
+
+export function PlaybookPortraitShell({
+  domain,
+  title,
+  currentStepTitle,
+  currentNarration,
+  safeStepIndex,
+  stepCount,
+  theme,
+  topbarAction,
+  exportAction,
+  moreAction,
+  stageSlot,
+  controlsSlot,
+  showMobileConsole,
+  activeTab,
+  onSelectTab,
+  onOpenSheet,
+  mobileCodeOverlay,
+  hasDomainPanel,
+  paramsContent,
+}: PlaybookPortraitShellProps) {
+  return (
+    <div className="playbook-player__workspace">
+      <header className="playbook-player__header">
+        <div className="playbook-player__brand">
+          <span className="playbook-player__brand-mark" aria-hidden="true" />
+          <span>MetaView</span>
+        </div>
+        <div className="playbook-player__lesson-title">
+          <span>{domain}</span>
+          <strong>{title}</strong>
+        </div>
+        <div className="playbook-player__header-actions">
+          {topbarAction}
+          {exportAction}
+          {moreAction}
+        </div>
+      </header>
+
+      <div className="playbook-player__mobile-step">
+        <span>步骤 {safeStepIndex + 1} / {stepCount}</span>
+        <strong>{currentStepTitle}</strong>
+      </div>
+
+      {stageSlot}
+      {controlsSlot}
+
+      <div className="playbook-player__caption playbook-player__caption--mobile">
+        <span aria-hidden="true" />
+        <p>{currentNarration || currentStepTitle}</p>
+      </div>
+
+      {showMobileConsole && (
+        <section className="playbook-player__mobile-console" aria-label="移动学习面板">
+          <div className="playbook-player__mobile-tabs" role="tablist" aria-label="移动学习面板">
+            {MOBILE_TABS.map((tab) => (
+              <button
+                key={tab.key}
+                type="button"
+                role="tab"
+                aria-selected={activeTab === tab.key}
+                className={activeTab === tab.key ? "is-active" : ""}
+                onClick={() => {
+                  onSelectTab(tab.key);
+                  if (tab.key === "followup" || tab.key === "more") {
+                    onOpenSheet(tab.key);
+                  }
+                }}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          <MobileTabPanel
+            activeTab={activeTab}
+            currentNarration={currentNarration}
+            currentStepTitle={currentStepTitle}
+            safeStepIndex={safeStepIndex}
+            stepCount={stepCount}
+            mobileCodeOverlay={mobileCodeOverlay}
+            theme={theme}
+            hasDomainPanel={hasDomainPanel}
+            paramsContent={paramsContent}
+            onOpenSheet={onOpenSheet}
+          />
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/playbook/engine/player/PlayerSettingsPopover.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlayerSettingsPopover.tsx
@@ -1,0 +1,265 @@
+import React, { useEffect, useRef, useState } from "react";
+
+import { AUTO_VOICE, OPENAI_VOICES } from "./useTTS";
+import type { TTSConfig } from "./useTTS";
+import { SpeakerOffSVG, SpeakerOnSVG } from "./PlaybookPlayerIcons";
+import { SPEED_STEPS } from "./playbackRates";
+
+interface PlayerSettingsPopoverProps {
+  playbackRate: number;
+  onPlaybackRateChange: (rate: number) => void;
+  stepThrough: boolean;
+  onStepThroughChange: (next: boolean) => void;
+  ttsEnabled: boolean;
+  ttsSupported: boolean;
+  onToggleTTS: () => void;
+  config: TTSConfig;
+  onUpdate: (patch: Partial<TTSConfig>) => void;
+  onClose: () => void;
+  isDark: boolean;
+  onPreview: (voice: string, sampleText: string) => void;
+}
+
+const SAMPLE_TEXT_DEFAULT = "你好，这是一段试听文字。Hello, this is a preview.";
+
+export const PlayerSettingsPopover: React.FC<PlayerSettingsPopoverProps> = ({
+  playbackRate,
+  onPlaybackRateChange,
+  stepThrough,
+  onStepThroughChange,
+  ttsEnabled,
+  ttsSupported,
+  onToggleTTS,
+  config,
+  onUpdate,
+  onClose,
+  isDark,
+  onPreview,
+}) => {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [sampleText, setSampleText] = useState(SAMPLE_TEXT_DEFAULT);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Element | null;
+      if (target?.closest(".playbook-player__settings-anchor")) return;
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [onClose]);
+
+  const bg = isDark ? "#161b22" : "#ffffff";
+  const border = isDark ? "#30363d" : "#d0d7de";
+  const text = isDark ? "#c9d1d9" : "#24292f";
+  const muted = isDark ? "#8b949e" : "#6e7781";
+  const inputBg = isDark ? "#0d1117" : "#f6f8fa";
+  const accent = isDark ? "#4de8b0" : "#00896e";
+
+  return (
+    <div
+      ref={popoverRef}
+      className="playbook-player__settings-popover"
+      style={{
+        "--player-settings-bg": bg,
+        "--player-settings-border": border,
+        "--player-settings-text": text,
+        "--player-settings-muted": muted,
+        "--player-settings-input": inputBg,
+        "--player-settings-accent": accent,
+      } as React.CSSProperties}
+    >
+      <div className="playbook-player__settings-section">
+        <div className="playbook-player__settings-label">播放速度</div>
+        <div className="playbook-player__settings-speed-row">
+          {SPEED_STEPS.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => onPlaybackRateChange(s)}
+              className={playbackRate === s ? "is-active" : ""}
+            >
+              {s}×
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="playbook-player__settings-section">
+        <div className="playbook-player__settings-row">
+          <span>播放模式</span>
+          <button
+            type="button"
+            className={`playbook-player__settings-toggle${stepThrough ? " is-active" : ""}`}
+            onClick={() => onStepThroughChange(!stepThrough)}
+          >
+            {stepThrough ? "步进" : "连播"}
+          </button>
+        </div>
+        <div className="playbook-player__settings-row">
+          <span>语音朗读</span>
+          <button
+            type="button"
+            className={`playbook-player__settings-toggle${ttsEnabled ? " is-active" : ""}`}
+            onClick={onToggleTTS}
+            disabled={!ttsSupported}
+          >
+            {ttsEnabled ? <SpeakerOnSVG /> : <SpeakerOffSVG />}
+            {ttsEnabled ? "开启" : "关闭"}
+          </button>
+        </div>
+      </div>
+
+      <div className="playbook-player__settings-section">
+        <div className="playbook-player__settings-label">语音后端</div>
+        <div className="playbook-player__settings-choice-row">
+          {(["system", "openai"] as const).map((b) => (
+            <button
+              key={b}
+              type="button"
+              onClick={() => onUpdate({ backend: b })}
+              className={config.backend === b ? "is-active" : ""}
+            >
+              {b === "system" ? "系统语音" : "OpenAI API"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* OpenAI backend now routes through the server-side proxy
+         (POST /api/v1/tts/speech) so the player never stores an API key.
+         The Base URL / Model / Key inputs that used to live here are gone
+         on purpose — issue #40. */}
+      {config.backend === "openai" && (
+        <div
+          className="playbook-player__settings-note"
+          style={{
+            border: `1px dashed ${border}`,
+          }}
+        >
+          通过服务端代理调用，API Key 由管理员在后端配置（METAVIEW_TTS_API_KEY）。
+        </div>
+      )}
+
+      {/* Voice picker (OpenAI only) */}
+      {config.backend === "openai" && (
+        <div>
+          <div className="playbook-player__settings-label">
+            音色 <span style={{ color: text }}>{config.voice === AUTO_VOICE ? "跟随学科" : config.voice}</span>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 4, maxHeight: 180, overflowY: "auto" }}>
+            <button
+              type="button"
+              onClick={() => onUpdate({ voice: AUTO_VOICE })}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                padding: "5px 8px",
+                borderRadius: 5,
+                border: `1px solid ${config.voice === AUTO_VOICE ? accent : border}`,
+                background: config.voice === AUTO_VOICE ? `${accent}18` : "transparent",
+                color: config.voice === AUTO_VOICE ? accent : text,
+                fontSize: 12,
+                cursor: "pointer",
+                textAlign: "left",
+              }}
+            >
+              <span>跟随学科自动推荐</span>
+            </button>
+            {OPENAI_VOICES.map((v) => (
+              <div
+                key={v.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "4px 8px",
+                  borderRadius: 5,
+                  border: `1px solid ${config.voice === v.id ? accent : border}`,
+                  background: config.voice === v.id ? `${accent}18` : "transparent",
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={() => onUpdate({ voice: v.id })}
+                  style={{
+                    flex: 1,
+                    background: "transparent",
+                    border: "none",
+                    color: config.voice === v.id ? accent : text,
+                    fontSize: 12,
+                    fontWeight: config.voice === v.id ? 600 : 400,
+                    textAlign: "left",
+                    cursor: "pointer",
+                    padding: 0,
+                  }}
+                  title={v.description}
+                >
+                  {v.label}
+                  <span style={{ color: muted, fontWeight: 400, marginLeft: 6 }}>{v.description}</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onPreview(v.id, sampleText)}
+                  style={{
+                    background: "transparent",
+                    border: `1px solid ${border}`,
+                    borderRadius: 4,
+                    color: muted,
+                    fontSize: 11,
+                    padding: "2px 6px",
+                    cursor: "pointer",
+                  }}
+                >
+                  ⏵ 试听
+                </button>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 6 }}>
+            <div style={{ fontSize: 11, color: muted, marginBottom: 3 }}>试听文字</div>
+            <input
+              type="text"
+              value={sampleText}
+              onChange={(e) => setSampleText(e.target.value)}
+              placeholder={SAMPLE_TEXT_DEFAULT}
+              style={{
+                width: "100%",
+                padding: "5px 8px",
+                background: inputBg,
+                border: `1px solid ${border}`,
+                borderRadius: 5,
+                color: text,
+                fontSize: 12,
+                outline: "none",
+                boxSizing: "border-box",
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="playbook-player__settings-section">
+        <div className="playbook-player__settings-label">
+          语速 <span style={{ color: text }}>{config.rate.toFixed(1)}×</span>
+        </div>
+        <input
+          type="range"
+          min="0.5"
+          max="2.0"
+          step="0.1"
+          value={config.rate}
+          onChange={(e) => onUpdate({ rate: parseFloat(e.target.value) })}
+          className="playbook-player__settings-range"
+        />
+      </div>
+
+      <div className="playbook-player__settings-footnote">
+        设置存储在本地浏览器中
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/features/playbook/engine/player/mobileCodeOverlay.ts
+++ b/apps/web/src/features/playbook/engine/player/mobileCodeOverlay.ts
@@ -1,0 +1,43 @@
+import type { CodeHighlightOverlay } from "../types";
+
+const CODE_CONTEXT_LINES = 2;
+
+export interface ClippedCodeOverlay {
+  overlay: CodeHighlightOverlay;
+  lineNumberOffset: number;
+  fromLine: number;
+  toLine: number;
+  totalLines: number;
+}
+
+export function clipCodeOverlay(
+  overlay: CodeHighlightOverlay | null,
+  contextLines = CODE_CONTEXT_LINES,
+): ClippedCodeOverlay | null {
+  if (!overlay || overlay.lines.length === 0) return null;
+  const anchor = Math.max(
+    0,
+    Math.min(
+      overlay.lines.length - 1,
+      overlay.active_line >= 0 ? overlay.active_line : overlay.active_lines[0] ?? 0,
+    ),
+  );
+  const from = Math.max(0, anchor - contextLines);
+  const to = Math.min(overlay.lines.length - 1, anchor + contextLines);
+  const activeLines = overlay.active_lines
+    .filter((line) => line >= from && line <= to)
+    .map((line) => line - from);
+
+  return {
+    overlay: {
+      ...overlay,
+      lines: overlay.lines.slice(from, to + 1),
+      active_line: anchor - from,
+      active_lines: activeLines.length ? activeLines : [anchor - from],
+    },
+    lineNumberOffset: from,
+    fromLine: from + 1,
+    toLine: to + 1,
+    totalLines: overlay.lines.length,
+  };
+}

--- a/apps/web/src/features/playbook/engine/player/playbackRates.ts
+++ b/apps/web/src/features/playbook/engine/player/playbackRates.ts
@@ -1,0 +1,1 @@
+export const SPEED_STEPS = [0.5, 0.75, 1, 1.25, 1.5, 2];

--- a/apps/web/src/styles/mobileWebSmoke.test.tsx
+++ b/apps/web/src/styles/mobileWebSmoke.test.tsx
@@ -43,6 +43,10 @@ vi.mock("../features/playbook/engine/player/useTTS", () => ({
   }),
 }));
 
+function readTextForCssContract(filePath: string): string {
+  return fs.readFileSync(filePath, "utf8").replace(/\r\n/g, "\n");
+}
+
 const phoneViewports = [
   { width: 375, height: 667, label: "iPhone SE" },
   { width: 390, height: 844, label: "iPhone 14" },
@@ -154,16 +158,14 @@ describe("mobile web smoke", () => {
 
   it("keeps mobile shell, safe-area, reduced-motion, and overflow CSS contracts", () => {
     const webRoot = path.resolve(__dirname, "..", "..");
-    const html = fs.readFileSync(path.join(webRoot, "index.html"), "utf8");
-    const globalCss = fs.readFileSync(path.join(webRoot, "src/styles/global.css"), "utf8");
-    const layoutCss = fs.readFileSync(path.join(webRoot, "src/styles/layout.css"), "utf8");
-    const playbookCss = fs.readFileSync(
+    const html = readTextForCssContract(path.join(webRoot, "index.html"));
+    const globalCss = readTextForCssContract(path.join(webRoot, "src/styles/global.css"));
+    const layoutCss = readTextForCssContract(path.join(webRoot, "src/styles/layout.css"));
+    const playbookCss = readTextForCssContract(
       path.join(webRoot, "src/styles/pages/playbook.css"),
-      "utf8",
     );
-    const studioCss = fs.readFileSync(
+    const studioCss = readTextForCssContract(
       path.join(webRoot, "src/styles/pages/studio.css"),
-      "utf8",
     );
 
     expect(html).toContain("viewport-fit=cover");


### PR DESCRIPTION
## Summary

- Add `args_schema` to the Animation Tool Registry and expose it through the agent animation-tools list endpoint and Node bridge.
- Preserve the existing `/expand` request shape while improving tool metadata for agent callers.
- Add a deterministic golden fixture for a function-graph generation path without calling external models.
- Split PlaybookPlayer mobile/chrome UI into smaller components while keeping playback, TTS, Remotion, controller, PlaybookScript, CSS class names, and desktop layout behavior intact.

## Why

The agent previously received only tool names and descriptions, so it had to infer tool arguments. Returning JSON schemas makes tool calls less guessy and keeps common animations on the registry path. PlaybookPlayer had also accumulated desktop, portrait, tabs, sheet, TTS, settings, and Remotion logic in one file, making follow-up mobile work risky.

## Validation

Equivalent `make check` commands were run manually because `make` is not installed in this Windows environment:

- `npm --workspace apps/web run lint`
- `npm --workspace apps/agent run lint`
- `.\\.venv\\Scripts\\ruff.exe check apps/api/app apps/api/tests`
- `.\\.venv\\Scripts\\python.exe -m pytest apps/api/tests -q`
- `npm --workspace apps/web run test`
- `npm --workspace apps/agent run test`
- `npm --workspace apps/web run build`
- `npm --workspace apps/agent run build`

`git fetch origin` and `git merge origin/main` were also run before push; the branch was already up to date.

## Notes

Remaining warnings are pre-existing: web lint reports fast-refresh warnings in `AlgorithmParamPanel.tsx`, and the web build reports the existing Vite large chunk warning.