### PR TITLE
feat: add shared lesson plan contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,28 @@ MetaView v2 是一个面向教育场景的 AI 可视化讲解平台。它不是�
 
 ```text
 User input
-  -> subject understanding / router / SkillPack / agent
+  -> subject understanding / router
+  -> LessonPlan
+  -> SkillPack / agent / legacy CIR
   -> PlaybookScript
   -> DirectorScript
   -> RenderPlan
   -> Remotion preview / export
 ```
 
-- `PlaybookScript` 是内容契约：负责教学步骤、snapshot、公式、画面对象、旁白、代码高亮和可渲染场景数据。
+- `LessonPlan` 是教学决策契约：负责学习目标、误区、结论、教学弧线与 SceneIntent，不包含 renderer 私有数据。
+- `PlaybookScript` 是内容渲染契约：负责教学步骤、snapshot、公式、画面对象、旁白、代码高亮和可渲染场景数据。
 - `DirectorScript` 是导演契约：负责镜头意图、shot type、camera motion、pacing、focus target、emphasis terms 和观看节奏。
 - `RenderPlan` 是渲染适配层：把 DirectorScript 转换为 Remotion 可消费的 scale、translate、opacity、timing 等参数。
 - Remotion 是唯一视频预览/导出出口。
 
 生成路径当前有两条：
 
-1. `single mode`: **LLM -> CIR + ExecutionMap -> PlaybookScript -> DirectorScript**
-2. `agent mode`: **Agent tool loop -> self-check -> PlaybookScript -> DirectorScript**
+1. `single mode`: **LessonPlan -> LLM -> CIR + ExecutionMap -> PlaybookScript -> DirectorScript**
+2. `agent mode`: **LessonPlan -> Agent tool loop -> self-check -> PlaybookScript -> DirectorScript**
+
+确定性 SkillPack 同样通过 `SkillExecutionContext` 接收这份 LessonPlan。运行历史会独立
+保存计划、PlaybookScript 和 QualityReport；LessonPlan 不会被塞入最终视频契约。
 
 项目仍不引入 Manim、HTML iframe 或服务端 HTML 视频渲染。管线契约见 [`docs/pipeline.md`](docs/pipeline.md)，Director 契约见 [`docs/director-layer.md`](docs/director-layer.md)。
 
@@ -123,7 +129,7 @@ Agent demo 验收见 [`docs/agent-demo-acceptance.md`](docs/agent-demo-acceptanc
 |--------|------|------|
 | `POST` | `/api/v1/pipeline` | 提交题目，返回 `run_id` |
 | `GET` | `/api/v1/runs` | 运行历史列表 |
-| `GET` | `/api/v1/runs/{run_id}` | 单次运行结果，含 PlaybookScript、DirectorScript 与原始 `prompt` |
+| `GET` | `/api/v1/runs/{run_id}` | 单次运行结果，含 LessonPlan、PlaybookScript、DirectorScript 与原始 `prompt` |
 | `POST` | `/api/v1/exports` | 创建视频导出任务 |
 | `GET` | `/api/v1/exports/{job_id}` | 查询导出任务状态 |
 | `GET` | `/health` | 健康检查 |
@@ -218,6 +224,7 @@ Director 相关字段不要塞回 Playbook step；DirectorScript 是独立契约
 - [`docs/director-layer.md`](docs/director-layer.md) - Director 独立导演层契约
 - [`docs/README.md`](docs/README.md) - 开发文档索引
 - [`docs/pipeline.md`](docs/pipeline.md) - 生成、PlaybookScript、DirectorScript 挂载点和导出管线
+- [`docs/lesson-plan.md`](docs/lesson-plan.md) - 教学规划契约、三路径接线、持久化与边界
 - [`docs/frontend-shell.md`](docs/frontend-shell.md) - Stage 路由、GlobalTopbar、Studio 布局、Provider 配置
 - [`docs/remotion-skills.md`](docs/remotion-skills.md) - Remotion 组件、渲染器、注册表约定
 - [`docs/topic-routing.md`](docs/topic-routing.md) - 学科路由策略

--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -34,6 +34,7 @@ export interface GenerateOptions {
   language?: string | null;
   provider?: ProviderConfig;
   routeDecision?: Record<string, unknown>;
+  lessonPlan?: Record<string, unknown>;
   playbookSchema?: Record<string, unknown>;
   constraints?: Record<string, unknown>;
   availableTools?: Array<Record<string, unknown>>;
@@ -48,6 +49,13 @@ export interface GenerateOptions {
 export const SYSTEM_PROMPT =
   `You are MetaView's educational visual designer. You build a
 step-by-step playbook by calling drawing tools.
+
+When the user prompt contains a \`[MetaView LessonPlan]\`, it is a BINDING,
+read-only teaching contract. Derive \`plan_outline\` from its SceneIntents in
+order, expanding one intent into multiple steps when needed to reach 8-14
+steps. Every required fact, visual role, preferred scene type, narration goal,
+and expected conclusion must be covered. Do not replace the plan with a new
+teaching arc, and do not copy LessonPlan fields into the final PlaybookScript.
 
 Workflow you MUST follow:
 
@@ -108,7 +116,11 @@ const MAX_SELF_REPAIR_ATTEMPTS = 2;
 export async function runAgentGeneration(
   opts: GenerateOptions,
 ): Promise<PlaybookOutput> {
-  let userPrompt = buildAgentPrompt(opts.prompt, opts.routeDecision);
+  let userPrompt = buildAgentPrompt(
+    opts.prompt,
+    opts.routeDecision,
+    opts.lessonPlan,
+  );
   let lastReport: SelfCheckReport | null = null;
 
   for (let attempt = 0; attempt <= MAX_SELF_REPAIR_ATTEMPTS; attempt++) {
@@ -124,6 +136,7 @@ export async function runAgentGeneration(
     userPrompt = buildAgentSelfRepairPrompt({
       originalPrompt: opts.prompt,
       routeDecision: opts.routeDecision,
+      lessonPlan: opts.lessonPlan,
       previousPlaybook: playbook,
       report,
       repairAttempt: attempt + 1,
@@ -266,23 +279,33 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function buildAgentPrompt(
+export function buildAgentPrompt(
   prompt: string,
   routeDecision?: Record<string, unknown>,
+  lessonPlan?: Record<string, unknown>,
 ): string {
-  if (!routeDecision) {
+  if (!routeDecision && !lessonPlan) {
     return prompt;
   }
-  return `[MetaView route decision]
-${JSON.stringify(routeDecision, null, 2)}
-
-[user prompt]
-${prompt}`;
+  const sections: string[] = [];
+  if (lessonPlan) {
+    sections.push(
+      `[MetaView LessonPlan]\nBINDING read-only teaching contract: preserve SceneIntent order and cover every required fact, visual role, narration goal, and expected conclusion. Expand intents into 8-14 Playbook steps; do not emit LessonPlan inside PlaybookScript.\n${JSON.stringify(lessonPlan, null, 2)}`,
+    );
+  }
+  if (routeDecision) {
+    sections.push(
+      `[MetaView route decision]\n${JSON.stringify(routeDecision, null, 2)}`,
+    );
+  }
+  sections.push(`[user prompt]\n${prompt}`);
+  return sections.join("\n\n");
 }
 
 interface SelfRepairPromptInput {
   originalPrompt: string;
   routeDecision?: Record<string, unknown>;
+  lessonPlan?: Record<string, unknown>;
   previousPlaybook: PlaybookOutput;
   report: SelfCheckReport;
   repairAttempt: number;
@@ -297,10 +320,12 @@ export function buildAgentSelfRepairPrompt(
     max_self_repair_attempts: MAX_SELF_REPAIR_ATTEMPTS,
     original_prompt: input.originalPrompt,
     route_decision: input.routeDecision ?? null,
+    lesson_plan: input.lessonPlan ?? null,
     previous_playbook: input.previousPlaybook,
     self_check: input.report,
     instructions: [
       "Repair by building a complete PlaybookScript through the Drawing CLI tools.",
+      "Treat lesson_plan as binding: preserve SceneIntent order and cover every required fact, visual role, narration goal, and expected conclusion.",
       "Keep PlaybookScript as the only rendering exit.",
       "Do not introduce raw HTML, iframe, Manim, or server video rendering.",
       "Use only renderer-supported snapshot kinds.",

--- a/apps/agent/src/server.ts
+++ b/apps/agent/src/server.ts
@@ -2,7 +2,8 @@
  * HTTP entry point for the MetaView agent sidecar.
  *
  * Exposes ``POST /generate`` with either the legacy body
- * ``{ prompt, provider?, route_decision? }`` or the wider AgentRequest shape,
+ * ``{ prompt, provider?, route_decision?, lesson_plan? }`` or the wider
+ * AgentRequest shape,
  * then returns ``{ playbook: PlaybookScript, provider, tool_events,
  * runtime_events }`` once the pi-agent-core loop has walked the Drawing CLI
  * flow. Health probe at ``GET /healthz``.
@@ -55,6 +56,7 @@ app.post("/generate", async (req: Request, res: Response) => {
     provider,
     provider_config,
     route_decision,
+    lesson_plan,
     playbook_schema,
     constraints,
     available_tools,
@@ -66,6 +68,7 @@ app.post("/generate", async (req: Request, res: Response) => {
     provider?: { provider?: string; model?: string; api_key?: string; base_url?: string };
     provider_config?: { provider?: string; model?: string; api_key?: string; base_url?: string };
     route_decision?: Record<string, unknown>;
+    lesson_plan?: Record<string, unknown>;
     playbook_schema?: Record<string, unknown>;
     constraints?: Record<string, unknown>;
     available_tools?: Array<Record<string, unknown>>;
@@ -89,6 +92,7 @@ app.post("/generate", async (req: Request, res: Response) => {
         language,
         provider: provider ?? provider_config,
         routeDecision: route_decision,
+        lessonPlan: lesson_plan,
         playbookSchema: playbook_schema,
         constraints,
         availableTools: available_tools,

--- a/apps/agent/test/agentPrompt.test.ts
+++ b/apps/agent/test/agentPrompt.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { SYSTEM_PROMPT, buildAgentSelfRepairPrompt } from "../src/agent.js";
+import {
+  SYSTEM_PROMPT,
+  buildAgentPrompt,
+  buildAgentSelfRepairPrompt,
+} from "../src/agent.js";
 import type { PlaybookOutput } from "../src/state/types.js";
 
 function fallbackPlaybook(): PlaybookOutput {
@@ -43,8 +47,49 @@ function fallbackPlaybook(): PlaybookOutput {
   };
 }
 
+function lessonPlan(): Record<string, unknown> {
+  return {
+    schema_version: "1.0.0",
+    domain: "geography",
+    title: "LESSON_PLAN_ONLY_MARKER",
+    learning_objectives: ["Explain the monsoon mechanism."],
+    prerequisites: ["Know that land and ocean heat at different rates."],
+    misconceptions: ["The wind direction never changes by season."],
+    expected_conclusion: "Seasonal pressure differences drive the monsoon.",
+    lesson_arc: "state_transition",
+    scenes: [
+      {
+        scene_id: "monsoon_mechanism",
+        teaching_goal: "Connect thermal contrast to pressure and wind.",
+        strategy: "state_transition",
+        required_fact_ids: ["land_ocean_heating"],
+        required_visual_roles: ["land", "ocean", "flow"],
+        preferred_scene_type: "east_asia_monsoon",
+        narration_goal: "Explain the causal sequence without renderer details.",
+      },
+    ],
+  };
+}
+
 describe("agent prompt contracts", () => {
+  it("hands the LessonPlan to the initial prompt as read-only context", () => {
+    const prompt = buildAgentPrompt(
+      "讲解东亚季风",
+      { destination: "agent", domain: "geography" },
+      lessonPlan(),
+    );
+
+    expect(prompt).toContain("[MetaView LessonPlan]");
+    expect(prompt).toContain("BINDING read-only teaching contract");
+    expect(prompt).toContain("cover every required fact");
+    expect(prompt).toContain("LESSON_PLAN_ONLY_MARKER");
+    expect(prompt).toContain("[MetaView route decision]");
+    expect(prompt).toContain("[user prompt]");
+  });
+
   it("steers subject visual scenes through SceneBlueprint and semantic renderer paths", () => {
+    expect(SYSTEM_PROMPT).toContain("BINDING");
+    expect(SYSTEM_PROMPT).toMatch(/SceneIntents in\s+order/);
     expect(SYSTEM_PROMPT).toContain("SceneBlueprint");
     expect(SYSTEM_PROMPT).toContain("scene_blueprint.compile");
     expect(SYSTEM_PROMPT).toContain("SkillPack runtime tool");
@@ -60,6 +105,7 @@ describe("agent prompt contracts", () => {
   it("gives specific repair guidance for subject visual array fallbacks", () => {
     const prompt = buildAgentSelfRepairPrompt({
       originalPrompt: "讲解东亚夏季风的海陆热力差异",
+      lessonPlan: lessonPlan(),
       previousPlaybook: fallbackPlaybook(),
       repairAttempt: 1,
       report: {
@@ -78,6 +124,9 @@ describe("agent prompt contracts", () => {
     });
 
     expect(prompt).toContain("snapshot.domain_fallback");
+    expect(prompt).toContain("LESSON_PLAN_ONLY_MARKER");
+    expect(prompt).toContain('"lesson_plan"');
+    expect(prompt).toContain("Treat lesson_plan as binding");
     expect(prompt).toContain("matching SkillPack runtime tool");
     expect(prompt).toContain("SceneBlueprint");
     expect(prompt).toContain("geo_map_scene");

--- a/apps/agent/test/agentRuntimeToolAdoption.test.ts
+++ b/apps/agent/test/agentRuntimeToolAdoption.test.ts
@@ -158,6 +158,10 @@ describe("agent runtime SceneBlueprint adoption", () => {
 
     const result = await runAgentGeneration({
       prompt: "讲解东亚夏季风的海陆热力差异",
+      lessonPlan: {
+        schema_version: "1.0.0",
+        title: "LESSON_PLAN_ONLY_MARKER",
+      },
       apiBaseUrl: "http://api.test",
       agentSharedToken: "secret",
       defaultProvider: "openai",
@@ -177,6 +181,8 @@ describe("agent runtime SceneBlueprint adoption", () => {
     );
     expect(result).toEqual(playbook);
     expect(result.steps[0].snapshot.kind).toBe("geo_map_scene");
+    expect(agentMock.prompts[0]).toContain("LESSON_PLAN_ONLY_MARKER");
+    expect(JSON.stringify(result)).not.toContain("LESSON_PLAN_ONLY_MARKER");
     expect(JSON.stringify(result)).not.toContain("algorithm_array");
   });
 

--- a/apps/api/app/application/agent/pipeline.py
+++ b/apps/api/app/application/agent/pipeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 
 from app.application.dto.pipeline_dto import PipelineRequest
+from app.domain.models.lesson_plan import LessonPlan
 from app.domain.skills.base import SkillRouteMatch
 
 
@@ -19,29 +20,38 @@ class AgentPipeline:
         *,
         route_request: Callable[[PipelineRequest], Awaitable[SkillRouteMatch | None]],
         try_execute_skill: Callable[
-            [str, PipelineRequest, SkillRouteMatch],
+            [str, PipelineRequest, SkillRouteMatch, LessonPlan],
             Awaitable[bool],
         ],
         fail_skill_consistency: Callable[[str, SkillRouteMatch, str], Awaitable[None]],
         build_route_context: Callable[[PipelineRequest, SkillRouteMatch | None], object],
-        execute_agent: Callable[[str, PipelineRequest, object], Awaitable[None]],
+        prepare_lesson_plan: Callable[
+            [str, PipelineRequest, object], Awaitable[LessonPlan]
+        ],
+        execute_agent: Callable[
+            [str, PipelineRequest, object, LessonPlan], Awaitable[None]
+        ],
     ) -> None:
         self._route_request = route_request
         self._try_execute_skill = try_execute_skill
         self._fail_skill_consistency = fail_skill_consistency
         self._build_route_context = build_route_context
+        self._prepare_lesson_plan = prepare_lesson_plan
         self._execute_agent = execute_agent
 
     async def execute(self, run_id: str, request: PipelineRequest) -> None:
         route_match = await self._route_request(request)
+        route_context = self._build_route_context(request, route_match)
+        lesson_plan = await self._prepare_lesson_plan(run_id, request, route_context)
         if route_match is not None:
             try:
-                handled = await self._try_execute_skill(run_id, request, route_match)
+                handled = await self._try_execute_skill(
+                    run_id, request, route_match, lesson_plan
+                )
             except AssertionError as exc:
                 await self._fail_skill_consistency(run_id, route_match, str(exc))
                 return
             if handled:
                 return
 
-        route_context = self._build_route_context(request, route_match)
-        await self._execute_agent(run_id, request, route_context)
+        await self._execute_agent(run_id, request, route_context, lesson_plan)

--- a/apps/api/app/application/agent/types.py
+++ b/apps/api/app/application/agent/types.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from app.domain.models.lesson_plan import LessonPlan
+
 
 class AgentConstraints(BaseModel):
     max_self_repair_attempts: int = 2
@@ -44,6 +46,7 @@ class AgentRequest(BaseModel):
     source_code: str | None = None
     language: str | None = None
     route_decision: dict[str, Any] = Field(default_factory=dict)
+    lesson_plan: LessonPlan | None = None
     provider_config: dict[str, Any] | None = None
     playbook_schema: dict[str, Any] = Field(default_factory=dict)
     constraints: AgentConstraints = Field(default_factory=AgentConstraints)

--- a/apps/api/app/application/dto/pipeline_dto.py
+++ b/apps/api/app/application/dto/pipeline_dto.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pydantic import BaseModel, Field, field_validator
 
 from app.domain.models.director import DirectorScript
+from app.domain.models.lesson_plan import LessonPlan
 from app.domain.models.pipeline_run import PipelineRunStatus
 from app.domain.models.playbook import PlaybookScript
 from app.domain.models.quality_report import QualityReport
@@ -75,3 +76,4 @@ class PipelineRunResponse(BaseModel):
     created_at: str
     review: CirReviewReport | PlaybookReviewVerdict | None = None
     quality_report: QualityReport | None = None
+    lesson_plan: LessonPlan | None = None

--- a/apps/api/app/application/ports/lesson_planner.py
+++ b/apps/api/app/application/ports/lesson_planner.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.domain.models.lesson_plan import LessonPlan
+from app.domain.models.route_decision import RouteDecision
+
+
+class ILessonPlanner(Protocol):
+    async def plan(
+        self,
+        *,
+        prompt: str,
+        domain: str | None = None,
+        title: str | None = None,
+        route_decision: RouteDecision | None = None,
+        source_code: str | None = None,
+        language: str | None = None,
+    ) -> LessonPlan: ...

--- a/apps/api/app/application/ports/run_repository.py
+++ b/apps/api/app/application/ports/run_repository.py
@@ -36,6 +36,8 @@ class IRunRepository(Protocol):
 
     async def update_quality_report(self, run_id: str, quality_report_json: str) -> None: ...
 
+    async def update_lesson_plan(self, run_id: str, lesson_plan_json: str) -> None: ...
+
     async def list(
         self,
         limit: int = 50,

--- a/apps/api/app/application/services/__init__.py
+++ b/apps/api/app/application/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application-level services that orchestrate domain contracts through ports."""

--- a/apps/api/app/application/services/lesson_planner.py
+++ b/apps/api/app/application/services/lesson_planner.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass
+
+from pydantic import ValidationError
+
+from app.application.ports.lesson_planner import ILessonPlanner
+from app.application.ports.llm_provider import ILLMProvider
+from app.domain.models.lesson_plan import LessonPlan, SceneIntent
+from app.domain.models.route_decision import RouteDecision
+from app.domain.models.topic import TopicDomain
+from app.domain.services.domain_router import route_topic
+
+
+@dataclass(frozen=True)
+class _DomainTemplate:
+    arc: str
+    prerequisite: str
+    misconception: str
+    primary_role: str
+    process_role: str
+
+
+@dataclass(frozen=True)
+class _CapabilityTemplate:
+    scene_type: str
+    terms: tuple[str, ...]
+    fact_ids: tuple[str, ...]
+    visual_roles: tuple[str, ...]
+    expected_conclusion: str
+    misconception: str
+
+
+_DOMAIN_TEMPLATES: dict[str, _DomainTemplate] = {
+    TopicDomain.ALGORITHM.value: _DomainTemplate(
+        arc="state_transition",
+        prerequisite="理解基本数据结构和按步骤执行的含义。",
+        misconception="算法步骤只描述结果，不需要展示中间状态。",
+        primary_role="data_structure",
+        process_role="algorithm_state_transition",
+    ),
+    TopicDomain.CODE.value: _DomainTemplate(
+        arc="state_transition",
+        prerequisite="能识别函数、变量和控制流。",
+        misconception="只读代码文本就能完整理解运行时状态。",
+        primary_role="code_structure",
+        process_role="runtime_state_transition",
+    ),
+    TopicDomain.MATH.value: _DomainTemplate(
+        arc="intuition_to_abstraction",
+        prerequisite="掌握题目涉及的基础符号和运算。",
+        misconception="记住公式就等于理解公式对应的几何或数量关系。",
+        primary_role="concrete_math_example",
+        process_role="math_relation",
+    ),
+    TopicDomain.PHYSICS.value: _DomainTemplate(
+        arc="problem_to_solution",
+        prerequisite="能区分物理量、方向和单位。",
+        misconception="公式中的各个量可以脱离受力或运动情境直接代入。",
+        primary_role="physical_phenomenon",
+        process_role="mechanism_or_vector_relation",
+    ),
+    TopicDomain.CHEMISTRY.value: _DomainTemplate(
+        arc="state_transition",
+        prerequisite="能识别基本物质、粒子或反应式。",
+        misconception="化学变化只是符号替换，不需要检查粒子和守恒关系。",
+        primary_role="chemical_structure_or_reactant",
+        process_role="reaction_transition",
+    ),
+    TopicDomain.BIOLOGY.value: _DomainTemplate(
+        arc="state_transition",
+        prerequisite="能区分生物结构、功能和过程。",
+        misconception="结构名称本身就足以解释其功能和过程。",
+        primary_role="biological_structure",
+        process_role="biological_process",
+    ),
+    TopicDomain.GEOGRAPHY.value: _DomainTemplate(
+        arc="comparison",
+        prerequisite="能识别基本空间位置和时间尺度。",
+        misconception="地理现象只有单一成因，且在所有区域和时间都相同。",
+        primary_role="spatial_context",
+        process_role="cause_effect_comparison",
+    ),
+    "general": _DomainTemplate(
+        arc="problem_to_solution",
+        prerequisite="理解题目中的基本术语。",
+        misconception="只给结论而不展示证据和推理过程也算完整解释。",
+        primary_role="concept_context",
+        process_role="evidence_relation",
+    ),
+}
+
+_CAPABILITY_TEMPLATES: tuple[_CapabilityTemplate, ...] = (
+    _CapabilityTemplate(
+        scene_type="bfs_graph",
+        terms=("bfs", "广度优先"),
+        fact_ids=("breadth_first", "queue", "visited", "order"),
+        visual_roles=("node", "edge", "current_node", "visited", "queue"),
+        expected_conclusion=(
+            "BFS 使用先进先出的队列逐层访问图节点：每次处理队首节点，"
+            "再把尚未访问的相邻节点加入队尾。"
+        ),
+        misconception="把 BFS 当成沿单一路径深入的 DFS，或忽略 visited 而重复入队。",
+    ),
+    _CapabilityTemplate(
+        scene_type="recursion_stack",
+        terms=("递归", "factorial", "调用栈"),
+        fact_ids=(
+            "factorial",
+            "base_case",
+            "recursive_call",
+            "return_unwind",
+            "factorial_result",
+        ),
+        visual_roles=("stack_frame", "active_frame", "code_line", "return_value"),
+        expected_conclusion=(
+            "factorial 通过递归建立等待相乘的栈帧，基例停止继续调用，"
+            "返回值随后沿调用栈逐层回溯并完成乘法。"
+        ),
+        misconception="把压栈顺序与回溯返回顺序混为一谈，或忽略终止递归所需的基例。",
+    ),
+    _CapabilityTemplate(
+        scene_type="derivative_tangent",
+        terms=("导数", "切线", "derivative", "tangent"),
+        fact_ids=("derivative", "tangent", "slope"),
+        visual_roles=("curve", "target_point", "secant", "tangent", "slope"),
+        expected_conclusion=(
+            "当割线的第二点趋近目标点时，割线斜率趋近该点的导数；"
+            "这个极限也就是曲线在该点的切线斜率。"
+        ),
+        misconception="把任意一条割线斜率直接当成导数，或只记公式而不能对应到切线。",
+    ),
+    _CapabilityTemplate(
+        scene_type="projectile_motion",
+        terms=("平抛", "抛体", "projectile"),
+        fact_ids=("horizontal_velocity", "vertical_velocity", "gravity", "parabolic"),
+        visual_roles=(
+            "object",
+            "trajectory",
+            "horizontal_velocity",
+            "vertical_velocity",
+            "gravity",
+        ),
+        expected_conclusion=(
+            "平抛运动的水平速度保持不变，竖直方向具有由重力产生的加速度，"
+            "因此重力使物体竖直加速、竖直速度不断改变，"
+            "两个分运动合成抛物线轨迹。"
+        ),
+        misconception="认为重力会改变水平速度，或把竖直加速度恒定误解为竖直速度不变。",
+    ),
+)
+
+_OTHER_CAPABILITY_SCENES: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("二分", "binary search"), "binary_search"),
+    (("东亚季风", "east asia monsoon"), "east_asia_monsoon"),
+    (("dna复制", "dna replication"), "dna_replication"),
+    (("细胞结构", "cell structure"), "cell_structure"),
+)
+
+
+class LessonPlanningError(RuntimeError):
+    """Raised when an assisted planner cannot produce a valid LessonPlan."""
+
+
+class RuleBasedLessonPlanner:
+    async def plan(
+        self,
+        *,
+        prompt: str,
+        domain: str | None = None,
+        title: str | None = None,
+        route_decision: RouteDecision | None = None,
+        source_code: str | None = None,
+        language: str | None = None,
+    ) -> LessonPlan:
+        return build_rule_based_lesson_plan(
+            prompt=prompt,
+            domain=domain,
+            title=title,
+            route_decision=route_decision,
+            source_code=source_code,
+            language=language,
+        )
+
+
+class LLMAssistedLessonPlanner:
+    def __init__(
+        self,
+        llm: ILLMProvider,
+        *,
+        base_planner: ILessonPlanner | None = None,
+    ) -> None:
+        self._llm = llm
+        self._base_planner = base_planner or RuleBasedLessonPlanner()
+
+    async def plan(
+        self,
+        *,
+        prompt: str,
+        domain: str | None = None,
+        title: str | None = None,
+        route_decision: RouteDecision | None = None,
+        source_code: str | None = None,
+        language: str | None = None,
+    ) -> LessonPlan:
+        draft = await self._base_planner.plan(
+            prompt=prompt,
+            domain=domain,
+            title=title,
+            route_decision=route_decision,
+            source_code=source_code,
+            language=language,
+        )
+        system, user = _lesson_planner_prompt(prompt, draft)
+        try:
+            raw = await self._llm.complete(system, user)
+            candidate = LessonPlan.model_validate_json(_strip_markdown_fences(raw))
+        except (ValidationError, ValueError, TypeError) as exc:
+            raise LessonPlanningError(
+                "LLM-assisted lesson planning returned invalid JSON."
+            ) from exc
+        if candidate.domain != draft.domain:
+            raise LessonPlanningError(
+                "LLM-assisted lesson planning changed the resolved lesson domain."
+            )
+        return candidate
+
+
+def build_rule_based_lesson_plan(
+    *,
+    prompt: str,
+    domain: str | None = None,
+    title: str | None = None,
+    route_decision: RouteDecision | None = None,
+    source_code: str | None = None,
+    language: str | None = None,
+) -> LessonPlan:
+    del language
+    topic = _lesson_title(title or prompt)
+    resolved_domain = _resolve_domain(prompt, domain)
+    template = _DOMAIN_TEMPLATES[resolved_domain]
+    capability = _capability_template(prompt, route_decision=route_decision)
+    preferred_scene_type = (
+        capability.scene_type if capability is not None else _other_preferred_scene_type(prompt)
+    )
+    fact_ids = list(capability.fact_ids) if capability is not None else []
+    if source_code and resolved_domain == TopicDomain.CODE.value:
+        fact_ids = _unique([*fact_ids, "source_code"])
+    capability_roles = list(capability.visual_roles) if capability is not None else []
+    core_roles = _unique([template.primary_role, template.process_role, *capability_roles])
+    process_roles = _unique([template.process_role, *capability_roles])
+    scenes = [
+        SceneIntent(
+            scene_id="lesson_context",
+            teaching_goal=f"建立对“{topic}”的直观问题情境。",
+            strategy="intuition",
+            required_fact_ids=[],
+            required_visual_roles=[template.primary_role],
+            preferred_scene_type=None,
+            narration_goal="说明为什么需要理解这个问题，并连接已有经验。",
+        ),
+        SceneIntent(
+            scene_id="lesson_core",
+            teaching_goal=f"展示“{topic}”的核心对象和关系。",
+            strategy="demonstration",
+            required_fact_ids=fact_ids,
+            required_visual_roles=core_roles,
+            preferred_scene_type=preferred_scene_type,
+            narration_goal="用一个具体、可观察的例子指出关键对象和当前状态。",
+        ),
+        SceneIntent(
+            scene_id="lesson_reasoning",
+            teaching_goal=f"解释“{topic}”从条件到结论的关键变化。",
+            strategy=_reasoning_strategy(resolved_domain),
+            required_fact_ids=fact_ids,
+            required_visual_roles=process_roles,
+            preferred_scene_type=preferred_scene_type,
+            narration_goal="逐步连接事实、状态或公式，避免跳过关键推理。",
+        ),
+        SceneIntent(
+            scene_id="lesson_summary",
+            teaching_goal=f"复核并总结“{topic}”的结论与适用边界。",
+            strategy="summary",
+            required_fact_ids=fact_ids,
+            required_visual_roles=_unique(["conclusion", *capability_roles]),
+            preferred_scene_type=None,
+            narration_goal="直接回答原问题，并指出结论依赖的核心证据。",
+        ),
+    ]
+    return LessonPlan(
+        schema_version="1.0.0",
+        domain=resolved_domain,
+        title=topic,
+        learning_objectives=[
+            f"理解“{topic}”的核心对象和关系。",
+            f"能沿着可视过程解释“{topic}”的关键推理。",
+            f"能用证据复核关于“{topic}”的结论。",
+        ],
+        prerequisites=[template.prerequisite],
+        misconceptions=_unique([
+            template.misconception,
+            *([capability.misconception] if capability is not None else []),
+        ]),
+        expected_conclusion=(
+            _expected_conclusion(prompt, capability, route_decision=route_decision)
+            if capability is not None
+            else f"用已解析事实和可视过程完整回答：{topic}"
+        ),
+        lesson_arc=template.arc,
+        scenes=scenes,
+    )
+
+
+def _resolve_domain(prompt: str, domain: str | None) -> str:
+    if domain:
+        normalized = domain.strip().lower()
+        try:
+            return TopicDomain(normalized).value
+        except ValueError:
+            return "general"
+    routed = route_topic(prompt)
+    return routed.domain.value if routed.domain is not None else "general"
+
+
+def _lesson_title(value: str) -> str:
+    first_line = next((line.strip() for line in value.splitlines() if line.strip()), "课程讲解")
+    return first_line if len(first_line) <= 80 else f"{first_line[:79]}…"
+
+
+def _capability_template(
+    prompt: str,
+    *,
+    route_decision: RouteDecision | None = None,
+) -> _CapabilityTemplate | None:
+    routing_terms = ""
+    if route_decision is not None:
+        routing_terms = " ".join(
+            value
+            for value in (
+                route_decision.skill_id,
+                route_decision.matched_capability,
+            )
+            if value
+        )
+    normalized = "".join(f"{prompt} {routing_terms}".lower().split())
+    for capability in _CAPABILITY_TEMPLATES:
+        if any(
+            "".join(term.lower().split()) in normalized for term in capability.terms
+        ):
+            return capability
+    return None
+
+
+def _expected_conclusion(
+    prompt: str,
+    capability: _CapabilityTemplate,
+    *,
+    route_decision: RouteDecision | None,
+) -> str:
+    if capability.scene_type == "derivative_tangent":
+        x_squared = re.search(r"(?:y\s*=\s*)?x(?:\^?2|²)", prompt, flags=re.IGNORECASE)
+        point = re.search(
+            r"(?:点|point)?\s*[（(]\s*(-?\d+(?:\.\d+)?)\s*[,，]\s*"
+            r"(-?\d+(?:\.\d+)?)\s*[）)]",
+            prompt,
+            flags=re.IGNORECASE,
+        )
+        if x_squared and point:
+            x0 = float(point.group(1))
+            y0 = float(point.group(2))
+            slope = 2 * x0
+            return (
+                f"曲线 y=x² 在点 ({_format_number(x0)},{_format_number(y0)}) 处的"
+                f"导数等于 {_format_number(slope)}，因此该点的切线斜率也等于 "
+                f"{_format_number(slope)}。"
+            )
+        problem_spec = route_decision.problem_spec if route_decision is not None else None
+        if isinstance(problem_spec, dict):
+            expression = str(problem_spec.get("expression") or "").replace(" ", "")
+            variable = str(problem_spec.get("variable") or "x")
+            if expression in {f"{variable}^2", f"{variable}**2", f"{variable}²"}:
+                return (
+                    f"函数 {expression} 对 {variable} 的导数为 2{variable}；"
+                    "这个导数给出各点的瞬时变化率，并在指定点等于切线斜率。"
+                )
+    if capability.scene_type == "recursion_stack":
+        factorial_match = re.search(r"factorial\s*[（(]\s*(\d+)\s*[）)]", prompt, re.I)
+        if factorial_match:
+            n = int(factorial_match.group(1))
+            if 0 <= n <= 12:
+                return (
+                    f"factorial({n}) 先建立等待相乘的递归栈帧，基例返回后逐层"
+                    f"回溯并完成乘法，最终 factorial({n})={math.factorial(n)}。"
+                )
+    return capability.expected_conclusion
+
+
+def _format_number(value: float) -> str:
+    return str(int(value)) if value.is_integer() else str(value)
+
+
+def _other_preferred_scene_type(prompt: str) -> str | None:
+    normalized = "".join(prompt.lower().split())
+    for terms, scene_type in _OTHER_CAPABILITY_SCENES:
+        if any("".join(term.lower().split()) in normalized for term in terms):
+            return scene_type
+    return None
+
+
+def _unique(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
+def _reasoning_strategy(domain: str) -> str:
+    if domain in {TopicDomain.ALGORITHM.value, TopicDomain.CODE.value, TopicDomain.BIOLOGY.value}:
+        return "state_transition"
+    if domain == TopicDomain.GEOGRAPHY.value:
+        return "comparison"
+    if domain == TopicDomain.MATH.value:
+        return "derivation"
+    return "demonstration"
+
+
+def _lesson_planner_prompt(prompt: str, draft: LessonPlan) -> tuple[str, str]:
+    schema = json.dumps(LessonPlan.model_json_schema(), ensure_ascii=False, indent=2)
+    draft_json = draft.model_dump_json(indent=2)
+    system = """You refine a MetaView LessonPlan for an educational visualization.
+Return one JSON object matching the supplied LessonPlan schema and nothing else.
+Preserve the resolved domain. Improve only teaching decisions: objectives,
+prerequisites, misconceptions, expected conclusion, lesson arc, and SceneIntent.
+Do not include coordinates, frames, SVG, asset paths, renderer-private fields,
+React structures, arbitrary code, or a PlaybookScript."""
+    user = f"""Original teaching request:
+{prompt}
+
+Deterministic draft:
+{draft_json}
+
+LessonPlan JSON schema:
+{schema}
+
+Return the refined LessonPlan JSON only."""
+    return system, user
+
+
+def _strip_markdown_fences(text: str) -> str:
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    lines = stripped.splitlines()[1:]
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+__all__ = [
+    "LLMAssistedLessonPlanner",
+    "LessonPlanningError",
+    "RuleBasedLessonPlanner",
+    "build_rule_based_lesson_plan",
+]

--- a/apps/api/app/application/use_cases/run_pipeline.py
+++ b/apps/api/app/application/use_cases/run_pipeline.py
@@ -16,11 +16,14 @@ from app.application.agent.types import AgentConstraints, AgentRequest
 from app.application.dto.pipeline_dto import PipelineRequest
 from app.application.ports.agent_provider import AgentProviderError, IAgentProvider
 from app.application.ports.director_repository import IRunDirectorRepository
+from app.application.ports.lesson_planner import ILessonPlanner
 from app.application.ports.llm_provider import ILLMProvider
 from app.application.ports.router_provider import IRouterProvider
 from app.application.ports.run_repository import IRunRepository
+from app.application.services.lesson_planner import RuleBasedLessonPlanner
 from app.config import GenerationMode, RouterMode
 from app.domain.models.cir import CirDocument, ExecutionMap
+from app.domain.models.lesson_plan import LessonPlan
 from app.domain.models.pipeline_run import PipelineRunStatus
 from app.domain.models.playbook import PlaybookScript
 from app.domain.models.quality_report import QualityReport
@@ -99,6 +102,7 @@ class RunPipelineUseCase:
         router_mode: RouterMode | str = "hybrid",
         router_min_confidence: float = 0.72,
         router_refine_confidence: float = 0.55,
+        lesson_planner: ILessonPlanner | None = None,
     ) -> None:
         self._repo = run_repo
         self._llm = llm
@@ -118,6 +122,7 @@ class RunPipelineUseCase:
         )
         self._router_min_confidence = router_min_confidence
         self._router_refine_confidence = router_refine_confidence
+        self._lesson_planner = lesson_planner or RuleBasedLessonPlanner()
 
     async def execute(self, run_id: str, request: PipelineRequest) -> None:
         await self._repo.update(run_id, status=PipelineRunStatus.RUNNING)
@@ -127,16 +132,27 @@ class RunPipelineUseCase:
 
                 agent_pipeline = AgentPipeline(
                     route_request=self._route_request,
-                    try_execute_skill=self._try_execute_skill,
+                    try_execute_skill=lambda rid, req, match, plan: self._try_execute_skill(
+                        rid,
+                        req,
+                        match,
+                        lesson_plan=plan,
+                    ),
                     fail_skill_consistency=self._fail_skill_consistency,
                     build_route_context=lambda req, match: self._generic_route_context(
                         req,
                         route_match=match,
                     ),
-                    execute_agent=lambda rid, req, ctx: self._execute_agent(
+                    prepare_lesson_plan=lambda rid, req, ctx: self._prepare_lesson_plan(
                         rid,
                         req,
                         route_context=ctx,  # type: ignore[arg-type]
+                    ),
+                    execute_agent=lambda rid, req, ctx, plan: self._execute_agent(
+                        rid,
+                        req,
+                        route_context=ctx,  # type: ignore[arg-type]
+                        lesson_plan=plan,
                     ),
                 )
                 await self._run_with_total_timeout(
@@ -145,19 +161,8 @@ class RunPipelineUseCase:
                 )
                 return
 
-            route_match = await self._route_request(request)
-            if route_match is not None:
-                try:
-                    handled = await self._try_execute_skill(run_id, request, route_match)
-                except AssertionError as exc:
-                    await self._fail_skill_consistency(run_id, route_match, str(exc))
-                    return
-                if handled:
-                    return
-
-            route_context = self._generic_route_context(request, route_match=route_match)
             await self._run_with_total_timeout(
-                self._execute_single(run_id, request, route_context=route_context),
+                self._execute_routed_single_pipeline(run_id, request),
                 run_id=run_id,
             )
         except TimeoutError:
@@ -193,6 +198,38 @@ class RunPipelineUseCase:
                 status=PipelineRunStatus.FAILED,
                 error=str(exc),
             )
+
+    async def _execute_routed_single_pipeline(
+        self,
+        run_id: str,
+        request: PipelineRequest,
+    ) -> None:
+        route_match = await self._route_request(request)
+        route_context = self._generic_route_context(request, route_match=route_match)
+        lesson_plan = await self._prepare_lesson_plan(
+            run_id,
+            request,
+            route_context=route_context,
+        )
+        if route_match is not None:
+            try:
+                handled = await self._try_execute_skill(
+                    run_id,
+                    request,
+                    route_match,
+                    lesson_plan=lesson_plan,
+                )
+            except AssertionError as exc:
+                await self._fail_skill_consistency(run_id, route_match, str(exc))
+                return
+            if handled:
+                return
+        await self._execute_single(
+            run_id,
+            request,
+            route_context=route_context,
+            lesson_plan=lesson_plan,
+        )
 
     async def _run_with_total_timeout(self, operation, *, run_id: str) -> None:
         timeout = self._pipeline_timeout_s
@@ -292,11 +329,32 @@ class RunPipelineUseCase:
             router_model=getattr(self._router_provider, "model_name", None),
         )
 
+    async def _prepare_lesson_plan(
+        self,
+        run_id: str,
+        request: PipelineRequest,
+        *,
+        route_context: RouteContext,
+    ) -> LessonPlan:
+        lesson_plan = await self._lesson_planner.plan(
+            prompt=request.prompt,
+            domain=route_context.decision.domain or request.domain,
+            route_decision=route_context.decision,
+            source_code=request.source_code,
+            language=request.language,
+        )
+        update_lesson_plan = getattr(self._repo, "update_lesson_plan", None)
+        if callable(update_lesson_plan):
+            await update_lesson_plan(run_id, lesson_plan.model_dump_json())
+        return lesson_plan
+
     async def _try_execute_skill(
         self,
         run_id: str,
         request: PipelineRequest,
         route_match: SkillRouteMatch,
+        *,
+        lesson_plan: LessonPlan,
     ) -> bool:
         skill = self._skill_registry.get(route_match.skill_id)
         if skill is None:
@@ -326,11 +384,21 @@ class RunPipelineUseCase:
                 run_id=run_id,
                 prompt=request.prompt,
                 route_match=route_match,
+                lesson_plan=lesson_plan,
             ),
             problem_spec,
         )
         if not result.handled or result.playbook_json is None:
             return False
+        if result.lesson_plan is not None:
+            if result.lesson_plan.domain != lesson_plan.domain:
+                raise AssertionError(
+                    "SkillPack LessonPlan domain does not match the routed LessonPlan domain."
+                )
+            lesson_plan = result.lesson_plan
+            update_lesson_plan = getattr(self._repo, "update_lesson_plan", None)
+            if callable(update_lesson_plan):
+                await update_lesson_plan(run_id, lesson_plan.model_dump_json())
 
         try:
             playbook = PlaybookScript.model_validate_json(result.playbook_json)
@@ -379,6 +447,7 @@ class RunPipelineUseCase:
             request.prompt,
             generator_path="skill_pack",
             coverage_mode="specialized",
+            lesson_plan=lesson_plan,
         )
         quality_report.actions = list(review_report.actions)
         if quality_report.status == "repairable":
@@ -454,6 +523,7 @@ class RunPipelineUseCase:
         request: PipelineRequest,
         *,
         route_context: RouteContext,
+        lesson_plan: LessonPlan,
     ) -> None:
         """Generate via the Node sidecar (pi-agent-core) and persist the
         resulting PlaybookScript verbatim. Skips CIR parsing / playbook_builder
@@ -481,6 +551,7 @@ class RunPipelineUseCase:
                 provider_config=provider_config,
                 route_context=route_context,
                 review_report=review_report,
+                lesson_plan=lesson_plan,
             )
             playbook, review_report = await self._review_agent_playbook(
                 run_id,
@@ -489,6 +560,7 @@ class RunPipelineUseCase:
                 provider_config=provider_config,
                 route_context=route_context,
                 review_report=review_report,
+                lesson_plan=lesson_plan,
             )
             quality_report = _quality_report_with_review(
                 playbook,
@@ -496,6 +568,7 @@ class RunPipelineUseCase:
                 review_report,
                 generator_path="agent",
                 coverage_mode="experimental",
+                lesson_plan=lesson_plan,
             )
             if quality_report.status == "repairable":
                 review_report = _with_playbook_review_actions(
@@ -520,6 +593,7 @@ class RunPipelineUseCase:
                     provider_config=provider_config,
                     route_context=route_context,
                     review_report=review_report,
+                    lesson_plan=lesson_plan,
                 )
                 playbook, review_report = await self._review_agent_playbook(
                     run_id,
@@ -528,6 +602,7 @@ class RunPipelineUseCase:
                     provider_config=provider_config,
                     route_context=route_context,
                     review_report=review_report,
+                    lesson_plan=lesson_plan,
                 )
                 quality_report = _quality_report_with_review(
                     playbook,
@@ -535,6 +610,7 @@ class RunPipelineUseCase:
                     review_report,
                     generator_path="agent",
                     coverage_mode="experimental",
+                    lesson_plan=lesson_plan,
                 )
             if quality_report.status == "repairable":
                 quality_report = _mark_quality_repair_exhausted(quality_report)
@@ -620,6 +696,7 @@ class RunPipelineUseCase:
         provider_config: dict[str, Any] | None,
         route_context: RouteContext,
         review_report: PlaybookReviewVerdict,
+        lesson_plan: LessonPlan,
     ) -> tuple[PlaybookScript, PlaybookReviewVerdict]:
         assert self._agent_provider is not None
         generation_prompt = prompt
@@ -631,6 +708,7 @@ class RunPipelineUseCase:
                 request=request,
                 provider_config=provider_config,
                 route_context=route_context,
+                lesson_plan=lesson_plan,
             )
             last_payload = playbook_dict
             # Validate the sidecar payload against the canonical PlaybookScript
@@ -661,7 +739,7 @@ class RunPipelineUseCase:
                 )
                 continue
 
-            check = self_check_playbook(playbook, prompt)
+            check = self_check_playbook(playbook, prompt, lesson_plan=lesson_plan)
             check = _with_playbook_review_actions(
                 check,
                 [*review_report.actions, *check.actions, f"agent:self_check:{check.status.value}"],
@@ -699,6 +777,7 @@ class RunPipelineUseCase:
         provider_config: dict[str, Any] | None,
         route_context: RouteContext,
         review_report: PlaybookReviewVerdict,
+        lesson_plan: LessonPlan,
     ) -> tuple[PlaybookScript, PlaybookReviewVerdict]:
         if self._reviewer_mode == "off":
             return playbook, _with_playbook_review_actions(
@@ -776,6 +855,7 @@ class RunPipelineUseCase:
                 provider_config=provider_config,
                 route_context=route_context,
                 review_report=review_report,
+                lesson_plan=lesson_plan,
             )
 
         raise PipelineValidationError(review_report)
@@ -805,6 +885,7 @@ class RunPipelineUseCase:
         provider_config: dict[str, Any] | None,
         route_context: RouteContext,
         review_report: PlaybookReviewVerdict,
+        lesson_plan: LessonPlan,
     ) -> tuple[PlaybookScript, PlaybookReviewVerdict]:
         assert self._agent_provider is not None
         repair_prompt = _build_agent_reviewer_repair_prompt(request.prompt, playbook, blocking)
@@ -814,6 +895,7 @@ class RunPipelineUseCase:
             request=request,
             provider_config=provider_config,
             route_context=route_context,
+            lesson_plan=lesson_plan,
         )
         try:
             repaired = PlaybookScript.model_validate(repaired_payload)
@@ -824,7 +906,11 @@ class RunPipelineUseCase:
                     actions=[*review_report.actions, "agent:schema_validation:blocked"],
                 )
             ) from exc
-        check = self_check_playbook(repaired, request.prompt)
+        check = self_check_playbook(
+            repaired,
+            request.prompt,
+            lesson_plan=lesson_plan,
+        )
         check = _with_playbook_review_actions(
             check,
             [*review_report.actions, *check.actions, f"agent:self_check:{check.status.value}"],
@@ -841,6 +927,7 @@ class RunPipelineUseCase:
         request: PipelineRequest,
         provider_config: dict[str, Any] | None,
         route_context: RouteContext,
+        lesson_plan: LessonPlan,
     ) -> dict[str, Any]:
         assert self._agent_provider is not None
         route_decision = route_context.decision.model_dump(mode="json")
@@ -850,6 +937,7 @@ class RunPipelineUseCase:
             source_code=request.source_code,
             language=request.language,
             route_decision=route_decision,
+            lesson_plan=lesson_plan,
             provider_config=provider_config,
             playbook_schema=PlaybookScript.model_json_schema(),
             constraints=AgentConstraints(
@@ -865,7 +953,7 @@ class RunPipelineUseCase:
             result = await runner(agent_request)
             return result.playbook
         return await self._agent_provider.generate(
-            prompt,
+            _build_agent_generation_prompt(prompt, lesson_plan),
             provider_config=provider_config,
             route_decision=route_decision,
         )
@@ -876,6 +964,7 @@ class RunPipelineUseCase:
         request: PipelineRequest,
         *,
         route_context: RouteContext,
+        lesson_plan: LessonPlan,
     ) -> None:
         """Original single-shot pipeline: prompt → LLM → CIR JSON → builder."""
         review_report = CirReviewReport(
@@ -897,6 +986,7 @@ class RunPipelineUseCase:
                 language=request.language,
                 skill_mode=route.skill_mode,
                 route_decision=route_context.decision,
+                lesson_plan=lesson_plan,
             )
             raw = await self._llm.complete(system, user)
             parsed, review_report = await self._review_output(
@@ -921,6 +1011,7 @@ class RunPipelineUseCase:
                 playbook,
                 request.prompt,
                 review_report,
+                lesson_plan=lesson_plan,
             )
 
             quality_attempts_allowed = CANONICAL_QUALITY_REPAIR_ATTEMPTS
@@ -967,6 +1058,7 @@ class RunPipelineUseCase:
                     playbook,
                     request.prompt,
                     review_report,
+                    lesson_plan=lesson_plan,
                 )
 
             if quality_report.status == "repairable":
@@ -1363,6 +1455,15 @@ def _blocking_playbook_review_issues(
     return [issue for issue in result.issues if issue.severity == PlaybookIssueSeverity.ERROR]
 
 
+def _build_agent_generation_prompt(prompt: str, lesson_plan: LessonPlan) -> str:
+    return (
+        "[MetaView LessonPlan]\n"
+        f"{lesson_plan.model_dump_json(indent=2)}\n\n"
+        "[user prompt]\n"
+        f"{prompt}"
+    )
+
+
 def _build_agent_self_repair_prompt(
     original_prompt: str,
     previous_payload: dict[str, Any] | None,
@@ -1423,12 +1524,14 @@ def _quality_report_with_review(
     *,
     generator_path: str,
     coverage_mode: str,
+    lesson_plan: LessonPlan,
 ) -> QualityReport:
     canonical = quality_gate_playbook(
         playbook,
         prompt,
         generator_path=generator_path,
         coverage_mode=coverage_mode,
+        lesson_plan=lesson_plan,
     )
     unique: dict[tuple[str, str, str], PlaybookReviewIssue] = {}
     for issue in [*canonical.issues, *review.issues]:
@@ -1452,12 +1555,15 @@ def _quality_report_for_single(
     playbook: PlaybookScript,
     prompt: str,
     review: CirReviewReport,
+    *,
+    lesson_plan: LessonPlan,
 ) -> QualityReport:
     report = quality_gate_playbook(
         playbook,
         prompt,
         generator_path="generic_cir",
         coverage_mode="experimental",
+        lesson_plan=lesson_plan,
     )
     report.actions = list(review.actions)
     report.attempts = review.attempts

--- a/apps/api/app/domain/models/__init__.py
+++ b/apps/api/app/domain/models/__init__.py
@@ -8,6 +8,7 @@ from app.domain.models.cir import (
     VisualToken,
 )
 from app.domain.models.execution import ExecutionParameterControl
+from app.domain.models.lesson_plan import LessonPlan, SceneIntent
 from app.domain.models.pipeline_run import (
     PipelineRunStatus,
     SandboxMode,
@@ -55,6 +56,7 @@ from app.domain.models.topic import TopicDomain, VisualKind
 __all__ = [
     "CirDocument", "CirStep", "VisualToken", "LayoutInstruction",
     "ExecutionMap", "ExecutionCheckpoint", "ExecutionArrayTrack", "ExecutionParameterControl",
+    "LessonPlan", "SceneIntent",
     "TopicDomain", "VisualKind",
     "PipelineRunStatus", "SandboxMode", "SandboxStatus", "UITheme",
     "ValidationSeverity", "ValidationStatus",

--- a/apps/api/app/domain/models/lesson_plan.py
+++ b/apps/api/app/domain/models/lesson_plan.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+LessonArc = Literal[
+    "intuition_to_abstraction",
+    "problem_to_solution",
+    "state_transition",
+    "comparison",
+    "derivation",
+]
+SceneStrategy = Literal[
+    "intuition",
+    "demonstration",
+    "derivation",
+    "comparison",
+    "state_transition",
+    "summary",
+]
+NonBlankString = Annotated[str, Field(min_length=1)]
+
+
+class SceneIntent(BaseModel):
+    """One pedagogical decision, without renderer or layout details."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    scene_id: NonBlankString
+    teaching_goal: NonBlankString
+    strategy: SceneStrategy
+    required_fact_ids: list[NonBlankString]
+    required_visual_roles: list[NonBlankString]
+    preferred_scene_type: NonBlankString | None
+    narration_goal: NonBlankString
+
+
+class LessonPlan(BaseModel):
+    """Renderer-independent teaching plan shared by every generation path."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    schema_version: Literal["1.0.0"]
+    domain: NonBlankString
+    title: NonBlankString
+    learning_objectives: list[NonBlankString] = Field(min_length=1)
+    prerequisites: list[NonBlankString]
+    misconceptions: list[NonBlankString]
+    expected_conclusion: NonBlankString
+    lesson_arc: LessonArc
+    scenes: list[SceneIntent] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_unique_scene_ids(self) -> "LessonPlan":
+        scene_ids = [scene.scene_id for scene in self.scenes]
+        if len(scene_ids) != len(set(scene_ids)):
+            raise ValueError("scene_id values must be unique within a LessonPlan")
+        return self
+
+
+__all__ = ["LessonArc", "LessonPlan", "SceneIntent", "SceneStrategy"]

--- a/apps/api/app/domain/models/quality_report.py
+++ b/apps/api/app/domain/models/quality_report.py
@@ -136,6 +136,12 @@ def _scores_from_verdict(verdict: PlaybookReviewVerdict) -> dict[str, float]:
             keys = ["scene_contract", "visual_structure", "export_readiness"]
         elif issue.code.startswith(("math.", "algorithm.")):
             keys = ["knowledge_correctness", "visual_structure"]
+        elif issue.code.startswith("lesson_plan.visual_role"):
+            keys = ["prompt_coverage", "scene_contract", "visual_structure"]
+        elif issue.code.startswith("lesson_plan.scene_type"):
+            keys = ["scene_contract", "visual_structure", "export_readiness"]
+        elif issue.code.startswith("lesson_plan."):
+            keys = ["knowledge_correctness", "prompt_coverage", "pedagogy"]
         elif issue.code.startswith("code."):
             keys = ["knowledge_correctness", "visual_structure", "code_sync"]
         elif issue.code.startswith(("narration.", "step.")):

--- a/apps/api/app/domain/services/cir_prompt.py
+++ b/apps/api/app/domain/services/cir_prompt.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from app.domain.models.lesson_plan import LessonPlan
 from app.domain.models.route_decision import RouteDecision
 from app.domain.models.topic import TopicDomain
 from app.domain.services.algorithm_code_library import infer_id, prompt_hint
@@ -309,6 +310,7 @@ def build_cir_prompt(
     language: str = "python",
     skill_mode: SkillMode = SkillMode.SPECIALIZED,
     route_decision: RouteDecision | dict[str, Any] | None = None,
+    lesson_plan: LessonPlan | None = None,
 ) -> tuple[str, str]:
     """Return (system_prompt, user_prompt) for CIR + ExecutionMap generation.
 
@@ -333,6 +335,7 @@ Skill mode: specialized.
 You may change this if the topic clearly belongs to a different domain."""
 
     route_section = _format_route_decision(route_decision)
+    lesson_plan_section = _format_lesson_plan(lesson_plan)
 
     code_track = ""
     if source_code and source_code.strip():
@@ -407,6 +410,8 @@ Only use: "array", "graph", "function", "scene", or "formula"
 {route_section}
 {domain_section}
 {domain_guidance}
+
+{lesson_plan_section}
 
 ## Narration Output Format
 Output the "narration" field of each cir step as a JSON array (NOT a plain string):
@@ -591,4 +596,19 @@ The router classified this request as:
 {json.dumps(payload, ensure_ascii=False, indent=2)}
 ```
 Use this as routing context only. Do not use unsupported deterministic skill output, and do not invent deterministic results when skill_id is unsupported or null.
+"""
+
+
+def _format_lesson_plan(lesson_plan: LessonPlan | None) -> str:
+    if lesson_plan is None:
+        return ""
+    payload = json.dumps(lesson_plan.model_dump(mode="json"), ensure_ascii=False, indent=2)
+    return f"""## Canonical LessonPlan (BINDING TEACHING DECISIONS)
+Use this renderer-independent plan as the teaching spine for the CIR.
+- Cover every SceneIntent in order; a SceneIntent may expand into multiple CIR steps.
+- Preserve its teaching goal, required facts, visual roles, narration goal, and conclusion.
+- Do not copy LessonPlan into renderer payloads or invent coordinates/assets from it.
+- The final CIR must still satisfy the CIR + ExecutionMap schema.
+
+{payload}
 """

--- a/apps/api/app/domain/services/legacy_cir_lesson_plan_adapter.py
+++ b/apps/api/app/domain/services/legacy_cir_lesson_plan_adapter.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from app.domain.models.cir import CirDocument, CirStep
+from app.domain.models.lesson_plan import LessonPlan, SceneIntent
+from app.domain.models.topic import TopicDomain, VisualKind
+
+_VISUAL_ROLES: dict[VisualKind, str] = {
+    VisualKind.ARRAY: "array_state",
+    VisualKind.FLOW: "process_flow",
+    VisualKind.FORMULA: "formula",
+    VisualKind.FUNCTION: "function_curve",
+    VisualKind.SCENE: "coordinate_scene",
+    VisualKind.GRAPH: "graph_structure",
+    VisualKind.TEXT: "concept_summary",
+    VisualKind.MOTION: "motion_state",
+    VisualKind.CIRCUIT: "circuit_structure",
+    VisualKind.MOLECULE: "molecular_structure",
+    VisualKind.MAP: "map_context",
+    VisualKind.CELL: "cell_structure",
+}
+
+_STATE_VISUALS = frozenset({
+    VisualKind.ARRAY,
+    VisualKind.FLOW,
+    VisualKind.GRAPH,
+    VisualKind.MOTION,
+})
+
+
+def lesson_plan_from_legacy_cir(cir: CirDocument) -> LessonPlan:
+    """Project legacy CIR teaching semantics into a renderer-free LessonPlan.
+
+    CIR does not contain prerequisites, misconceptions, fact identifiers, or an
+    explicit conclusion.  The adapter therefore keeps those fields conservative
+    instead of inventing domain knowledge, and deliberately ignores layout,
+    timing, layers, assets, and animation calls.
+    """
+
+    title = cir.title.strip() or "Legacy lesson"
+    summary = cir.summary.strip() or title
+    scenes = [
+        _scene_intent(step, index=index, total=len(cir.steps))
+        for index, step in enumerate(cir.steps)
+    ]
+    if not scenes:
+        scenes = [
+            SceneIntent(
+                scene_id="legacy_summary",
+                teaching_goal=summary,
+                strategy="summary",
+                required_fact_ids=[],
+                required_visual_roles=["concept_summary"],
+                preferred_scene_type=None,
+                narration_goal=summary,
+            )
+        ]
+    conclusion = _narration_text(cir.steps[-1]) if cir.steps else ""
+    return LessonPlan(
+        schema_version="1.0.0",
+        domain=cir.domain.value,
+        title=title,
+        learning_objectives=[summary],
+        prerequisites=[],
+        misconceptions=[],
+        expected_conclusion=conclusion or summary,
+        lesson_arc=_lesson_arc(cir),
+        scenes=scenes,
+    )
+
+
+def _scene_intent(step: CirStep, *, index: int, total: int) -> SceneIntent:
+    narration = _narration_text(step)
+    teaching_goal = step.title.strip() or narration or f"Legacy scene {index + 1}"
+    return SceneIntent(
+        scene_id=step.id,
+        teaching_goal=teaching_goal,
+        strategy=_scene_strategy(step.visual_kind, index=index, total=total),
+        required_fact_ids=[],
+        required_visual_roles=[_VISUAL_ROLES[step.visual_kind]],
+        preferred_scene_type=None,
+        narration_goal=narration or teaching_goal,
+    )
+
+
+def _lesson_arc(cir: CirDocument) -> str:
+    kinds = {step.visual_kind for step in cir.steps}
+    if cir.domain == TopicDomain.MATH and kinds & {
+        VisualKind.FORMULA,
+        VisualKind.FUNCTION,
+        VisualKind.SCENE,
+    }:
+        return "derivation"
+    if kinds & _STATE_VISUALS:
+        return "state_transition"
+    return "problem_to_solution"
+
+
+def _scene_strategy(kind: VisualKind, *, index: int, total: int) -> str:
+    if total > 1 and index == 0:
+        return "intuition"
+    if total > 1 and index == total - 1:
+        return "summary"
+    if kind in _STATE_VISUALS:
+        return "state_transition"
+    if kind == VisualKind.FORMULA:
+        return "derivation"
+    return "demonstration"
+
+
+def _narration_text(step: CirStep) -> str:
+    narration: Any = step.narration
+    if isinstance(narration, str):
+        stripped = narration.strip()
+        if stripped.startswith("["):
+            try:
+                decoded = json.loads(stripped)
+            except json.JSONDecodeError:
+                decoded = None
+            if isinstance(decoded, list):
+                narration = decoded
+            else:
+                return _resolve_token_placeholders(stripped, step)
+        else:
+            return _resolve_token_placeholders(stripped, step)
+    return _flatten_narration(narration, step).strip()
+
+
+def _flatten_narration(value: Any, step: CirStep) -> str:
+    if isinstance(value, str):
+        return _resolve_token_placeholders(value, step)
+    if isinstance(value, dict) and isinstance(value.get("t"), str):
+        token_id = value["t"]
+        return next((token.label for token in step.tokens if token.id == token_id), token_id)
+    if isinstance(value, list):
+        parts = [_flatten_narration(item, step).strip() for item in value]
+        return " ".join(part for part in parts if part)
+    return ""
+
+
+def _resolve_token_placeholders(text: str, step: CirStep) -> str:
+    token_labels = {token.id: token.label for token in step.tokens}
+    return re.sub(
+        r"\{\{([^}]+)\}\}",
+        lambda match: token_labels.get(match.group(1), match.group(1)),
+        text,
+    )
+
+
+__all__ = ["lesson_plan_from_legacy_cir"]

--- a/apps/api/app/domain/services/playbook_quality.py
+++ b/apps/api/app/domain/services/playbook_quality.py
@@ -5,6 +5,7 @@ import re
 from typing import Any
 
 from app.domain.contracts.playbook_contract import SUPPORTED_SNAPSHOT_KIND_SET
+from app.domain.models.lesson_plan import LessonPlan
 from app.domain.models.playbook import (
     AlgorithmArraySnapshot,
     AlgorithmBarsSnapshot,
@@ -196,6 +197,72 @@ _FORBIDDEN_RENDERING_PATTERNS = (
     "ffmpeg",
 )
 
+_LESSON_FACT_ALIASES: dict[str, tuple[str, ...]] = {
+    "derivative": ("derivative", "导数", "f'", "f′"),
+    "tangent": ("tangent", "切线"),
+    "slope": ("slope", "斜率"),
+    "breadth_first": ("bfs", "breadth-first", "breadth first", "广度优先"),
+    "queue": ("queue", "frontier", "队列"),
+    "visited": ("visited", "已访问", "访问集合"),
+    "order": ("visit_order", "visit order", "layer by layer", "访问顺序", "逐层"),
+    "factorial": ("factorial", "阶乘"),
+    "base_case": ("base_case", "base case", "基例", "递归出口"),
+    "recursive_call": ("recursive_call", "recursive call", "递归调用"),
+    "return_unwind": ("return_unwind", "unwind", "回溯", "返回"),
+    "factorial_result": ("factorial_result", "return_value", "返回值", "阶乘结果"),
+    "horizontal_velocity": (
+        "horizontal_velocity",
+        "horizontal velocity",
+        "velocity-x",
+        "v_x",
+        "水平速度",
+    ),
+    "vertical_velocity": (
+        "vertical_velocity",
+        "vertical velocity",
+        "velocity-y",
+        "v_y",
+        "竖直速度",
+    ),
+    "gravity": ("gravity", "重力", "g向下"),
+    "parabolic": ("parabolic", "parabola", "抛物线"),
+}
+
+_LESSON_VISUAL_ROLE_ALIASES: dict[str, tuple[str, ...]] = {
+    "curve": ("curves", "curve", "expression"),
+    "target_point": ("target_point", "marker_x", "point"),
+    "secant": ("secant", "割线"),
+    "tangent": ("tangent", "切线"),
+    "slope": ("slope", "斜率"),
+    "node": ("nodes", "node_ids", "node"),
+    "edge": ("edges", "edge"),
+    "current_node": (
+        "current",
+        "current_node",
+        "current_node_id",
+        "active_node",
+        "active_node_ids",
+    ),
+    "visited": ("visited", "visited_node_ids"),
+    "queue": ("queue", "queue_node_ids", "frontier", "frontier_node_ids"),
+    "stack_frame": ("frames", "stack_frame", "call_stack"),
+    "active_frame": ("active_frame", "active_frame_id", "current_frame_id"),
+    "code_line": ("code_trace", "active_line", "code_lines"),
+    "return_value": ("return_value", "returned_value", "result", "return", "returned"),
+    "object": ("objects", "object", "body_id"),
+    "trajectory": ("trajectory", "path_points", "trail"),
+    "horizontal_velocity": ("horizontal_velocity", "velocity-x", "v_x", "vx"),
+    "vertical_velocity": ("vertical_velocity", "velocity-y", "v_y", "vy"),
+    "gravity": ("gravity", "acceleration", "g"),
+}
+
+_LESSON_SCENE_SNAPSHOT_KINDS: dict[str, frozenset[str]] = {
+    "derivative_tangent": frozenset(("math_plot", "math_scene")),
+    "bfs_graph": frozenset(("graph_scene", "algorithm_tree")),
+    "recursion_stack": frozenset(("call_stack_scene",)),
+    "projectile_motion": frozenset(("physics_force_scene", "motion_scene", "math_scene")),
+}
+
 
 PlaybookCheckReport = PlaybookReviewVerdict
 
@@ -206,18 +273,34 @@ def quality_gate_playbook(
     *,
     generator_path: str,
     coverage_mode: str = "unknown",
+    lesson_plan: LessonPlan | None = None,
 ) -> QualityReport:
     """Run the canonical backend quality gate for a candidate playbook."""
     return QualityReport.from_review_verdict(
-        _review_playbook(playbook, prompt, enforce_agent_step_bounds=False),
+        _review_playbook(
+            playbook,
+            prompt,
+            enforce_agent_step_bounds=False,
+            lesson_plan=lesson_plan,
+        ),
         generator_path=generator_path,
         coverage_mode=coverage_mode,
     )
 
 
-def self_check_playbook(playbook: PlaybookScript, prompt: str) -> PlaybookCheckReport:
+def self_check_playbook(
+    playbook: PlaybookScript,
+    prompt: str,
+    *,
+    lesson_plan: LessonPlan | None = None,
+) -> PlaybookCheckReport:
     """Strict agent pre-check; final success still goes through ``quality_gate_playbook``."""
-    return _review_playbook(playbook, prompt, enforce_agent_step_bounds=True)
+    return _review_playbook(
+        playbook,
+        prompt,
+        enforce_agent_step_bounds=True,
+        lesson_plan=lesson_plan,
+    )
 
 
 def _review_playbook(
@@ -225,6 +308,7 @@ def _review_playbook(
     prompt: str,
     *,
     enforce_agent_step_bounds: bool,
+    lesson_plan: LessonPlan | None,
 ) -> PlaybookCheckReport:
     issues: list[PlaybookReviewIssue] = []
     _check_structure(playbook, issues, enforce_step_bounds=enforce_agent_step_bounds)
@@ -233,6 +317,8 @@ def _review_playbook(
     _check_domain_quality(playbook, prompt, issues)
     _check_assets(playbook, issues)
     _check_forbidden_rendering_paths(playbook, issues)
+    if lesson_plan is not None:
+        _check_lesson_plan_adherence(playbook, lesson_plan, issues)
     return playbook_review_verdict_from_issues(
         issues,
         clean_summary="Playbook passed API self-check.",
@@ -1225,6 +1311,378 @@ def _check_forbidden_rendering_paths(
                     "Use only PlaybookScript consumed by the frontend Remotion renderer.",
                 )
             )
+
+
+def _check_lesson_plan_adherence(
+    playbook: PlaybookScript,
+    lesson_plan: LessonPlan,
+    issues: list[PlaybookReviewIssue],
+) -> None:
+    evidence = _lesson_plan_evidence(playbook)
+    visual_tokens = _lesson_plan_visual_tokens(playbook)
+    required_facts = {
+        fact_id for scene in lesson_plan.scenes for fact_id in scene.required_fact_ids
+    }
+    required_roles = {
+        role for scene in lesson_plan.scenes for role in scene.required_visual_roles
+    }
+
+    for fact_id in sorted(required_facts):
+        aliases = _LESSON_FACT_ALIASES.get(fact_id)
+        if aliases is None:
+            issues.append(
+                _issue(
+                    "lesson_plan.fact_unverifiable",
+                    PlaybookIssueSeverity.WARNING,
+                    f"lesson_plan.required_fact_ids.{fact_id}",
+                    f"Required fact {fact_id!r} has no deterministic evidence matcher yet.",
+                    (
+                        "Register a deterministic fact check before treating this "
+                        "fact as verified."
+                    ),
+                )
+            )
+        elif not _contains_lesson_alias(evidence, aliases):
+            issues.append(
+                _issue(
+                    "lesson_plan.fact_missing",
+                    PlaybookIssueSeverity.ERROR,
+                    f"lesson_plan.required_fact_ids.{fact_id}",
+                    f"Playbook does not provide evidence for required fact {fact_id!r}.",
+                    "Repair the relevant scene and narration to cover this LessonPlan fact.",
+                )
+            )
+
+    for role in sorted(required_roles):
+        aliases = _LESSON_VISUAL_ROLE_ALIASES.get(role)
+        if aliases is None:
+            continue
+        if not _contains_lesson_visual_alias(visual_tokens, aliases):
+            issues.append(
+                _issue(
+                    "lesson_plan.visual_role_missing",
+                    PlaybookIssueSeverity.ERROR,
+                    f"lesson_plan.required_visual_roles.{role}",
+                    f"Playbook does not render required visual role {role!r}.",
+                    "Compile a scene containing this semantic visual role.",
+                )
+            )
+
+    snapshot_kinds = {step.snapshot.kind for step in playbook.steps}
+    preferred_scene_types = {
+        scene.preferred_scene_type
+        for scene in lesson_plan.scenes
+        if scene.preferred_scene_type is not None
+    }
+    for scene_type in sorted(preferred_scene_types):
+        accepted_kinds = _LESSON_SCENE_SNAPSHOT_KINDS.get(scene_type)
+        if accepted_kinds is None:
+            continue
+        if snapshot_kinds.isdisjoint(accepted_kinds):
+            issues.append(
+                _issue(
+                    "lesson_plan.scene_type_missing",
+                    PlaybookIssueSeverity.ERROR,
+                    f"lesson_plan.preferred_scene_type.{scene_type}",
+                    f"Playbook does not contain a renderer for scene type {scene_type!r}.",
+                    "Use a compatible SceneBlueprint or renderer-backed snapshot kind.",
+                )
+            )
+
+    _check_lesson_plan_exact_conclusion(
+        lesson_plan,
+        _lesson_plan_final_evidence(playbook),
+        required_facts,
+        issues,
+    )
+
+
+def _check_lesson_plan_exact_conclusion(
+    lesson_plan: LessonPlan,
+    final_evidence: str,
+    required_facts: set[str],
+    issues: list[PlaybookReviewIssue],
+) -> None:
+    if "factorial_result" in required_facts:
+        conclusion = re.sub(r"\s+", "", lesson_plan.expected_conclusion.casefold())
+        match = re.search(r"factorial\((\d+)\)=(\d+)", conclusion)
+        if match:
+            n, result = match.groups()
+            actual_values = _factorial_conclusion_values(final_evidence, n)
+            _check_exact_numeric_conclusion(
+                expected_value=float(result),
+                actual_values=actual_values,
+                required_marker=match.group(0),
+                issues=issues,
+            )
+    elif {"derivative", "tangent", "slope"} <= required_facts:
+        expected_values = _derivative_conclusion_values(lesson_plan.expected_conclusion)
+        if expected_values:
+            expected_value = expected_values[-1]
+            _check_exact_numeric_conclusion(
+                expected_value=expected_value,
+                actual_values=_derivative_conclusion_values(final_evidence),
+                required_marker=f"导数/切线斜率等于 {_format_lesson_number(expected_value)}",
+                issues=issues,
+            )
+
+
+def _check_exact_numeric_conclusion(
+    *,
+    expected_value: float,
+    actual_values: list[float],
+    required_marker: str,
+    issues: list[PlaybookReviewIssue],
+) -> None:
+    conflicting_values = [
+        value
+        for value in actual_values
+        if not math.isclose(value, expected_value, rel_tol=0.0, abs_tol=1e-12)
+    ]
+    if conflicting_values:
+        rendered_values = ", ".join(
+            sorted({_format_lesson_number(value) for value in conflicting_values})
+        )
+        issues.append(
+            _issue(
+                "lesson_plan.conclusion_conflict",
+                PlaybookIssueSeverity.ERROR,
+                "lesson_plan.expected_conclusion",
+                (
+                    f"Final teaching scene states {rendered_values}, which conflicts with the "
+                    f"planned conclusion {required_marker!r}."
+                ),
+                "Repair the final teaching scene so every explicit result matches the plan.",
+            )
+        )
+        return
+
+    if not any(
+        math.isclose(value, expected_value, rel_tol=0.0, abs_tol=1e-12)
+        for value in actual_values
+    ):
+        issues.append(
+            _issue(
+                "lesson_plan.conclusion_missing",
+                PlaybookIssueSeverity.ERROR,
+                "lesson_plan.expected_conclusion",
+                f"Final teaching scene does not establish {required_marker!r}.",
+                "Repair the final teaching scene so it explicitly states the verified conclusion.",
+            )
+        )
+
+
+_LESSON_NUMBER_PATTERN = (
+    r"(?<![\w.])-?\d+(?:\.\d+)?(?![\w.])(?!(?:\s*)[+*/^%-])"
+)
+_DERIVATIVE_SUBJECT_PATTERN = (
+    r"(?:f\s*['′]\s*\([^\n)]{1,24}\)|derivative|tangent(?:'s)?\s+slope|"
+    r"slope\s+of\s+(?:the\s+)?tangent|导数|切线(?:的)?斜率)"
+)
+_DERIVATIVE_WORD_RESULT_PATTERN = re.compile(
+    rf"{_DERIVATIVE_SUBJECT_PATTERN}[^。！？!?；;\n]{{0,48}}?"
+    rf"(?:(?<!不)(?:等于|为|是)|\bis\b(?!\s+not\b)|\bequals\b)\s*"
+    rf"({_LESSON_NUMBER_PATTERN})",
+    flags=re.IGNORECASE,
+)
+_DERIVATIVE_EQUAL_RESULT_PATTERN = re.compile(
+    rf"{_DERIVATIVE_SUBJECT_PATTERN}\s*=\s*({_LESSON_NUMBER_PATTERN})",
+    flags=re.IGNORECASE,
+)
+_DERIVATIVE_FORMULA_RESULT_PATTERN = re.compile(
+    rf"f\s*['′]\s*\([^\n)]{{1,24}}\)\s*=\s*[^\n]{{1,180}}?"
+    rf"=\s*({_LESSON_NUMBER_PATTERN})",
+    flags=re.IGNORECASE,
+)
+
+
+def _derivative_conclusion_values(evidence: str) -> list[float]:
+    patterns = (
+        _DERIVATIVE_WORD_RESULT_PATTERN,
+        _DERIVATIVE_EQUAL_RESULT_PATTERN,
+        _DERIVATIVE_FORMULA_RESULT_PATTERN,
+    )
+    return [
+        float(match.group(1))
+        for pattern in patterns
+        for match in pattern.finditer(evidence)
+    ]
+
+
+def _factorial_conclusion_values(evidence: str, n: str) -> list[float]:
+    escaped_n = re.escape(n)
+    relationship = r"(?:=|等于|为|是|\bis\b|\bequals\b)"
+    patterns = (
+        rf"factorial\s*[（(]\s*{escaped_n}\s*[）)]\s*{relationship}\s*"
+        rf"({_LESSON_NUMBER_PATTERN})",
+        rf"(?<!\d){escaped_n}(?!\d)\s*!\s*{relationship}\s*"
+        rf"({_LESSON_NUMBER_PATTERN})",
+        rf"阶乘\s*{escaped_n}\s*{relationship}\s*({_LESSON_NUMBER_PATTERN})",
+        rf"(?<!\d){escaped_n}(?!\d)\s*的阶乘\s*{relationship}\s*"
+        rf"({_LESSON_NUMBER_PATTERN})",
+    )
+    values: list[float] = []
+    for pattern in patterns:
+        values.extend(
+            float(match.group(1))
+            for match in re.finditer(pattern, evidence, flags=re.IGNORECASE)
+        )
+    return values
+
+
+def _format_lesson_number(value: float) -> str:
+    return str(int(value)) if value.is_integer() else str(value)
+
+
+def _lesson_plan_evidence(playbook: PlaybookScript) -> str:
+    evidence: list[str] = [playbook.title, playbook.summary]
+    for step in playbook.steps:
+        evidence.extend((step.title, step.voiceover_text, step.snapshot.kind))
+        _collect_lesson_snapshot_evidence(
+            step.snapshot.model_dump(mode="json", exclude_none=True),
+            evidence,
+        )
+    return " ".join(evidence).casefold()
+
+
+_LESSON_VISUAL_STRUCTURAL_FIELDS = frozenset(
+    {
+        "active_line",
+        "active_lines",
+        "active_node_ids",
+        "code_trace",
+        "current_frame_id",
+        "current_node_id",
+        "curves",
+        "edges",
+        "frames",
+        "frontier_node_ids",
+        "marker_x",
+        "nodes",
+        "objects",
+        "path_points",
+        "points",
+        "queue_node_ids",
+        "segments",
+        "trail",
+        "trajectory",
+        "vectors",
+        "visited_node_ids",
+    }
+)
+_LESSON_VISUAL_DRAWABLE_FIELDS = frozenset(
+    {"curves", "edges", "frames", "nodes", "objects", "points", "segments", "vectors"}
+)
+
+
+def _lesson_plan_visual_tokens(playbook: PlaybookScript) -> set[str]:
+    tokens: set[str] = set()
+    for step in playbook.steps:
+        tokens.add(step.snapshot.kind.casefold())
+        _collect_lesson_visual_snapshot_tokens(
+            step.snapshot.model_dump(mode="json", exclude_none=True),
+            tokens,
+        )
+    return tokens
+
+
+def _lesson_plan_final_evidence(playbook: PlaybookScript) -> str:
+    if not playbook.steps:
+        return ""
+    final_step = playbook.steps[-1]
+    evidence = [final_step.title, final_step.voiceover_text, final_step.snapshot.kind]
+    _collect_lesson_snapshot_evidence(
+        final_step.snapshot.model_dump(mode="json", exclude_none=True),
+        evidence,
+    )
+    return "\n".join(evidence).casefold()
+
+
+def _collect_lesson_snapshot_evidence(value: Any, evidence: list[str]) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if _has_lesson_semantic_value(child):
+                evidence.append(str(key))
+            _collect_lesson_snapshot_evidence(child, evidence)
+    elif isinstance(value, list):
+        for child in value:
+            _collect_lesson_snapshot_evidence(child, evidence)
+    elif isinstance(value, str) and value.strip():
+        evidence.append(value)
+
+
+def _collect_lesson_visual_snapshot_tokens(
+    value: Any,
+    tokens: set[str],
+    *,
+    inside_drawable: bool = False,
+) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            normalized_key = key.casefold()
+            if normalized_key == "formula_latex" and isinstance(child, str):
+                if re.search(r"(?:\bm\b|m[_({]|f\s*['′])", child, flags=re.IGNORECASE):
+                    tokens.add("slope")
+                continue
+            if normalized_key in _LESSON_VISUAL_STRUCTURAL_FIELDS:
+                if _has_lesson_semantic_value(child):
+                    tokens.add(normalized_key)
+                if normalized_key in _LESSON_VISUAL_DRAWABLE_FIELDS:
+                    _collect_lesson_visual_snapshot_tokens(
+                        child,
+                        tokens,
+                        inside_drawable=True,
+                    )
+                continue
+            if inside_drawable and normalized_key in {"id", "label", "semantic_role", "state"}:
+                if isinstance(child, str) and child.strip():
+                    _add_lesson_visual_drawable_token(child, tokens)
+                continue
+            if inside_drawable and normalized_key == "variables" and isinstance(child, dict):
+                tokens.update(str(variable).casefold() for variable in child)
+                continue
+            if isinstance(child, (dict, list)):
+                _collect_lesson_visual_snapshot_tokens(
+                    child,
+                    tokens,
+                    inside_drawable=inside_drawable,
+                )
+    elif isinstance(value, list):
+        for child in value:
+            _collect_lesson_visual_snapshot_tokens(
+                child,
+                tokens,
+                inside_drawable=inside_drawable,
+            )
+
+
+def _add_lesson_visual_drawable_token(value: str, tokens: set[str]) -> None:
+    normalized = value.strip().casefold()
+    tokens.add(normalized)
+    for aliases in _LESSON_VISUAL_ROLE_ALIASES.values():
+        for alias in aliases:
+            normalized_alias = alias.casefold()
+            if normalized_alias == "g":
+                if normalized == normalized_alias:
+                    tokens.add(normalized_alias)
+            elif normalized_alias in normalized:
+                tokens.add(normalized_alias)
+
+
+def _has_lesson_semantic_value(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, dict)):
+        return bool(value)
+    return value is not None
+
+
+def _contains_lesson_alias(evidence: str, aliases: tuple[str, ...]) -> bool:
+    return any(alias.casefold() in evidence for alias in aliases)
+
+
+def _contains_lesson_visual_alias(tokens: set[str], aliases: tuple[str, ...]) -> bool:
+    return any(alias.casefold() in tokens for alias in aliases)
 
 
 def _tokens_for_snapshot(snapshot: Any) -> set[str]:

--- a/apps/api/app/domain/skills/base.py
+++ b/apps/api/app/domain/skills/base.py
@@ -4,6 +4,8 @@ from typing import Any, Literal, Protocol
 
 from pydantic import BaseModel, Field, model_validator
 
+from app.domain.models.lesson_plan import LessonPlan
+
 SkillExecutionMode = Literal[
     "deterministic",
     "llm_assisted",
@@ -56,11 +58,13 @@ class SkillExecutionContext(BaseModel):
     run_id: str
     prompt: str
     route_match: SkillRouteMatch | None = None
+    lesson_plan: LessonPlan | None = None
 
 
 class SkillExecutionResult(BaseModel):
     handled: bool
     playbook_json: str | None = None
+    lesson_plan: LessonPlan | None = None
     review_actions: list[str] = Field(default_factory=list)
     fallback_reason: str | None = None
 

--- a/apps/api/app/infrastructure/agent/codex_agent_provider.py
+++ b/apps/api/app/infrastructure/agent/codex_agent_provider.py
@@ -25,6 +25,12 @@ PlaybookScript schema. Do not edit files. Do not render video. The only valid
 rendering path is PlaybookScript consumed by the Remotion Player.
 
 Hard contract:
+- When the runtime payload includes lesson_plan, treat it as a binding,
+  read-only teaching contract. Preserve SceneIntent order and cover every
+  required fact, visual role, preferred scene type, narration goal, and
+  expected conclusion. A SceneIntent may expand into multiple Playbook steps.
+- Do not replace the LessonPlan teaching arc and do not copy LessonPlan fields
+  into the final PlaybookScript.
 - Use schema_version "1.0.0".
 - Use fps 30 unless the caller asks otherwise.
 - total_frames must be >= 1.
@@ -210,13 +216,21 @@ def _build_runtime_user_prompt(request: AgentRequest) -> str:
     runtime_payload = {
         "run_id": request.run_id,
         "route_decision": request.route_decision,
+        "lesson_plan": (
+            request.lesson_plan.model_dump(mode="json")
+            if request.lesson_plan is not None
+            else None
+        ),
         "constraints": request.constraints.model_dump(mode="json"),
         "tools": [tool.model_dump(mode="json") for tool in request.available_tools],
         "note": (
-            "Codex can inspect these runtime tool manifests, but this provider "
-            "cannot execute tools yet. Prefer deterministic tool results when "
-            "they are already present in the prompt; do not invent exact "
-            "validator or kernel outputs."
+            "The lesson_plan is binding when present: preserve SceneIntent order "
+            "and cover its required facts, visual roles, narration goals, and "
+            "expected conclusion without embedding it in PlaybookScript. Codex "
+            "can inspect these runtime tool manifests, but this provider cannot "
+            "execute tools yet. Prefer deterministic tool results when they are "
+            "already present in the prompt; do not invent exact validator or "
+            "kernel outputs."
         ),
     }
     return (

--- a/apps/api/app/infrastructure/persistence/db_init.py
+++ b/apps/api/app/infrastructure/persistence/db_init.py
@@ -15,12 +15,14 @@ def _create_pipeline_runs(conn: sqlite3.Connection) -> None:
             error       TEXT,
             review_json TEXT,
             quality_report_json TEXT,
+            lesson_plan_json TEXT,
             created_at  TEXT NOT NULL,
             FOREIGN KEY(user_id) REFERENCES accounts(user_id)
         )
     """)
     _add_column_if_missing(conn, "pipeline_runs", "user_id", "TEXT")
     _add_column_if_missing(conn, "pipeline_runs", "quality_report_json", "TEXT")
+    _add_column_if_missing(conn, "pipeline_runs", "lesson_plan_json", "TEXT")
     conn.execute("""
         CREATE TABLE IF NOT EXISTS pipeline_run_followups (
             followup_id    TEXT PRIMARY KEY,

--- a/apps/api/app/infrastructure/persistence/sqlite_run_repository.py
+++ b/apps/api/app/infrastructure/persistence/sqlite_run_repository.py
@@ -7,6 +7,7 @@ import sqlite3
 
 from app.application.dto.followup_dto import RunFollowUpRecord, RunVersionRecord
 from app.application.dto.pipeline_dto import PipelineRunResponse
+from app.domain.models.lesson_plan import LessonPlan
 from app.domain.models.pipeline_run import PipelineRunStatus
 from app.domain.models.playbook import PlaybookScript
 from app.domain.models.quality_report import QualityReport
@@ -99,6 +100,17 @@ class SqliteRunRepository:
                 conn.execute(
                     "UPDATE pipeline_runs SET quality_report_json=? WHERE run_id=?",
                     (quality_report_json, run_id),
+                )
+                conn.commit()
+
+        await asyncio.to_thread(_sync)
+
+    async def update_lesson_plan(self, run_id: str, lesson_plan_json: str) -> None:
+        def _sync() -> None:
+            with self._connect() as conn:
+                conn.execute(
+                    "UPDATE pipeline_runs SET lesson_plan_json=? WHERE run_id=?",
+                    (lesson_plan_json, run_id),
                 )
                 conn.commit()
 
@@ -368,6 +380,9 @@ def _row_to_response(row: sqlite3.Row) -> PipelineRunResponse:
     quality_report = None
     if "quality_report_json" in row.keys() and row["quality_report_json"]:
         quality_report = QualityReport.model_validate_json(row["quality_report_json"])
+    lesson_plan = None
+    if "lesson_plan_json" in row.keys() and row["lesson_plan_json"]:
+        lesson_plan = LessonPlan.model_validate_json(row["lesson_plan_json"])
     return PipelineRunResponse(
         run_id=row["run_id"],
         status=PipelineRunStatus(row["status"]),
@@ -377,6 +392,7 @@ def _row_to_response(row: sqlite3.Row) -> PipelineRunResponse:
         created_at=row["created_at"],
         review=review,
         quality_report=quality_report,
+        lesson_plan=lesson_plan,
     )
 
 

--- a/apps/api/tests/test_agent_provider_contract.py
+++ b/apps/api/tests/test_agent_provider_contract.py
@@ -8,6 +8,7 @@ from app.application.agent.types import (
     AgentResult,
     ToolManifest,
 )
+from app.domain.models.lesson_plan import LessonPlan, SceneIntent
 
 
 @pytest.mark.asyncio
@@ -16,6 +17,8 @@ async def test_agent_provider_run_contract_uses_wide_request_shape() -> None:
         async def run(self, request: AgentRequest) -> AgentResult:
             assert request.run_id == "run-contract"
             assert request.route_decision["destination"] == "generic_cir"
+            assert request.lesson_plan is not None
+            assert request.lesson_plan.title == "Line lesson plan"
             assert request.available_tools[0].name == "playbook.schema.validate"
             return AgentResult(
                 playbook={"title": "ok"},
@@ -26,12 +29,34 @@ async def test_agent_provider_run_contract_uses_wide_request_shape() -> None:
                 artifacts={},
             )
 
+    lesson_plan = LessonPlan(
+        schema_version="1.0.0",
+        domain="math",
+        title="Line lesson plan",
+        learning_objectives=["Explain the line y=x."],
+        prerequisites=["Know x and y coordinates."],
+        misconceptions=["The line contains only the origin."],
+        expected_conclusion="Every point on y=x has equal coordinates.",
+        lesson_arc="intuition_to_abstraction",
+        scenes=[
+            SceneIntent(
+                scene_id="line",
+                teaching_goal="Plot representative points on y=x.",
+                strategy="demonstration",
+                required_fact_ids=["line_identity"],
+                required_visual_roles=["axis", "line"],
+                preferred_scene_type="line_graph",
+                narration_goal="Connect equal coordinates to the diagonal line.",
+            )
+        ],
+    )
     request = AgentRequest(
         run_id="run-contract",
         prompt="explain y=x",
         source_code=None,
         language=None,
         route_decision={"destination": "generic_cir"},
+        lesson_plan=lesson_plan,
         provider_config={"model": "test-model"},
         playbook_schema={"type": "object"},
         constraints=AgentConstraints(max_self_repair_attempts=2),

--- a/apps/api/tests/test_cir_prompt.py
+++ b/apps/api/tests/test_cir_prompt.py
@@ -1,3 +1,4 @@
+from app.application.services.lesson_planner import build_rule_based_lesson_plan
 from app.domain.models.topic import TopicDomain
 from app.domain.services.cir_prompt import build_cir_prompt
 from app.domain.services.domain_router import SkillMode
@@ -13,6 +14,23 @@ def test_user_prompt_equals_original_input() -> None:
     prompt = "请可视化二分查找"
     _, user = build_cir_prompt(prompt, TopicDomain.ALGORITHM)
     assert user == prompt
+
+
+def test_canonical_lesson_plan_guides_cir_without_changing_user_prompt() -> None:
+    prompt = "用 BFS 解释广度优先遍历为什么需要队列"
+    lesson_plan = build_rule_based_lesson_plan(prompt=prompt, domain="algorithm")
+
+    system, user = build_cir_prompt(
+        prompt,
+        TopicDomain.ALGORITHM,
+        lesson_plan=lesson_plan,
+    )
+
+    assert user == prompt
+    assert "Canonical LessonPlan" in system
+    assert '"preferred_scene_type": "bfs_graph"' in system
+    assert '"required_fact_ids"' in system
+    assert "Do not copy LessonPlan into renderer payloads" in system
 
 
 def test_system_prompt_contains_domain_hint() -> None:

--- a/apps/api/tests/test_codex_agent_provider.py
+++ b/apps/api/tests/test_codex_agent_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 import types
 from pathlib import Path
@@ -11,6 +12,7 @@ import pytest
 
 from app.application.agent.types import AgentConstraints, AgentRequest, ToolManifest
 from app.application.ports.agent_provider import AgentProviderError
+from app.domain.models.lesson_plan import LessonPlan, SceneIntent
 from app.domain.models.playbook import PlaybookScript
 from app.infrastructure.agent.codex_agent_provider import (
     CodexAgentProvider,
@@ -50,6 +52,30 @@ _PLAYBOOK_JSON = """{
   ],
   "parameter_controls": []
 }"""
+
+
+def _lesson_plan() -> LessonPlan:
+    return LessonPlan(
+        schema_version="1.0.0",
+        domain="math",
+        title="LESSON_PLAN_ONLY_MARKER",
+        learning_objectives=["Connect a line equation to its graph."],
+        prerequisites=["Know the coordinate plane."],
+        misconceptions=["A line equation describes only one point."],
+        expected_conclusion="The graph of y=x is a straight line through the origin.",
+        lesson_arc="intuition_to_abstraction",
+        scenes=[
+            SceneIntent(
+                scene_id="line_graph",
+                teaching_goal="Relate equal x and y values to the diagonal line.",
+                strategy="demonstration",
+                required_fact_ids=["line_identity"],
+                required_visual_roles=["axis", "line"],
+                preferred_scene_type="line_graph",
+                narration_goal="Explain why every point on the line has x equal to y.",
+            )
+        ],
+    )
 
 
 class _FakeThread:
@@ -223,6 +249,7 @@ async def test_codex_provider_run_includes_tool_manifests_and_returns_agent_resu
             source_code=None,
             language=None,
             route_decision={"destination": "generic_cir"},
+            lesson_plan=_lesson_plan(),
             provider_config=None,
             playbook_schema={"type": "object"},
             constraints=AgentConstraints(max_self_repair_attempts=2),
@@ -242,8 +269,15 @@ async def test_codex_provider_run_includes_tool_manifests_and_returns_agent_resu
     prompt = fake.thread.run_calls[0]["input"]
     assert "[MetaView runtime tools]" in prompt
     assert "playbook.schema.validate" in prompt
+    assert '"lesson_plan"' in prompt
+    assert "lesson_plan is binding" in prompt
+    assert "LESSON_PLAN_ONLY_MARKER" in prompt
+    instructions = fake.thread_start_calls[0]["developer_instructions"]
+    assert "binding" in instructions
+    assert "Preserve SceneIntent order" in instructions
     assert result.provider == "codex"
     assert result.playbook["title"] == "Line"
+    assert "LESSON_PLAN_ONLY_MARKER" not in json.dumps(result.playbook)
     assert result.runtime_events[0]["event"] == "codex.tool_execution_unavailable"
 
 

--- a/apps/api/tests/test_http_agent_provider.py
+++ b/apps/api/tests/test_http_agent_provider.py
@@ -15,6 +15,7 @@ import pytest
 
 from app.application.agent.types import AgentConstraints, AgentRequest, ToolManifest
 from app.application.ports.agent_provider import AgentProviderError
+from app.domain.models.lesson_plan import LessonPlan, SceneIntent
 from app.infrastructure.agent.http_agent_provider import HttpAgentProvider
 
 
@@ -110,6 +111,27 @@ async def test_run_posts_wide_agent_request_and_returns_agent_result() -> None:
         )
 
     provider = _make_provider_with_handler(handler, shared_token="shared-secret")
+    lesson_plan = LessonPlan(
+        schema_version="1.0.0",
+        domain="math",
+        title="Line lesson plan",
+        learning_objectives=["Explain the line y=x."],
+        prerequisites=["Know x and y coordinates."],
+        misconceptions=["The line contains only the origin."],
+        expected_conclusion="Every point on y=x has equal coordinates.",
+        lesson_arc="intuition_to_abstraction",
+        scenes=[
+            SceneIntent(
+                scene_id="line",
+                teaching_goal="Plot representative points on y=x.",
+                strategy="demonstration",
+                required_fact_ids=["line_identity"],
+                required_visual_roles=["axis", "line"],
+                preferred_scene_type="line_graph",
+                narration_goal="Connect equal coordinates to the diagonal line.",
+            )
+        ],
+    )
     result = await provider.run(
         AgentRequest(
             run_id="run-http",
@@ -117,6 +139,7 @@ async def test_run_posts_wide_agent_request_and_returns_agent_result() -> None:
             source_code=None,
             language=None,
             route_decision={"destination": "generic_cir"},
+            lesson_plan=lesson_plan,
             provider_config={"model": "gpt-4o-mini"},
             playbook_schema={"type": "object"},
             constraints=AgentConstraints(max_self_repair_attempts=2),
@@ -136,6 +159,7 @@ async def test_run_posts_wide_agent_request_and_returns_agent_result() -> None:
     assert seen["prompt"] == "hello"
     assert seen["provider"] == {"model": "gpt-4o-mini"}
     assert seen["route_decision"] == {"destination": "generic_cir"}
+    assert seen["lesson_plan"] == lesson_plan.model_dump(mode="json")
     assert seen["playbook_schema"] == {"type": "object"}
     assert seen["available_tools"][0]["name"] == "playbook.schema.validate"
     assert result.provider == "pi"

--- a/apps/api/tests/test_legacy_cir_lesson_plan_adapter.py
+++ b/apps/api/tests/test_legacy_cir_lesson_plan_adapter.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from app.domain.models.cir import CirDocument, CirStep, LayoutInstruction, VisualToken
+from app.domain.models.topic import TopicDomain, VisualKind
+from app.domain.services.legacy_cir_lesson_plan_adapter import (
+    lesson_plan_from_legacy_cir,
+)
+
+
+def test_legacy_cir_adapter_keeps_teaching_semantics_without_renderer_fields() -> None:
+    cir = CirDocument(
+        title="Breadth-first traversal",
+        domain=TopicDomain.ALGORITHM,
+        summary="Use a FIFO queue to visit a graph level by level.",
+        steps=[
+            CirStep(
+                id="introduce",
+                title="Start from the root",
+                narration="Put {{root}} into the queue.",
+                visual_kind=VisualKind.GRAPH,
+                layout=LayoutInstruction(x=120, y=80, width=900, height=500),
+                tokens=[VisualToken(id="root", label="A")],
+                start_time=1.5,
+                end_time=4.0,
+            ),
+            CirStep(
+                id="finish",
+                title="Traversal complete",
+                narration=["The queue is empty.", {"t": "root"}, "was visited."],
+                visual_kind=VisualKind.TEXT,
+                tokens=[VisualToken(id="root", label="A")],
+            ),
+        ],
+    )
+
+    plan = lesson_plan_from_legacy_cir(cir)
+    payload = plan.model_dump(mode="json")
+
+    assert plan.domain == "algorithm"
+    assert plan.title == cir.title
+    assert plan.learning_objectives == [cir.summary]
+    assert plan.prerequisites == []
+    assert plan.misconceptions == []
+    assert plan.expected_conclusion == "The queue is empty. A was visited."
+    assert plan.lesson_arc == "state_transition"
+    assert [scene.scene_id for scene in plan.scenes] == ["introduce", "finish"]
+    assert plan.scenes[0].strategy == "intuition"
+    assert plan.scenes[0].required_visual_roles == ["graph_structure"]
+    assert plan.scenes[0].narration_goal == "Put A into the queue."
+    assert plan.scenes[1].strategy == "summary"
+    assert all(scene.required_fact_ids == [] for scene in plan.scenes)
+    assert all(scene.preferred_scene_type is None for scene in plan.scenes)
+    assert not {
+        "layout",
+        "x",
+        "y",
+        "width",
+        "height",
+        "start_time",
+        "end_time",
+        "layers",
+        "animation_calls",
+        "asset_id",
+        "snapshot",
+    } & _collect_keys(payload)
+
+
+def test_legacy_cir_adapter_infers_math_derivation_and_parses_json_narration() -> None:
+    cir = CirDocument(
+        title="Derivative",
+        domain=TopicDomain.MATH,
+        summary="Relate a derivative to tangent slope.",
+        steps=[
+            CirStep(
+                id="derive",
+                title="Take the limit",
+                narration='["Let the secant approach the tangent.", {"t": "slope"}]',
+                visual_kind=VisualKind.FORMULA,
+                tokens=[VisualToken(id="slope", label="The slope tends to 2.")],
+            )
+        ],
+    )
+
+    plan = lesson_plan_from_legacy_cir(cir)
+
+    assert plan.lesson_arc == "derivation"
+    assert plan.scenes[0].strategy == "derivation"
+    assert plan.scenes[0].narration_goal == (
+        "Let the secant approach the tangent. The slope tends to 2."
+    )
+
+
+def test_legacy_cir_adapter_represents_empty_cir_without_inventing_facts() -> None:
+    cir = CirDocument(
+        title="Concept review",
+        domain=TopicDomain.BIOLOGY,
+        summary="Review the concept honestly.",
+        steps=[],
+    )
+
+    plan = lesson_plan_from_legacy_cir(cir)
+
+    assert plan.expected_conclusion == cir.summary
+    assert len(plan.scenes) == 1
+    assert plan.scenes[0].scene_id == "legacy_summary"
+    assert plan.scenes[0].strategy == "summary"
+    assert plan.scenes[0].required_fact_ids == []
+
+
+def _collect_keys(value) -> set[str]:
+    if isinstance(value, dict):
+        return set(value) | {
+            nested for child in value.values() for nested in _collect_keys(child)
+        }
+    if isinstance(value, list):
+        return {nested for child in value for nested in _collect_keys(child)}
+    return set()

--- a/apps/api/tests/test_lesson_plan_contracts.py
+++ b/apps/api/tests/test_lesson_plan_contracts.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import copy
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from app.application.services.lesson_planner import build_rule_based_lesson_plan
+from app.domain.models import LessonPlan, SceneIntent
+from eval.benchmark_v2 import load_benchmark_v2_suite
+
+ROOT = Path(__file__).resolve().parents[3]
+LESSON_PLAN_DIR = ROOT / "eval" / "benchmark_v2" / "lesson_plans"
+LESSON_PLAN_SCHEMA = ROOT / "apps" / "web" / "public" / "schemas" / "lesson-plan.schema.json"
+STARTER_PROMPTS = ROOT / "eval" / "prompts" / "starter.yaml"
+WEB_PIPELINE_TYPES = ROOT / "apps" / "web" / "src" / "entities" / "pipeline" / "types.ts"
+
+LESSON_PLAN_FIELDS = {
+    "schema_version",
+    "domain",
+    "title",
+    "learning_objectives",
+    "prerequisites",
+    "misconceptions",
+    "expected_conclusion",
+    "lesson_arc",
+    "scenes",
+}
+SCENE_INTENT_FIELDS = {
+    "scene_id",
+    "teaching_goal",
+    "strategy",
+    "required_fact_ids",
+    "required_visual_roles",
+    "preferred_scene_type",
+    "narration_goal",
+}
+FORBIDDEN_RENDERER_FIELDS = {
+    "animation_hint",
+    "asset_id",
+    "asset_path",
+    "body",
+    "camera",
+    "end_frame",
+    "frame",
+    "height",
+    "layers",
+    "layout",
+    "path",
+    "renderer",
+    "snapshot",
+    "start_frame",
+    "svg",
+    "total_frames",
+    "width",
+    "x",
+    "y",
+    "z",
+}
+
+
+@pytest.fixture(scope="module")
+def raw_plans() -> dict[str, dict[str, Any]]:
+    return {
+        path.stem: json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(LESSON_PLAN_DIR.glob("*.json"))
+    }
+
+
+@pytest.fixture(scope="module")
+def plans(raw_plans: dict[str, dict[str, Any]]) -> dict[str, LessonPlan]:
+    return {case_id: LessonPlan.model_validate(payload) for case_id, payload in raw_plans.items()}
+
+
+def test_lesson_plan_models_are_public_domain_contracts() -> None:
+    assert LessonPlan.__module__ == "app.domain.models.lesson_plan"
+    assert SceneIntent.__module__ == "app.domain.models.lesson_plan"
+
+
+def test_public_lesson_plan_schema_is_generated_from_domain_contract() -> None:
+    stored_schema = json.loads(LESSON_PLAN_SCHEMA.read_text(encoding="utf-8"))
+
+    assert stored_schema == LessonPlan.model_json_schema()
+
+
+def test_web_lesson_plan_types_match_canonical_schema() -> None:
+    source = WEB_PIPELINE_TYPES.read_text(encoding="utf-8")
+    schema = LessonPlan.model_json_schema()
+    scene_schema = schema["$defs"]["SceneIntent"]
+
+    assert _typescript_union(source, "LessonArc") == set(
+        schema["properties"]["lesson_arc"]["enum"]
+    )
+    assert _typescript_union(source, "SceneTeachingStrategy") == set(
+        scene_schema["properties"]["strategy"]["enum"]
+    )
+    assert _typescript_interface_fields(source, "LessonPlan") == set(
+        schema["properties"]
+    )
+    assert _typescript_interface_fields(source, "SceneIntent") == set(
+        scene_schema["properties"]
+    )
+    assert _typescript_interface_contract(source, "LessonPlan") == {
+        "schema_version": (False, '"1.0.0"'),
+        "domain": (False, "string"),
+        "title": (False, "string"),
+        "learning_objectives": (False, "string[]"),
+        "prerequisites": (False, "string[]"),
+        "misconceptions": (False, "string[]"),
+        "expected_conclusion": (False, "string"),
+        "lesson_arc": (False, "LessonArc"),
+        "scenes": (False, "SceneIntent[]"),
+    }
+    assert _typescript_interface_contract(source, "SceneIntent") == {
+        "scene_id": (False, "string"),
+        "teaching_goal": (False, "string"),
+        "strategy": (False, "SceneTeachingStrategy"),
+        "required_fact_ids": (False, "string[]"),
+        "required_visual_roles": (False, "string[]"),
+        "preferred_scene_type": (False, "string|null"),
+        "narration_goal": (False, "string"),
+    }
+
+
+def test_gold_lesson_plan_files_match_benchmark_cases(
+    plans: dict[str, LessonPlan],
+) -> None:
+    suite = load_benchmark_v2_suite()
+
+    assert set(plans) == {case.id for case in suite.cases}
+
+
+def test_gold_lesson_plans_cover_benchmark_semantics(
+    plans: dict[str, LessonPlan],
+) -> None:
+    suite = load_benchmark_v2_suite()
+    for expectation in suite.cases:
+        _assert_plan_covers_expectation(plans[expectation.id], expectation)
+
+
+def test_production_rule_planner_covers_gold_benchmark_semantics() -> None:
+    raw = yaml.safe_load(STARTER_PROMPTS.read_text(encoding="utf-8"))
+    prompts = {item["id"]: item for item in raw["prompts"]}
+
+    for expectation in load_benchmark_v2_suite().cases:
+        item = prompts[expectation.id]
+        plan = build_rule_based_lesson_plan(
+            prompt=item["prompt"],
+            domain=item["domain"],
+        )
+        _assert_plan_covers_expectation(plan, expectation)
+
+
+def test_gold_lesson_plans_only_use_contract_fields(
+    raw_plans: dict[str, dict[str, Any]],
+) -> None:
+    for payload in raw_plans.values():
+        assert set(payload) == LESSON_PLAN_FIELDS
+        assert payload["scenes"]
+        assert all(set(scene) == SCENE_INTENT_FIELDS for scene in payload["scenes"])
+        assert not (_collect_keys(payload) & FORBIDDEN_RENDERER_FIELDS)
+
+
+def test_lesson_plan_rejects_extra_renderer_fields(
+    raw_plans: dict[str, dict[str, Any]],
+) -> None:
+    payload = copy.deepcopy(raw_plans["math-derivative-tangent"])
+    payload["scenes"][0]["asset_id"] = "must-not-enter-lesson-plan"
+
+    with pytest.raises(ValidationError, match="asset_id"):
+        LessonPlan.model_validate(payload)
+
+
+def test_lesson_plan_requires_unique_scene_ids(
+    raw_plans: dict[str, dict[str, Any]],
+) -> None:
+    payload = copy.deepcopy(raw_plans["algorithm-bfs-tree"])
+    payload["scenes"][1]["scene_id"] = payload["scenes"][0]["scene_id"]
+
+    with pytest.raises(ValidationError, match="scene_id values must be unique"):
+        LessonPlan.model_validate(payload)
+
+
+def test_lesson_plan_allows_honest_empty_legacy_lists(
+    raw_plans: dict[str, dict[str, Any]],
+) -> None:
+    payload = copy.deepcopy(raw_plans["math-derivative-tangent"])
+    payload["prerequisites"] = []
+    payload["misconceptions"] = []
+    payload["scenes"][0]["required_fact_ids"] = []
+    payload["scenes"][0]["required_visual_roles"] = []
+
+    plan = LessonPlan.model_validate(payload)
+
+    assert plan.prerequisites == []
+    assert plan.misconceptions == []
+    assert plan.scenes[0].required_fact_ids == []
+    assert plan.scenes[0].required_visual_roles == []
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("domain",), " "),
+        (("title",), " "),
+        (("learning_objectives",), []),
+        (("learning_objectives", 0), " "),
+        (("expected_conclusion",), " "),
+        (("scenes",), []),
+        (("scenes", 0, "scene_id"), " "),
+        (("scenes", 0, "teaching_goal"), " "),
+        (("scenes", 0, "required_fact_ids"), [" "]),
+        (("scenes", 0, "required_visual_roles"), [" "]),
+        (("scenes", 0, "preferred_scene_type"), " "),
+        (("scenes", 0, "narration_goal"), " "),
+    ],
+)
+def test_lesson_plan_rejects_blank_or_missing_semantics(
+    raw_plans: dict[str, dict[str, Any]],
+    path: tuple[str | int, ...],
+    value: Any,
+) -> None:
+    payload = copy.deepcopy(raw_plans["math-derivative-tangent"])
+    _set_path(payload, path, value)
+
+    with pytest.raises(ValidationError):
+        LessonPlan.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("schema_version",), "2.0.0"),
+        (("lesson_arc",), "cinematic"),
+        (("scenes", 0, "strategy"), "camera_pan"),
+    ],
+)
+def test_lesson_plan_rejects_unknown_versions_and_enums(
+    raw_plans: dict[str, dict[str, Any]],
+    path: tuple[str | int, ...],
+    value: Any,
+) -> None:
+    payload = copy.deepcopy(raw_plans["math-derivative-tangent"])
+    _set_path(payload, path, value)
+
+    with pytest.raises(ValidationError):
+        LessonPlan.model_validate(payload)
+
+
+def _collect_keys(value: Any) -> set[str]:
+    if isinstance(value, dict):
+        return set(value) | {
+            nested_key for child in value.values() for nested_key in _collect_keys(child)
+        }
+    if isinstance(value, list):
+        return {nested_key for child in value for nested_key in _collect_keys(child)}
+    return set()
+
+
+def _assert_plan_covers_expectation(plan: LessonPlan, expectation: Any) -> None:
+    fact_ids = {
+        fact_id for scene in plan.scenes for fact_id in scene.required_fact_ids
+    }
+    visual_roles = {
+        role for scene in plan.scenes for role in scene.required_visual_roles
+    }
+    scene_types = {
+        scene.preferred_scene_type
+        for scene in plan.scenes
+        if scene.preferred_scene_type is not None
+    }
+
+    assert plan.domain in expectation.expected_domains
+    assert {fact.id for fact in expectation.required_text_facts} <= fact_ids
+    assert set(expectation.required_semantic_roles) <= visual_roles
+    assert set(expectation.required_scene_types) <= scene_types
+
+    normalized_conclusion = plan.expected_conclusion.casefold()
+    for aliases in expectation.expected_conclusion.all_of:
+        assert any(alias.casefold() in normalized_conclusion for alias in aliases)
+    assert not any(
+        alias.casefold() in normalized_conclusion
+        for alias in expectation.expected_conclusion.none_of
+    )
+
+
+def _set_path(payload: Any, path: tuple[str | int, ...], value: Any) -> None:
+    target = payload
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+
+
+def _typescript_union(source: str, name: str) -> set[str]:
+    match = re.search(rf"export type {name}\s*=\s*(.*?);", source, flags=re.DOTALL)
+    assert match is not None
+    return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def _typescript_interface_fields(source: str, name: str) -> set[str]:
+    match = re.search(
+        rf"export interface {name}\s*\{{(.*?)\n\}}",
+        source,
+        flags=re.DOTALL,
+    )
+    assert match is not None
+    return set(re.findall(r"^\s{2}([a-z_]+)\??:", match.group(1), flags=re.MULTILINE))
+
+
+def _typescript_interface_contract(
+    source: str,
+    name: str,
+) -> dict[str, tuple[bool, str]]:
+    match = re.search(
+        rf"export interface {name}\s*\{{(.*?)\n\}}",
+        source,
+        flags=re.DOTALL,
+    )
+    assert match is not None
+    properties = re.findall(
+        r"^\s{2}([a-z_]+)(\??):\s*([^;]+);",
+        match.group(1),
+        flags=re.MULTILINE,
+    )
+    return {
+        field: (optional == "?", re.sub(r"\s+", "", type_text))
+        for field, optional, type_text in properties
+    }

--- a/apps/api/tests/test_lesson_plan_persistence.py
+++ b/apps/api/tests/test_lesson_plan_persistence.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from app.domain.models.lesson_plan import LessonPlan, SceneIntent
+from app.domain.models.pipeline_run import PipelineRunStatus
+from app.infrastructure.persistence.db_init import init_db
+from app.infrastructure.persistence.sqlite_run_repository import SqliteRunRepository
+
+
+def _lesson_plan() -> LessonPlan:
+    return LessonPlan(
+        schema_version="1.0.0",
+        domain="algorithm",
+        title="Breadth-first traversal",
+        learning_objectives=["Explain why BFS uses a FIFO queue."],
+        prerequisites=["Know what a graph node and edge are."],
+        misconceptions=["BFS follows one branch to its deepest node first."],
+        expected_conclusion="BFS visits the graph level by level using a FIFO queue.",
+        lesson_arc="state_transition",
+        scenes=[
+            SceneIntent(
+                scene_id="introduce_queue",
+                teaching_goal="Connect level-order traversal to a FIFO queue.",
+                strategy="intuition",
+                required_fact_ids=["bfs_fifo"],
+                required_visual_roles=["node", "edge", "queue"],
+                preferred_scene_type="bfs_graph",
+                narration_goal="Explain why newly discovered nodes wait at the queue tail.",
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_lesson_plan_round_trips_through_run_repository(tmp_path) -> None:
+    db_path = str(tmp_path / "lesson-plan.db")
+    init_db(db_path)
+    repo = SqliteRunRepository(db_path)
+    await repo.create("run-lesson", "Explain BFS", "2026-07-10T00:00:00+00:00")
+
+    plan = _lesson_plan()
+    await repo.update_lesson_plan("run-lesson", plan.model_dump_json())
+    await repo.update("run-lesson", status=PipelineRunStatus.RUNNING)
+
+    stored = await repo.get("run-lesson")
+    assert stored is not None
+    assert stored.lesson_plan == plan
+
+    listed = await repo.list()
+    assert len(listed) == 1
+    assert listed[0].lesson_plan == plan
+
+
+@pytest.mark.asyncio
+async def test_existing_run_without_lesson_plan_migrates_as_nullable(tmp_path) -> None:
+    db_path = str(tmp_path / "legacy-lesson-plan.db")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE pipeline_runs (
+                run_id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                prompt TEXT NOT NULL,
+                playbook_json TEXT,
+                error TEXT,
+                review_json TEXT,
+                created_at TEXT NOT NULL
+            )
+        """)
+        conn.execute(
+            "INSERT INTO pipeline_runs"
+            " (run_id, status, prompt, created_at) VALUES (?, ?, ?, ?)",
+            ("legacy-run", "succeeded", "Old prompt", "2026-07-09T00:00:00+00:00"),
+        )
+
+    init_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(pipeline_runs)")}
+        value = conn.execute(
+            "SELECT lesson_plan_json FROM pipeline_runs WHERE run_id=?",
+            ("legacy-run",),
+        ).fetchone()
+
+    assert "lesson_plan_json" in columns
+    assert value == (None,)
+
+    stored = await SqliteRunRepository(db_path).get("legacy-run")
+    assert stored is not None
+    assert stored.lesson_plan is None

--- a/apps/api/tests/test_lesson_planner.py
+++ b/apps/api/tests/test_lesson_planner.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import pytest
+
+from app.application.services.lesson_planner import (
+    LessonPlanningError,
+    LLMAssistedLessonPlanner,
+    RuleBasedLessonPlanner,
+    build_rule_based_lesson_plan,
+)
+from app.domain.models.route_decision import RouteDecision
+
+
+class _ReturningLLM:
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls: list[tuple[str, str]] = []
+
+    async def complete(self, system: str, user: str) -> str:
+        self.calls.append((system, user))
+        return self.response
+
+
+def test_rule_planner_is_deterministic_and_selects_known_capability() -> None:
+    kwargs = {
+        "prompt": "用 BFS 解释为什么广度优先遍历需要队列",
+        "domain": "algorithm",
+        "title": "BFS 与队列",
+    }
+
+    first = build_rule_based_lesson_plan(**kwargs)
+    second = build_rule_based_lesson_plan(**kwargs)
+
+    assert first == second
+    assert first.domain == "algorithm"
+    assert first.lesson_arc == "state_transition"
+    assert first.title == "BFS 与队列"
+    assert [scene.strategy for scene in first.scenes] == [
+        "intuition",
+        "demonstration",
+        "state_transition",
+        "summary",
+    ]
+    assert {
+        scene.preferred_scene_type
+        for scene in first.scenes
+        if scene.preferred_scene_type is not None
+    } == {"bfs_graph"}
+    assert {"breadth_first", "queue", "visited", "order"} <= {
+        fact_id for scene in first.scenes for fact_id in scene.required_fact_ids
+    }
+    assert {"node", "edge", "current_node", "visited", "queue"} <= {
+        role for scene in first.scenes for role in scene.required_visual_roles
+    }
+    assert "先进先出" in first.expected_conclusion
+
+
+@pytest.mark.asyncio
+async def test_rule_planner_infers_domain_without_fixture_io() -> None:
+    planner = RuleBasedLessonPlanner()
+
+    plan = await planner.plan(prompt="解释导数与切线斜率的关系")
+
+    assert plan.domain == "math"
+    assert plan.scenes[1].preferred_scene_type == "derivative_tangent"
+    assert plan.scenes[2].strategy == "derivation"
+
+
+@pytest.mark.asyncio
+async def test_rule_planner_uses_honest_general_domain_for_unknown_topic() -> None:
+    planner = RuleBasedLessonPlanner()
+
+    plan = await planner.plan(prompt="解释这个新概念")
+
+    assert plan.domain == "general"
+    assert plan.lesson_arc == "problem_to_solution"
+    assert all(scene.preferred_scene_type is None for scene in plan.scenes)
+
+
+def test_rule_planner_uses_resolved_route_capability() -> None:
+    route = RouteDecision(
+        destination="deterministic_skill",
+        domain="math",
+        skill_id="calculus_core",
+        confidence=0.95,
+        matched_capability="calculus_core.derivative",
+        problem_spec={
+            "task": "derivative",
+            "expression": "x^2",
+            "variable": "x",
+        },
+    )
+
+    plan = build_rule_based_lesson_plan(
+        prompt="求 d/dx (x^2)",
+        domain="math",
+        route_decision=route,
+    )
+
+    assert {"derivative", "tangent", "slope"} <= {
+        fact_id for scene in plan.scenes for fact_id in scene.required_fact_ids
+    }
+    assert plan.scenes[1].preferred_scene_type == "derivative_tangent"
+    assert "导数为 2x" in plan.expected_conclusion
+
+
+@pytest.mark.parametrize(
+    ("prompt", "domain", "scene_type", "facts", "roles", "conclusion_term"),
+    [
+        (
+            "解释导数与切线斜率",
+            "math",
+            "derivative_tangent",
+            {"derivative", "tangent", "slope"},
+            {"curve", "target_point", "secant", "tangent", "slope"},
+            "切线斜率",
+        ),
+        (
+            "用 BFS 遍历图",
+            "algorithm",
+            "bfs_graph",
+            {"breadth_first", "queue", "visited", "order"},
+            {"node", "edge", "current_node", "visited", "queue"},
+            "先进先出",
+        ),
+        (
+            "追踪 factorial 的递归调用栈",
+            "code",
+            "recursion_stack",
+            {
+                "factorial",
+                "base_case",
+                "recursive_call",
+                "return_unwind",
+                "factorial_result",
+            },
+            {"stack_frame", "active_frame", "code_line", "return_value"},
+            "乘法",
+        ),
+        (
+            "解释平抛运动",
+            "physics",
+            "projectile_motion",
+            {"horizontal_velocity", "vertical_velocity", "gravity", "parabolic"},
+            {
+                "object",
+                "trajectory",
+                "horizontal_velocity",
+                "vertical_velocity",
+                "gravity",
+            },
+            "抛物线",
+        ),
+    ],
+)
+def test_rule_planner_adds_capability_semantics(
+    prompt: str,
+    domain: str,
+    scene_type: str,
+    facts: set[str],
+    roles: set[str],
+    conclusion_term: str,
+) -> None:
+    plan = build_rule_based_lesson_plan(prompt=prompt, domain=domain)
+
+    assert scene_type in {
+        scene.preferred_scene_type
+        for scene in plan.scenes
+        if scene.preferred_scene_type is not None
+    }
+    assert facts <= {
+        fact_id for scene in plan.scenes for fact_id in scene.required_fact_ids
+    }
+    assert roles <= {
+        role for scene in plan.scenes for role in scene.required_visual_roles
+    }
+    assert conclusion_term in plan.expected_conclusion
+    assert len(plan.misconceptions) >= 2
+
+
+@pytest.mark.asyncio
+async def test_llm_assisted_planner_refines_and_validates_rule_draft() -> None:
+    draft = build_rule_based_lesson_plan(
+        prompt="解释平抛运动",
+        domain="physics",
+    )
+    refined = draft.model_copy(
+        update={
+            "expected_conclusion": "水平速度保持不变，竖直速度受重力持续改变。",
+        }
+    )
+    llm = _ReturningLLM(f"```json\n{refined.model_dump_json()}\n```")
+    planner = LLMAssistedLessonPlanner(llm)
+
+    plan = await planner.plan(prompt="解释平抛运动", domain="physics")
+
+    assert plan.expected_conclusion == refined.expected_conclusion
+    assert plan.domain == "physics"
+    assert len(llm.calls) == 1
+    system, user = llm.calls[0]
+    assert "Do not include coordinates" in system
+    assert "Deterministic draft" in user
+    assert "LessonPlan JSON schema" in user
+
+
+@pytest.mark.asyncio
+async def test_llm_assisted_planner_fails_closed_on_invalid_output() -> None:
+    planner = LLMAssistedLessonPlanner(_ReturningLLM("not json"))
+
+    with pytest.raises(LessonPlanningError, match="invalid JSON"):
+        await planner.plan(prompt="解释牛顿第二定律", domain="physics")
+
+
+@pytest.mark.asyncio
+async def test_llm_assisted_planner_rejects_domain_drift() -> None:
+    draft = build_rule_based_lesson_plan(prompt="解释导数", domain="math")
+    changed = draft.model_copy(update={"domain": "physics"})
+    planner = LLMAssistedLessonPlanner(_ReturningLLM(changed.model_dump_json()))
+
+    with pytest.raises(LessonPlanningError, match="changed the resolved lesson domain"):
+        await planner.plan(prompt="解释导数", domain="math")

--- a/apps/api/tests/test_playbook_review_self_check.py
+++ b/apps/api/tests/test_playbook_review_self_check.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 import pytest
 
+from app.application.services.lesson_planner import build_rule_based_lesson_plan
 from app.domain.models.playbook import PlaybookScript
 from app.domain.models.review import PlaybookReviewStatus
 from app.domain.services.playbook_quality import quality_gate_playbook
@@ -133,11 +134,354 @@ def _bfs_playbook(*, skip_f_checkpoint: bool = False, include_code_sync: bool = 
     )
 
 
+def _derivative_playbook(
+    *,
+    final_value: str = "2",
+    include_secant: bool = True,
+    include_early_correct_conclusion: bool = False,
+) -> PlaybookScript:
+    payload = _valid_playbook().model_dump(mode="json")
+    payload["domain"] = "math"
+    payload["title"] = "从割线到切线"
+    payload["summary"] = "观察割线靠近目标点，再得到切线斜率。"
+    for index, step in enumerate(payload["steps"]):
+        is_final = index == len(payload["steps"]) - 1
+        curves = [
+            {
+                "expression": "x^2",
+                "label": "y=x²",
+                "semantic_role": "curve",
+            }
+        ]
+        if is_final:
+            curves.append(
+                {
+                    "expression": f"{final_value}*x-1",
+                    "label": f"切线斜率 = {final_value}",
+                    "semantic_role": "tangent",
+                }
+            )
+            formula = f"f'(1)={final_value}"
+            voiceover = f"最终导数与切线斜率都等于 {final_value}。"
+        else:
+            if include_secant:
+                curves.append(
+                    {
+                        "expression": "(2+h)*x-(1+h)",
+                        "label": "comparison line" if index else "割线斜率 = 2+h",
+                        "semantic_role": "secant",
+                    }
+                )
+            formula = "f'(1)=2" if include_early_correct_conclusion and index == 0 else "m_h=2+h"
+            voiceover = "让割线逐步靠近目标点，观察斜率的变化。"
+        snapshot = {
+            "kind": "math_plot",
+            "curves": curves,
+            "params": {"h": max(0.1, 1 - index / 10)},
+            "marker_x": 1,
+            "formula_latex": formula,
+            "caption": "目标点是 (1,1)。",
+        }
+        step["title"] = "总结" if is_final else f"割线状态 {index + 1}"
+        step["voiceover_text"] = voiceover
+        step["snapshot"] = deepcopy(snapshot)
+        step["layers"] = [{"body": deepcopy(snapshot)}]
+        step["code_highlight"] = None
+    return PlaybookScript.model_validate(payload)
+
+
 def test_playbook_self_check_returns_clean_for_renderer_ready_script() -> None:
     verdict = review_playbook_script(_valid_playbook(), prompt="Explain binary search.")
 
     assert verdict.status == PlaybookReviewStatus.CLEAN
     assert verdict.issues == []
+
+
+def test_canonical_gate_blocks_playbook_that_ignores_lesson_plan() -> None:
+    lesson_plan = build_rule_based_lesson_plan(
+        prompt="用二叉树演示广度优先遍历的访问顺序，逐层点亮节点。",
+        domain="algorithm",
+    )
+
+    report = quality_gate_playbook(
+        _valid_playbook(),
+        "Explain binary search.",
+        generator_path="test",
+        lesson_plan=lesson_plan,
+    )
+
+    assert report.status == "repairable"
+    assert {issue.code for issue in report.issues} >= {
+        "lesson_plan.fact_missing",
+        "lesson_plan.visual_role_missing",
+        "lesson_plan.scene_type_missing",
+    }
+
+
+def test_canonical_gate_accepts_playbook_with_lesson_plan_evidence() -> None:
+    prompt = "用二叉树演示广度优先遍历的访问顺序，逐层点亮节点。"
+    lesson_plan = build_rule_based_lesson_plan(prompt=prompt, domain="algorithm")
+
+    report = quality_gate_playbook(
+        _bfs_playbook(),
+        prompt,
+        generator_path="test",
+        lesson_plan=lesson_plan,
+    )
+
+    assert not any(issue.code.startswith("lesson_plan.") for issue in report.issues)
+
+
+def test_lesson_plan_visual_role_cannot_be_satisfied_by_narration_only() -> None:
+    prompt = "用图像解释曲线 y=x^2 在点 (1,1) 处的导数，从割线过渡到切线。"
+    payload = _derivative_playbook(include_secant=False).model_dump(mode="json")
+    for step in payload["steps"]:
+        step["snapshot"]["params"]["secant"] = 1.0
+        step["snapshot"]["caption"] = "这里只讨论割线，快照中没有对应曲线。"
+        step["layers"] = [{"body": deepcopy(step["snapshot"])}]
+    report = quality_gate_playbook(
+        PlaybookScript.model_validate(payload),
+        prompt,
+        generator_path="test",
+        lesson_plan=build_rule_based_lesson_plan(prompt=prompt, domain="math"),
+    )
+
+    missing_paths = {
+        issue.path
+        for issue in report.issues
+        if issue.code == "lesson_plan.visual_role_missing"
+    }
+    assert "lesson_plan.required_visual_roles.secant" in missing_paths
+
+
+def test_lesson_plan_conclusion_does_not_match_numeric_prefix() -> None:
+    prompt = "用图像解释曲线 y=x^2 在点 (1,1) 处的导数，从割线过渡到切线。"
+    report = quality_gate_playbook(
+        _derivative_playbook(final_value="2.5"),
+        prompt,
+        generator_path="test",
+        lesson_plan=build_rule_based_lesson_plan(prompt=prompt, domain="math"),
+    )
+
+    assert "lesson_plan.conclusion_conflict" in {issue.code for issue in report.issues}
+
+
+@pytest.mark.parametrize("expression", ["2+1", "2 / 10"])
+def test_lesson_plan_conclusion_rejects_unevaluated_expression(expression: str) -> None:
+    prompt = "用图像解释曲线 y=x^2 在点 (1,1) 处的导数，从割线过渡到切线。"
+    report = quality_gate_playbook(
+        _derivative_playbook(final_value=expression),
+        prompt,
+        generator_path="test",
+        lesson_plan=build_rule_based_lesson_plan(prompt=prompt, domain="math"),
+    )
+
+    assert "lesson_plan.conclusion_missing" in {issue.code for issue in report.issues}
+
+
+def test_lesson_plan_conclusion_ignores_negated_value() -> None:
+    prompt = "用图像解释曲线 y=x^2 在点 (1,1) 处的导数，从割线过渡到切线。"
+    payload = _derivative_playbook().model_dump(mode="json")
+    payload["steps"][-1]["voiceover_text"] = "最终导数不等于 3，而是 2。"
+    playbook = PlaybookScript.model_validate(payload)
+    report = quality_gate_playbook(
+        playbook,
+        prompt,
+        generator_path="test",
+        lesson_plan=build_rule_based_lesson_plan(prompt=prompt, domain="math"),
+    )
+
+    assert "lesson_plan.conclusion_conflict" not in {issue.code for issue in report.issues}
+    assert "lesson_plan.conclusion_missing" not in {issue.code for issue in report.issues}
+
+
+def test_lesson_plan_conclusion_does_not_treat_coordinate_as_result() -> None:
+    prompt = "用图像解释曲线 y=x^2 在点 (1,1) 处的导数，从割线过渡到切线。"
+    payload = _derivative_playbook().model_dump(mode="json")
+    payload["steps"][-1]["voiceover_text"] = (
+        "切线斜率是 2。因为导数定义给出 x=1 处的瞬时斜率 m=2。"
+    )
+    report = quality_gate_playbook(
+        PlaybookScript.model_validate(payload),
+        prompt,
+        generator_path="test",
+        lesson_plan=build_rule_based_lesson_plan(prompt=prompt, domain="math"),
+    )
+
+    assert "lesson_plan.conclusion_conflict" not in {issue.code for issue in report.issues}
+
+
+def test_lesson_plan_conclusion_uses_final_scene_not_earlier_correct_value() -> None:
+    prompt = "用图像解释曲线 y=x^2 在点 (1,1) 处的导数，从割线过渡到切线。"
+    report = quality_gate_playbook(
+        _derivative_playbook(final_value="3", include_early_correct_conclusion=True),
+        prompt,
+        generator_path="test",
+        lesson_plan=build_rule_based_lesson_plan(prompt=prompt, domain="math"),
+    )
+
+    assert "lesson_plan.conclusion_conflict" in {issue.code for issue in report.issues}
+
+
+def test_lesson_plan_visual_roles_accept_canonical_recursion_snapshot_fields() -> None:
+    prompt = "逐行追踪 factorial(4) 的递归调用栈、压栈和回溯返回值。"
+    lesson_plan = build_rule_based_lesson_plan(prompt=prompt, domain="code")
+    payload = _valid_playbook().model_dump(mode="json")
+    payload["domain"] = "code"
+    payload["title"] = "factorial(4) 递归调用栈"
+    payload["summary"] = "展示 recursive call、base case 和 return unwind。"
+    for index, step in enumerate(payload["steps"]):
+        is_final = index == len(payload["steps"]) - 1
+        variables = {"n": "4", **({"return": "24"} if is_final else {})}
+        snapshot = {
+            "kind": "call_stack_scene",
+            "frames": [
+                {
+                    "id": "factorial-4",
+                    "label": "factorial(4)",
+                    "state": "returned" if is_final else "active",
+                    "variables": variables,
+                }
+            ],
+            "code_trace": {
+                "language": "python",
+                "lines": [
+                    "def factorial(n):",
+                    "    if n <= 1:  # base case",
+                    "        return 1",
+                    "    return n * factorial(n - 1)  # recursive call",
+                ],
+                "active_lines": [2 if is_final else 3],
+                "active_line": 2 if is_final else 3,
+            },
+            "current_frame_id": "factorial-4",
+            "caption": (
+                "阶乘结果 factorial(4)=24，返回值完成回溯。"
+                if is_final
+                else "递归调用进入 active frame，等待 return unwind。"
+            ),
+        }
+        step["title"] = "最终返回" if is_final else f"递归状态 {index + 1}"
+        step["voiceover_text"] = (
+            "factorial(4)=24，base case 返回后逐层回溯。"
+            if is_final
+            else "recursive call 创建栈帧，base case 后 return unwind。"
+        )
+        step["snapshot"] = deepcopy(snapshot)
+        step["layers"] = [{"body": deepcopy(snapshot)}]
+        step["code_highlight"] = {
+            "language": "python",
+            "lines": snapshot["code_trace"]["lines"],
+            "active_lines": snapshot["code_trace"]["active_lines"],
+            "active_line": snapshot["code_trace"]["active_line"],
+            "variables": variables,
+        }
+    report = quality_gate_playbook(
+        PlaybookScript.model_validate(payload),
+        prompt,
+        generator_path="test",
+        lesson_plan=lesson_plan,
+    )
+
+    assert not any(
+        issue.code == "lesson_plan.visual_role_missing" for issue in report.issues
+    )
+
+    for step in payload["steps"]:
+        frame = step["snapshot"]["frames"][0]
+        frame["state"] = "waiting"
+        frame["variables"].pop("return", None)
+        step["snapshot"]["caption"] = "调用栈仍包含 Python return 代码行。"
+        step["layers"] = [{"body": deepcopy(step["snapshot"])}]
+        step["code_highlight"]["variables"] = {"n": "4"}
+    missing_report = quality_gate_playbook(
+        PlaybookScript.model_validate(payload),
+        prompt,
+        generator_path="test",
+        lesson_plan=lesson_plan,
+    )
+
+    assert any(
+        issue.code == "lesson_plan.visual_role_missing"
+        and issue.path == "lesson_plan.required_visual_roles.return_value"
+        for issue in missing_report.issues
+    )
+
+
+def test_lesson_plan_visual_roles_accept_canonical_projectile_vector_fields() -> None:
+    prompt = "演示平抛运动：水平速度不变、竖直速度受重力改变，并画出抛物线轨迹。"
+    lesson_plan = build_rule_based_lesson_plan(prompt=prompt, domain="physics")
+    payload = _valid_playbook().model_dump(mode="json")
+    payload["domain"] = "physics"
+    payload["title"] = "平抛运动"
+    payload["summary"] = "水平速度和竖直速度在重力下合成抛物线轨迹。"
+    snapshot = {
+        "kind": "physics_force_scene",
+        "objects": [{"id": "projectile", "label": "抛体", "x": 14, "y": 22}],
+        "vectors": [
+            {
+                "id": "velocity-x",
+                "target": "projectile",
+                "semantic_role": "velocity",
+                "dx": 16,
+                "dy": 0,
+                "label": "v_x",
+            },
+            {
+                "id": "velocity-y",
+                "target": "projectile",
+                "semantic_role": "velocity",
+                "dx": 0,
+                "dy": 8,
+                "label": "v_y",
+            },
+            {
+                "id": "gravity",
+                "target": "projectile",
+                "semantic_role": "acceleration",
+                "dx": 0,
+                "dy": 12,
+                "label": "g",
+            },
+        ],
+        "trajectory": [[14, 22], [24, 24], [34, 30], [44, 40]],
+        "caption": "v_x 保持不变，v_y 受重力改变，轨迹为抛物线。",
+    }
+    for index, step in enumerate(payload["steps"]):
+        step["title"] = f"平抛状态 {index + 1}"
+        step["voiceover_text"] = "水平速度不变，竖直速度受重力改变并形成抛物线。"
+        step["snapshot"] = deepcopy(snapshot)
+        step["layers"] = [{"body": deepcopy(snapshot)}]
+        step["code_highlight"] = None
+    report = quality_gate_playbook(
+        PlaybookScript.model_validate(payload),
+        prompt,
+        generator_path="test",
+        lesson_plan=lesson_plan,
+    )
+
+    assert not any(
+        issue.code == "lesson_plan.visual_role_missing" for issue in report.issues
+    )
+
+    for step in payload["steps"]:
+        step["snapshot"]["vectors"] = [
+            vector for vector in step["snapshot"]["vectors"] if vector["id"] != "gravity"
+        ]
+        step["snapshot"]["caption"] = "v_x 与 v_y 合成 trajectory。"
+        step["layers"] = [{"body": deepcopy(step["snapshot"])}]
+    missing_report = quality_gate_playbook(
+        PlaybookScript.model_validate(payload),
+        prompt,
+        generator_path="test",
+        lesson_plan=lesson_plan,
+    )
+
+    assert any(
+        issue.code == "lesson_plan.visual_role_missing"
+        and issue.path == "lesson_plan.required_visual_roles.gravity"
+        for issue in missing_report.issues
+    )
 
 
 @pytest.mark.parametrize(

--- a/apps/api/tests/test_run_pipeline.py
+++ b/apps/api/tests/test_run_pipeline.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from app.application.dto.pipeline_dto import PipelineRequest
+from app.application.services.lesson_planner import build_rule_based_lesson_plan
 from app.application.use_cases.run_pipeline import RunPipelineUseCase, _strip_markdown_fences
 from app.domain.models.pipeline_run import PipelineRunStatus
 from app.infrastructure.persistence.db_init import init_db
@@ -57,6 +58,15 @@ class MockLLMSlow:
         return _VALID_CIR
 
 
+class SlowLessonPlanner:
+    async def plan(self, **kwargs):
+        await asyncio.sleep(0.08)
+        return build_rule_based_lesson_plan(
+            prompt=kwargs["prompt"],
+            domain=kwargs.get("domain"),
+        )
+
+
 class FailingDirectorRepository:
     async def upsert(self, director, updated_at: str) -> None:  # noqa: ARG002
         raise RuntimeError("director database unavailable")
@@ -94,6 +104,9 @@ async def test_successful_pipeline_run(repo) -> None:
         "timeline.voiceover_too_short"
     }
     assert result.quality_report.generator_path == "generic_cir"
+    assert result.lesson_plan is not None
+    assert result.lesson_plan.schema_version == "1.0.0"
+    assert result.lesson_plan.domain == "general"
 
 
 @pytest.mark.asyncio
@@ -142,12 +155,33 @@ async def test_failed_pipeline_run_on_invalid_json(repo) -> None:
     assert result is not None
     assert result.status == PipelineRunStatus.FAILED
     assert result.playbook is None
+    assert result.lesson_plan is not None
     assert result.error is not None
     assert result.quality_report is not None
     assert result.quality_report.status == "blocked"
     assert {issue.code for issue in result.quality_report.issues} >= {
         "parse.invalid_json"
     }
+
+
+@pytest.mark.asyncio
+async def test_pipeline_timeout_includes_lesson_planning(repo) -> None:
+    use_case = RunPipelineUseCase(
+        repo,
+        MockLLMSuccess(),
+        lesson_planner=SlowLessonPlanner(),
+        pipeline_timeout_s=0.01,
+    )
+    await repo.create("run-plan-timeout", "test prompt", "2024-01-01T00:00:00+00:00")
+
+    await use_case.execute("run-plan-timeout", PipelineRequest(prompt="test prompt"))
+
+    result = await repo.get("run-plan-timeout")
+    assert result is not None
+    assert result.status == PipelineRunStatus.FAILED
+    assert result.lesson_plan is None
+    assert result.quality_report is not None
+    assert {issue.code for issue in result.quality_report.issues} == {"pipeline.timeout"}
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_run_pipeline_agent_mode.py
+++ b/apps/api/tests/test_run_pipeline_agent_mode.py
@@ -25,6 +25,7 @@ class _RecordingRepo:
     def __init__(self) -> None:
         self.updates: list[dict[str, Any]] = []
         self.quality_reports: list[dict[str, Any]] = []
+        self.lesson_plans: list[dict[str, Any]] = []
 
     async def create(self, run_id: str, prompt: str, created_at: str) -> None:
         return None
@@ -41,6 +42,11 @@ class _RecordingRepo:
     async def update_quality_report(self, run_id: str, quality_report_json: str) -> None:
         self.quality_reports.append(
             {"run_id": run_id, "report": json.loads(quality_report_json)}
+        )
+
+    async def update_lesson_plan(self, run_id: str, lesson_plan_json: str) -> None:
+        self.lesson_plans.append(
+            {"run_id": run_id, "lesson_plan": json.loads(lesson_plan_json)}
         )
 
 
@@ -298,7 +304,8 @@ async def test_agent_mode_routes_to_agent_provider() -> None:
 
     await use_case.execute("run-1", PipelineRequest(prompt="hello math"))
 
-    assert agent.calls[0]["prompt"] == "hello math"
+    assert "[MetaView LessonPlan]" in agent.calls[0]["prompt"]
+    assert agent.calls[0]["prompt"].endswith("[user prompt]\nhello math")
     assert agent.calls[0]["provider_config"] is None
     assert agent.calls[0]["route_decision"]["destination"] == "generic_cir"
     # The final update must carry the persisted playbook JSON.
@@ -335,7 +342,10 @@ async def test_agent_mode_calls_wide_run_contract_when_available() -> None:
         reviewer_mode="off",
     )
 
-    await use_case.execute("run-wide", PipelineRequest(prompt="hello math"))
+    await use_case.execute(
+        "run-wide",
+        PipelineRequest(prompt="hello math", domain="math"),
+    )
 
     request = agent.requests[0]
     assert request.run_id == "run-wide"
@@ -343,6 +353,9 @@ async def test_agent_mode_calls_wide_run_contract_when_available() -> None:
     assert request.route_decision["destination"] == "generic_cir"
     assert request.playbook_schema["title"] == "PlaybookScript"
     assert "playbook.schema.validate" in {tool.name for tool in request.available_tools}
+    assert request.lesson_plan is not None
+    assert request.lesson_plan.domain == "math"
+    assert repo.lesson_plans[-1]["lesson_plan"] == request.lesson_plan.model_dump(mode="json")
     assert repo.updates[-1]["status"].value == "succeeded"
 
 

--- a/apps/api/tests/test_skill_pack_pipeline.py
+++ b/apps/api/tests/test_skill_pack_pipeline.py
@@ -27,12 +27,18 @@ class _RecordingRepo:
     def __init__(self) -> None:
         self.updates: list[dict[str, Any]] = []
         self.quality_reports: list[dict[str, Any]] = []
+        self.lesson_plans: list[dict[str, Any]] = []
 
     async def update(self, run_id: str, **kwargs: Any) -> None:
         self.updates.append({"run_id": run_id, **kwargs})
 
     async def update_quality_report(self, run_id: str, quality_report_json: str) -> None:
         self.quality_reports.append({"run_id": run_id, "report": json.loads(quality_report_json)})
+
+    async def update_lesson_plan(self, run_id: str, lesson_plan_json: str) -> None:
+        self.lesson_plans.append(
+            {"run_id": run_id, "lesson_plan": json.loads(lesson_plan_json)}
+        )
 
     @property
     def final_status(self) -> PipelineRunStatus:
@@ -100,6 +106,9 @@ class FakeSkillPack:
         ],
     )
 
+    def __init__(self) -> None:
+        self.contexts: list[SkillExecutionContext] = []
+
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         if "fake skill test" not in request.prompt:
             return None
@@ -119,6 +128,7 @@ class FakeSkillPack:
         context: SkillExecutionContext,
         problem_spec: BaseModel | None,
     ) -> SkillExecutionResult:
+        self.contexts.append(context)
         assert isinstance(problem_spec, FakeSpec)
         return SkillExecutionResult(
             handled=True,
@@ -249,7 +259,8 @@ async def test_solid_geometry_runs_through_skill_registry() -> None:
 
 @pytest.mark.asyncio
 async def test_new_skill_can_run_without_pipeline_changes() -> None:
-    registry = SkillRegistry([FakeSkillPack()])
+    skill = FakeSkillPack()
+    registry = SkillRegistry([skill])
     repo = _RecordingRepo()
     use_case = RunPipelineUseCase(repo, _FailingLLM(), skill_registry=registry)
 
@@ -258,6 +269,11 @@ async def test_new_skill_can_run_without_pipeline_changes() -> None:
     assert repo.final_status == PipelineRunStatus.SUCCEEDED
     assert "skill:fake_skill" in repo.review_json
     assert repo.quality_reports[-1]["report"]["status"] == "clean"
+    assert skill.contexts[0].lesson_plan is not None
+    assert skill.contexts[0].lesson_plan.domain == "math"
+    assert repo.lesson_plans[-1]["lesson_plan"] == (
+        skill.contexts[0].lesson_plan.model_dump(mode="json")
+    )
 
 
 @pytest.mark.asyncio

--- a/apps/web/public/schemas/lesson-plan.schema.json
+++ b/apps/web/public/schemas/lesson-plan.schema.json
@@ -1,0 +1,157 @@
+{
+  "$defs": {
+    "SceneIntent": {
+      "additionalProperties": false,
+      "description": "One pedagogical decision, without renderer or layout details.",
+      "properties": {
+        "scene_id": {
+          "minLength": 1,
+          "title": "Scene Id",
+          "type": "string"
+        },
+        "teaching_goal": {
+          "minLength": 1,
+          "title": "Teaching Goal",
+          "type": "string"
+        },
+        "strategy": {
+          "enum": [
+            "intuition",
+            "demonstration",
+            "derivation",
+            "comparison",
+            "state_transition",
+            "summary"
+          ],
+          "title": "Strategy",
+          "type": "string"
+        },
+        "required_fact_ids": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Required Fact Ids",
+          "type": "array"
+        },
+        "required_visual_roles": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Required Visual Roles",
+          "type": "array"
+        },
+        "preferred_scene_type": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Preferred Scene Type"
+        },
+        "narration_goal": {
+          "minLength": 1,
+          "title": "Narration Goal",
+          "type": "string"
+        }
+      },
+      "required": [
+        "scene_id",
+        "teaching_goal",
+        "strategy",
+        "required_fact_ids",
+        "required_visual_roles",
+        "preferred_scene_type",
+        "narration_goal"
+      ],
+      "title": "SceneIntent",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Renderer-independent teaching plan shared by every generation path.",
+  "properties": {
+    "schema_version": {
+      "const": "1.0.0",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "domain": {
+      "minLength": 1,
+      "title": "Domain",
+      "type": "string"
+    },
+    "title": {
+      "minLength": 1,
+      "title": "Title",
+      "type": "string"
+    },
+    "learning_objectives": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Learning Objectives",
+      "type": "array"
+    },
+    "prerequisites": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Prerequisites",
+      "type": "array"
+    },
+    "misconceptions": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Misconceptions",
+      "type": "array"
+    },
+    "expected_conclusion": {
+      "minLength": 1,
+      "title": "Expected Conclusion",
+      "type": "string"
+    },
+    "lesson_arc": {
+      "enum": [
+        "intuition_to_abstraction",
+        "problem_to_solution",
+        "state_transition",
+        "comparison",
+        "derivation"
+      ],
+      "title": "Lesson Arc",
+      "type": "string"
+    },
+    "scenes": {
+      "items": {
+        "$ref": "#/$defs/SceneIntent"
+      },
+      "minItems": 1,
+      "title": "Scenes",
+      "type": "array"
+    }
+  },
+  "required": [
+    "schema_version",
+    "domain",
+    "title",
+    "learning_objectives",
+    "prerequisites",
+    "misconceptions",
+    "expected_conclusion",
+    "lesson_arc",
+    "scenes"
+  ],
+  "title": "LessonPlan",
+  "type": "object"
+}

--- a/apps/web/src/entities/pipeline/types.ts
+++ b/apps/web/src/entities/pipeline/types.ts
@@ -34,6 +34,43 @@ export interface QualityReport {
   attempts: number;
 }
 
+export type LessonArc =
+  | "intuition_to_abstraction"
+  | "problem_to_solution"
+  | "state_transition"
+  | "comparison"
+  | "derivation";
+
+export type SceneTeachingStrategy =
+  | "intuition"
+  | "demonstration"
+  | "derivation"
+  | "comparison"
+  | "state_transition"
+  | "summary";
+
+export interface SceneIntent {
+  scene_id: string;
+  teaching_goal: string;
+  strategy: SceneTeachingStrategy;
+  required_fact_ids: string[];
+  required_visual_roles: string[];
+  preferred_scene_type: string | null;
+  narration_goal: string;
+}
+
+export interface LessonPlan {
+  schema_version: "1.0.0";
+  domain: string;
+  title: string;
+  learning_objectives: string[];
+  prerequisites: string[];
+  misconceptions: string[];
+  expected_conclusion: string;
+  lesson_arc: LessonArc;
+  scenes: SceneIntent[];
+}
+
 export type PipelineRunStatus =
   | "queued"
   | "running"
@@ -51,4 +88,5 @@ export interface PipelineRunResult {
   created_at: string;
   review?: ReviewReport | null;
   quality_report?: QualityReport | null;
+  lesson_plan?: LessonPlan | null;
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
 | [START_HERE.md](./START_HERE.md) | 当前唯一入门入口：产品主线、部署默认、Director/Playbook 边界、下一步优先级 |
 | [director-layer.md](./director-layer.md) | Director 独立导演层：运镜、节奏、镜头、强调、RenderPlan 和阶段路线 |
 | [pipeline.md](./pipeline.md) | single / agent 生成路径、PlaybookScript、DirectorScript 挂载点、视频导出管线 |
+| [lesson-plan.md](./lesson-plan.md) | 三条生成路径共享的教学规划契约、持久化、边界与当前限制 |
 | [quality-gate.md](./quality-gate.md) | 后端 Canonical QualityReport、修复、持久化、Director 与导出阻断语义 |
 | [frontend-shell.md](./frontend-shell.md) | Stage 路由、GlobalTopbar、Studio 布局、Provider 配置、snapshot support levels |
 | [animation-tool-registry.md](./animation-tool-registry.md) | 后端 animation tool registry 的扩展流程、当前工具和新增规则 |

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -12,7 +12,9 @@ The core pipeline is:
 
 ```text
 User input
-  -> subject understanding / router / SkillPack / agent
+  -> subject understanding / router
+  -> LessonPlan
+  -> SkillPack / agent / legacy CIR
   -> PlaybookScript
   -> canonical backend QualityReport
   -> DirectorScript
@@ -45,12 +47,13 @@ Agent mode is an active verification path, not the default production claim. To 
 
 1. `docs/director-layer.md` — Director as the independent shot-planning layer.
 2. `docs/pipeline.md` — generation modes, PlaybookScript, and export path.
-3. `docs/quality-gate.md` — backend success semantics, repair, persistence, and export recheck.
-4. `docs/benchmark-v2.md` — four Gold Cases and strict product-quality scoring.
-5. `docs/agent-demo-acceptance.md` — how to prove agent / runtime-tool mode actually works.
-6. `docs/skill-pack-architecture.md` — deterministic SkillPack contract.
-7. `docs/frontend-shell.md` — frontend page and studio shell structure.
-8. `AGENTS.md` — required working rules for coding agents.
+3. `docs/lesson-plan.md` — shared teaching decisions and the renderer-free contract.
+4. `docs/quality-gate.md` — backend success semantics, repair, persistence, and export recheck.
+5. `docs/benchmark-v2.md` — four Gold Cases and strict product-quality scoring.
+6. `docs/agent-demo-acceptance.md` — how to prove agent / runtime-tool mode actually works.
+7. `docs/skill-pack-architecture.md` — deterministic SkillPack contract.
+8. `docs/frontend-shell.md` — frontend page and studio shell structure.
+9. `AGENTS.md` — required working rules for coding agents.
 
 ## What not to do now
 
@@ -64,5 +67,5 @@ Agent mode is an active verification path, not the default production claim. To 
 
 1. Migrate the four Gold generators from static/repeated state to genuine visual progression.
 2. Make the four cases pass three independent live runs without hard failures.
-3. Add LessonPlan as the shared teaching contract without removing legacy CIR in one step.
+3. Compile SceneIntent into shared SceneBlueprint/Playbook assembly without removing legacy CIR in one step.
 4. Add CoverageDecision and the controlled Generalist Composer only after the Gold gate is green.

--- a/docs/lesson-plan.md
+++ b/docs/lesson-plan.md
@@ -1,0 +1,106 @@
+# LessonPlan
+
+Status: Active
+
+`LessonPlan` is MetaView's renderer-independent teaching contract. It records
+why a lesson is structured a certain way before a SkillPack, agent, or legacy
+CIR generator produces `PlaybookScript`.
+
+It is not a rendering format and does not replace `PlaybookScript`.
+
+## Runtime position
+
+```text
+Intake
+  -> Router
+  -> RuleBasedLessonPlanner
+  -> persist pipeline_runs.lesson_plan_json
+  -> specialized SkillPack | Agent provider | legacy CIR generator
+  -> PlaybookScript
+  -> Canonical QualityReport
+  -> DirectorScript
+  -> Remotion
+```
+
+The plan is created after routing and before any generation provider call. The
+same typed object is passed through each path:
+
+- specialized SkillPack: `SkillExecutionContext.lesson_plan`;
+- agent: `AgentRequest.lesson_plan`, including the Node sidecar and Codex SDK
+  prompt context;
+- legacy single: the canonical plan is embedded in `build_cir_prompt(...)` as
+  binding teaching guidance.
+
+The plan is persisted before generation starts. Provider failures therefore
+still leave the teaching decision visible in run history. Existing database
+rows migrate with `lesson_plan = null`; MetaView does not invent plans for
+historical runs.
+
+The canonical backend gate receives the same plan. Registered fact IDs,
+semantic visual roles, preferred scene types and exact numeric conclusions are
+checked against the candidate Playbook. Missing evidence is repairable and
+cannot enter `succeeded`; a deterministic SkillPack without a repair path fails
+closed. Facts without a registered deterministic evidence matcher remain visible warnings
+instead of being silently treated as verified.
+
+## Contract boundary
+
+`LessonPlan` contains:
+
+- domain, title, objectives, prerequisites and misconceptions;
+- expected conclusion and lesson arc;
+- ordered `SceneIntent` values;
+- required fact IDs and semantic visual roles;
+- an optional semantic `preferred_scene_type` value.
+
+It must not contain coordinates, frames, SVG, asset paths, layers, React
+structures, renderer-private fields or Director instructions. Pydantic uses
+`extra="forbid"`, and the checked-in JSON Schema is compared directly with
+the model in contract tests.
+
+Canonical files:
+
+- model: `apps/api/app/domain/models/lesson_plan.py`;
+- planner port: `apps/api/app/application/ports/lesson_planner.py`;
+- rule and assisted planners: `apps/api/app/application/services/lesson_planner.py`;
+- public schema: `apps/web/public/schemas/lesson-plan.schema.json`;
+- four verified plans: `eval/benchmark_v2/lesson_plans/`.
+
+## Planner implementations
+
+`RuleBasedLessonPlanner` is the production default. It is deterministic and
+has capability-semantic guidance for derivative/tangent, BFS, recursion stack
+and projectile motion without branching on Gold case IDs. Unknown topics use
+a bounded general teaching arc rather than renderer guesses. The planner also
+receives the resolved route decision and ProblemSpec, so a notation such as
+`d/dx(x^2)` does not lose the already matched calculus capability.
+
+`LLMAssistedLessonPlanner` is implemented and contract-tested, but is not the
+default runtime planner. It refines a deterministic draft, rejects invalid JSON
+and domain drift, and may only change teaching decisions.
+
+`lesson_plan_from_legacy_cir(...)` is a deliberately lossy compatibility
+adapter. CIR does not contain reliable prerequisites, misconceptions or fact
+IDs, so the adapter leaves those lists empty instead of fabricating knowledge.
+It never copies layout, timing, layers or assets. New single-mode runs are
+planned before CIR generation; the adapter is for importing legacy CIR objects,
+not a second production planner.
+
+## Current limits
+
+- LessonPlan is initial run provenance; follow-up versions do not yet patch or
+  version-bind it.
+- SceneBlueprint is not yet a multi-SceneIntent compiler. The current phase
+  passes teaching intent into existing generators without changing the sole
+  PlaybookScript rendering contract.
+- Runtime adherence checks currently cover the four initial Gold
+  capabilities. New fact IDs and scene capabilities must register deterministic checks;
+  until then the QualityReport marks them as unverified.
+- The current gate validates aggregate fact/visual/scene evidence and exact
+  Gold conclusions. It does not yet prove per-SceneIntent execution order or
+  `narration_goal` alignment. That requires the planned PlaybookAssembler/
+  localized scene trace rather than brittle text matching.
+- Existing SkillPacks may optionally return a refined `LessonPlan`, but old
+  SkillPacks remain valid and receive the shared plan through their context.
+- CoverageDecision, Generalist Composer and SkillRecipe are later phases and
+  are not implied by this contract.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -5,6 +5,21 @@
 > `single mode` 仍保留为 legacy fallback：**LLM → CIR + ExecutionMap → PlaybookScript**。
 > 项目仍不引入 Manim、HTML iframe 或服务端 HTML 视频渲染；前端通过 Remotion 帧驱动渲染。
 
+路由完成后，三条路径会先共享同一份 renderer-independent `LessonPlan`：
+
+```text
+Router
+  -> RuleBasedLessonPlanner
+  -> persist LessonPlan
+  -> SkillExecutionContext | AgentRequest | legacy CIR prompt
+  -> PlaybookScript
+```
+
+LessonPlan 只记录教学目标、误区、结论、教学弧线和 SceneIntent，不包含 frame、坐标、
+asset、layer 或 renderer 私有字段。最终候选还会由后端检查已注册的 required facts、
+visual roles、preferred scene type 和精确结论；缺失证据会触发 repair 或阻断。
+详见 [`lesson-plan.md`](./lesson-plan.md)。
+
 ## 0. 当前成功语义与契约同步
 
 SkillPack、Agent、legacy single 三条生成路径在写入 `succeeded` 前都会调用 API 侧
@@ -34,6 +49,9 @@ Pydantic `AnySnapshot` discriminator、Agent self-check allow-list、Web `Snapsh
 ## 1. Legacy single generation path: LLM 输出契约
 
 `METAVIEW_GENERATION_MODE=single` 时，LLM 必须输出**单一 JSON 对象**，包含两层：
+
+生成前，后端会把已持久化的 canonical LessonPlan 注入 system prompt。CIR 可以把一个
+SceneIntent 展开为多个步骤，但必须保持教学目标、所需事实、视觉角色和预期结论。
 
 ```jsonc
 {

--- a/docs/quality-gate.md
+++ b/docs/quality-gate.md
@@ -45,6 +45,10 @@ The initial backend rule set covers:
 - Code Sync source bounds plus current/queue/visited agreement with the graph
   scene and current-frame variable agreement for recursion; missing BFS or
   recursion Code Sync tracks are repairable errors;
+- aggregate LessonPlan adherence for registered fact IDs, semantic visual
+  roles, preferred scene types and exact Gold conclusions; missing evidence is
+  repairable, while per-SceneIntent order/narration tracing remains a documented
+  PlaybookAssembler follow-up;
 - final teaching step that does not address an explicit request;
 - forbidden alternate rendering paths;
 - Director persistence/load failures and export-readiness failures.

--- a/eval/benchmark_v2/lesson_plans/algorithm-bfs-tree.json
+++ b/eval/benchmark_v2/lesson_plans/algorithm-bfs-tree.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "1.0.0",
+  "domain": "algorithm",
+  "title": "广度优先遍历：队列驱动的逐层访问",
+  "learning_objectives": [
+    "说明 BFS 为什么使用先进先出的队列",
+    "区分当前节点、已访问集合和等待队列",
+    "根据队列状态复述二叉树的逐层访问顺序"
+  ],
+  "prerequisites": [
+    "树的节点与边",
+    "队首与队尾",
+    "先进先出的基本规则"
+  ],
+  "misconceptions": [
+    "把 BFS 与沿单一路径深入的 DFS 混淆",
+    "忽略 visited 状态而重复加入同一节点",
+    "认为同一层的多个节点可以同时出队，而不需要保持先后顺序"
+  ],
+  "expected_conclusion": "BFS 使用先进先出的队列按层访问节点；每次从队首取出一个当前节点，再把尚未访问的相邻节点加入队尾。",
+  "lesson_arc": "state_transition",
+  "scenes": [
+    {
+      "scene_id": "bfs-structure",
+      "teaching_goal": "建立树结构、遍历起点和 FIFO 队列",
+      "strategy": "demonstration",
+      "required_fact_ids": ["breadth_first", "queue", "order"],
+      "required_visual_roles": ["node", "edge", "queue"],
+      "preferred_scene_type": "bfs_graph",
+      "narration_goal": "介绍 BFS 从根节点开始，并由队列决定接下来处理哪个节点。"
+    },
+    {
+      "scene_id": "bfs-root-transition",
+      "teaching_goal": "展示根节点入队、出队和子节点入队的第一次完整状态变化",
+      "strategy": "state_transition",
+      "required_fact_ids": ["queue", "visited", "order"],
+      "required_visual_roles": ["node", "edge", "current_node", "visited", "queue"],
+      "preferred_scene_type": "bfs_graph",
+      "narration_goal": "逐项同步说明 current、visited 与 queue 在一次出队处理中的变化。"
+    },
+    {
+      "scene_id": "bfs-first-layer",
+      "teaching_goal": "展示第一层节点按照队列顺序依次处理",
+      "strategy": "state_transition",
+      "required_fact_ids": ["breadth_first", "queue", "visited", "order"],
+      "required_visual_roles": ["node", "edge", "current_node", "visited", "queue"],
+      "preferred_scene_type": "bfs_graph",
+      "narration_goal": "强调先进入队列的同层节点先被处理，新发现节点只能追加到队尾。"
+    },
+    {
+      "scene_id": "bfs-completion",
+      "teaching_goal": "完成所有可达节点的独立出队 checkpoint",
+      "strategy": "state_transition",
+      "required_fact_ids": ["breadth_first", "queue", "visited", "order"],
+      "required_visual_roles": ["node", "edge", "current_node", "visited", "queue"],
+      "preferred_scene_type": "bfs_graph",
+      "narration_goal": "保持每个出队节点都有独立状态，并展示队列最终清空。"
+    },
+    {
+      "scene_id": "bfs-summary",
+      "teaching_goal": "总结 BFS 的逐层顺序及 FIFO 原因",
+      "strategy": "summary",
+      "required_fact_ids": ["breadth_first", "queue", "visited", "order"],
+      "required_visual_roles": ["node", "edge", "visited", "queue"],
+      "preferred_scene_type": "bfs_graph",
+      "narration_goal": "明确回答 BFS 为什么按层访问，以及队列如何保证这一顺序。"
+    }
+  ]
+}

--- a/eval/benchmark_v2/lesson_plans/code-recursion-factorial.json
+++ b/eval/benchmark_v2/lesson_plans/code-recursion-factorial.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "1.0.0",
+  "domain": "code",
+  "title": "factorial(4)：递归调用栈与返回值",
+  "learning_objectives": [
+    "识别递归调用、基例和等待返回的栈帧",
+    "按顺序解释 factorial(4) 的压栈过程",
+    "追踪返回值 1、2、6、24 的逐层传播"
+  ],
+  "prerequisites": [
+    "函数调用与返回值",
+    "条件分支",
+    "阶乘的乘法定义"
+  ],
+  "misconceptions": [
+    "认为递归调用会立即得到最终结果",
+    "把压栈顺序与回溯返回顺序混为一谈",
+    "忽略基例或错误地让基例返回 0"
+  ],
+  "expected_conclusion": "factorial(4) 先建立等待相乘的递归栈帧，再从基例开始逐层返回并回溯，最终得到 factorial(4)=24。",
+  "lesson_arc": "state_transition",
+  "scenes": [
+    {
+      "scene_id": "factorial-contract",
+      "teaching_goal": "明确 factorial 的递归关系和终止基例",
+      "strategy": "demonstration",
+      "required_fact_ids": ["factorial", "base_case", "recursive_call"],
+      "required_visual_roles": ["stack_frame", "active_frame", "code_line"],
+      "preferred_scene_type": "recursion_stack",
+      "narration_goal": "说明非基例调用会暂停当前乘法并进入更小参数的调用。"
+    },
+    {
+      "scene_id": "factorial-push",
+      "teaching_goal": "逐步展示 factorial(4) 到基例的压栈过程",
+      "strategy": "state_transition",
+      "required_fact_ids": ["factorial", "recursive_call"],
+      "required_visual_roles": ["stack_frame", "active_frame", "code_line"],
+      "preferred_scene_type": "recursion_stack",
+      "narration_goal": "让每次调用拥有独立栈帧和局部 n，并区分 active 与 waiting 状态。"
+    },
+    {
+      "scene_id": "factorial-base-case",
+      "teaching_goal": "展示基例停止继续递归并产生第一个返回值",
+      "strategy": "demonstration",
+      "required_fact_ids": ["base_case", "return_unwind"],
+      "required_visual_roles": ["stack_frame", "active_frame", "code_line", "return_value"],
+      "preferred_scene_type": "recursion_stack",
+      "narration_goal": "明确基例返回 1，它是后续逐层乘法能够开始的条件。"
+    },
+    {
+      "scene_id": "factorial-unwind",
+      "teaching_goal": "追踪返回值沿调用栈逐层传播",
+      "strategy": "state_transition",
+      "required_fact_ids": ["return_unwind", "factorial_result"],
+      "required_visual_roles": ["stack_frame", "active_frame", "code_line", "return_value"],
+      "preferred_scene_type": "recursion_stack",
+      "narration_goal": "依次说明返回值 1、2、6、24，并把每次乘法对应到正在恢复的栈帧。"
+    },
+    {
+      "scene_id": "factorial-summary",
+      "teaching_goal": "总结压栈、基例和回溯共同产生最终结果",
+      "strategy": "summary",
+      "required_fact_ids": [
+        "factorial",
+        "base_case",
+        "recursive_call",
+        "return_unwind",
+        "factorial_result"
+      ],
+      "required_visual_roles": ["stack_frame", "active_frame", "code_line", "return_value"],
+      "preferred_scene_type": "recursion_stack",
+      "narration_goal": "明确陈述 factorial(4)=24，并解释结果来自等待乘法在回溯阶段逐层完成。"
+    }
+  ]
+}

--- a/eval/benchmark_v2/lesson_plans/math-derivative-tangent.json
+++ b/eval/benchmark_v2/lesson_plans/math-derivative-tangent.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "1.0.0",
+  "domain": "math",
+  "title": "导数的几何意义：从割线到切线",
+  "learning_objectives": [
+    "识别曲线 y=x² 上的目标点 (1,1) 及其切线",
+    "用割线斜率的极限解释瞬时变化率",
+    "说明 f'(1)、切线斜率与数值 2 表示同一结论"
+  ],
+  "prerequisites": [
+    "直线斜率公式",
+    "函数图像上的点",
+    "极限的直观含义"
+  ],
+  "misconceptions": [
+    "把某一条割线的斜率直接当成导数",
+    "认为切线斜率描述整条曲线的平均变化",
+    "只记住 f'(1)=2 而不能把它对应到切线"
+  ],
+  "expected_conclusion": "当割线的第二点趋近 (1,1) 时，割线斜率趋近 2，因此 y=x² 在 x=1 处的导数与切线斜率都等于 2。",
+  "lesson_arc": "intuition_to_abstraction",
+  "scenes": [
+    {
+      "scene_id": "derivative-context",
+      "teaching_goal": "建立曲线、目标点与局部斜率问题之间的联系",
+      "strategy": "intuition",
+      "required_fact_ids": ["derivative"],
+      "required_visual_roles": ["curve", "target_point"],
+      "preferred_scene_type": "derivative_tangent",
+      "narration_goal": "指出导数研究的是曲线在指定点附近的瞬时变化，而不是整段平均变化。"
+    },
+    {
+      "scene_id": "secant-approach",
+      "teaching_goal": "展示第二点靠近目标点时割线斜率如何变化",
+      "strategy": "demonstration",
+      "required_fact_ids": ["slope"],
+      "required_visual_roles": ["curve", "target_point", "secant", "slope"],
+      "preferred_scene_type": "derivative_tangent",
+      "narration_goal": "说明中间割线可以具有其他斜率，但随着两点靠近，斜率逐步趋近 2。"
+    },
+    {
+      "scene_id": "tangent-limit",
+      "teaching_goal": "把割线斜率极限转化为目标点处的切线斜率",
+      "strategy": "derivation",
+      "required_fact_ids": ["derivative", "tangent", "slope"],
+      "required_visual_roles": ["curve", "target_point", "secant", "tangent", "slope"],
+      "preferred_scene_type": "derivative_tangent",
+      "narration_goal": "推导并明确 f'(1)=2，同时将代数结果对应到切线的倾斜程度。"
+    },
+    {
+      "scene_id": "derivative-summary",
+      "teaching_goal": "总结导数、切线与斜率 2 的统一含义",
+      "strategy": "summary",
+      "required_fact_ids": ["derivative", "tangent", "slope"],
+      "required_visual_roles": ["curve", "target_point", "tangent", "slope"],
+      "preferred_scene_type": "derivative_tangent",
+      "narration_goal": "用一句完整结论回答为什么该点的切线斜率等于 2。"
+    }
+  ]
+}

--- a/eval/benchmark_v2/lesson_plans/physics-projectile.json
+++ b/eval/benchmark_v2/lesson_plans/physics-projectile.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": "1.0.0",
+  "domain": "physics",
+  "title": "平抛运动：水平匀速与竖直重力加速",
+  "learning_objectives": [
+    "把平抛运动分解为水平和竖直两个独立分量",
+    "说明重力只改变竖直速度而不改变水平速度",
+    "解释两个分运动为什么合成为抛物线轨迹"
+  ],
+  "prerequisites": [
+    "速度的矢量分解",
+    "匀速直线运动",
+    "匀加速直线运动"
+  ],
+  "misconceptions": [
+    "认为重力会让水平速度越来越大",
+    "认为竖直加速度恒定就代表竖直速度不变",
+    "把水平和竖直运动分开后误认为合轨迹仍是直线"
+  ],
+  "expected_conclusion": "平抛运动同时具有不变的水平速度和由重力产生的竖直加速度，两个分运动合成一条抛物线轨迹。",
+  "lesson_arc": "comparison",
+  "scenes": [
+    {
+      "scene_id": "projectile-components",
+      "teaching_goal": "建立物体及水平、竖直速度分量",
+      "strategy": "demonstration",
+      "required_fact_ids": ["horizontal_velocity", "vertical_velocity"],
+      "required_visual_roles": ["object", "horizontal_velocity", "vertical_velocity"],
+      "preferred_scene_type": "projectile_motion",
+      "narration_goal": "说明平抛初始水平速度非零、初始竖直速度为零，但两个方向需要分别分析。"
+    },
+    {
+      "scene_id": "projectile-component-comparison",
+      "teaching_goal": "比较相同时间内水平和竖直分量的不同变化规律",
+      "strategy": "comparison",
+      "required_fact_ids": ["gravity", "horizontal_velocity", "vertical_velocity"],
+      "required_visual_roles": [
+        "object",
+        "horizontal_velocity",
+        "vertical_velocity",
+        "gravity"
+      ],
+      "preferred_scene_type": "projectile_motion",
+      "narration_goal": "强调水平方向保持匀速，竖直速度则因向下重力加速度持续变化。"
+    },
+    {
+      "scene_id": "projectile-state-transition",
+      "teaching_goal": "展示运动状态随时间推进并形成弯曲轨迹",
+      "strategy": "state_transition",
+      "required_fact_ids": [
+        "parabolic",
+        "gravity",
+        "horizontal_velocity",
+        "vertical_velocity"
+      ],
+      "required_visual_roles": [
+        "object",
+        "trajectory",
+        "horizontal_velocity",
+        "vertical_velocity",
+        "gravity"
+      ],
+      "preferred_scene_type": "projectile_motion",
+      "narration_goal": "把每个时刻的位置变化与速度分量同步起来，显示竖直间隔逐渐增大。"
+    },
+    {
+      "scene_id": "projectile-trajectory-reason",
+      "teaching_goal": "解释两个分运动合成抛物线的原因",
+      "strategy": "derivation",
+      "required_fact_ids": [
+        "parabolic",
+        "gravity",
+        "horizontal_velocity",
+        "vertical_velocity"
+      ],
+      "required_visual_roles": [
+        "object",
+        "trajectory",
+        "horizontal_velocity",
+        "vertical_velocity",
+        "gravity"
+      ],
+      "preferred_scene_type": "projectile_motion",
+      "narration_goal": "连接水平位移随时间线性增长与竖直位移随时间平方增长，得到抛物线结论。"
+    },
+    {
+      "scene_id": "projectile-summary",
+      "teaching_goal": "总结水平、竖直分运动与整体轨迹",
+      "strategy": "summary",
+      "required_fact_ids": [
+        "parabolic",
+        "gravity",
+        "horizontal_velocity",
+        "vertical_velocity"
+      ],
+      "required_visual_roles": [
+        "object",
+        "trajectory",
+        "horizontal_velocity",
+        "vertical_velocity",
+        "gravity"
+      ],
+      "preferred_scene_type": "projectile_motion",
+      "narration_goal": "明确回答水平速度不变、竖直受重力加速以及轨迹为何是抛物线。"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add the renderer-independent `LessonPlan` and `SceneIntent` contracts with one canonical JSON Schema and exact Python/TypeScript contract tests
- add a default rule-based planner, an optional LLM-assisted planner, a legacy CIR adapter, and deterministic plans for the four Gold cases
- create and persist one LessonPlan after routing, then pass it through specialized SkillPack, Agent/Codex SDK, and legacy single/CIR generation paths
- bind initial generation and repair prompts to the same teaching plan
- extend the canonical backend gate with aggregate plan adherence checks for required facts, structured visual roles, scene types, and exact final factorial/derivative conclusions
- expose the persisted plan through run history and document current production boundaries

## Why

The three generation paths previously had no shared teaching contract. That allowed an otherwise schema-valid Playbook to omit required teaching facts or visuals, and made plans unavailable for audit after provider failures.

This change establishes a shared pedagogical handoff without replacing PlaybookScript, SceneBlueprint, DirectorScript, SkillPack routing, or Remotion.

## Quality gate fixes

The adherence gate now:

- derives visual-role evidence from structured snapshot fields instead of narration, captions, arbitrary params, or source-code text
- evaluates exact numeric conclusions from the final teaching scene, so `2.5` cannot satisfy `2` and an earlier correct value cannot hide a wrong final result
- rejects conflicting and unevaluated result expressions while preserving the approved Gold outputs

## Validation

- `make check`
  - API: 831 passed, 2 skipped
  - Web: 951 passed
  - Agent: 63 passed
  - MCP server: 18 passed
  - Web and Agent builds passed
- focused changed-path tests: 166 passed
- LessonPlan quality regressions: 47 passed
- prior formal Gold replay: 12 runs, checked against both rule-based and static Gold plans; 24/24 adherence checks clean
- independent final review: no merge blockers

## Live evidence and limitations

A fresh Codex SDK run with the compatible `gpt-5.5` model passed derivative and BFS at 100/100 (BFS Code Sync 5/5). The requested `gpt-5.6-terra` model is unavailable in the installed Codex SDK/CLI version; fresh recursion and projectile attempts then hit the Codex usage limit, so they were not counted as new live passes. Their previously approved 3x Gold runs were replayed through this new gate and remained clean.

Current adherence is aggregate: it does not yet prove per-SceneIntent ordering or narration-goal alignment. LessonPlan is persisted on the initial run but is not yet bound to follow-up versions. Unknown fact IDs remain visible warnings until a deterministic check is registered.