### PR TITLE
feat: add controlled SkillRecipe contract

### DIFF
--- a/apps/api/app/application/services/coverage_resolver.py
+++ b/apps/api/app/application/services/coverage_resolver.py
@@ -5,17 +5,13 @@ from dataclasses import dataclass
 
 from app.application.agent.runtime_tool_hub import RuntimeToolHub
 from app.domain.animation_tools import list_animation_tools
+from app.domain.contracts.quality_contract import PLAYBOOK_VALIDATOR_TOOL_IDS
 from app.domain.models.coverage import CoverageDecision, CoverageFallbackPolicy
 from app.domain.models.topic import TopicDomain
 from app.domain.services.domain_router import route_topic
 from app.domain.services.scene_blueprint_schema import scene_blueprint_schema
 from app.domain.skills.base import SkillRouteInput, SkillRouteMatch
 from app.domain.skills.registry import SkillRegistry, build_default_skill_registry
-
-_PLAYBOOK_VALIDATORS = (
-    "playbook.schema.validate",
-    "playbook.self_check",
-)
 
 
 @dataclass(frozen=True)
@@ -36,7 +32,7 @@ _CONTROLLED_PROFILES = (
             "scene_blueprint.compile",
             "geometry.assert_passes_through",
         ),
-        required_validator_ids=_PLAYBOOK_VALIDATORS,
+        required_validator_ids=PLAYBOOK_VALIDATOR_TOOL_IDS,
         required_scene_types=("derivative_tangent", "math_plot"),
     ),
     _ControlledCompositionProfile(
@@ -46,7 +42,7 @@ _CONTROLLED_PROFILES = (
             "scene_blueprint.compile",
             "animation_tool.expand",
         ),
-        required_validator_ids=_PLAYBOOK_VALIDATORS,
+        required_validator_ids=PLAYBOOK_VALIDATOR_TOOL_IDS,
         required_scene_types=("bfs_graph", "graph_scene"),
         required_animation_tool_ids=("algorithm.graph_traversal",),
     ),
@@ -54,7 +50,7 @@ _CONTROLLED_PROFILES = (
         profile_id="recursion_stack",
         allowed_domains=frozenset({TopicDomain.ALGORITHM.value, TopicDomain.CODE.value}),
         required_tool_ids=("scene_blueprint.compile",),
-        required_validator_ids=_PLAYBOOK_VALIDATORS,
+        required_validator_ids=PLAYBOOK_VALIDATOR_TOOL_IDS,
         required_scene_types=("recursion_stack", "call_stack_scene"),
     ),
     _ControlledCompositionProfile(
@@ -64,7 +60,7 @@ _CONTROLLED_PROFILES = (
             "scene_blueprint.compile",
             "animation_tool.expand",
         ),
-        required_validator_ids=_PLAYBOOK_VALIDATORS,
+        required_validator_ids=PLAYBOOK_VALIDATOR_TOOL_IDS,
         required_scene_types=("projectile_motion", "physics_force_scene"),
         required_animation_tool_ids=("physics.projectile_motion",),
     ),
@@ -162,7 +158,7 @@ class DefaultCoverageResolver:
                 confidence=route_match.confidence,
                 matched_skill_ids=matched_skill_ids,
                 available_tool_ids=_available_evidence(
-                    (solve_tool_id, *_PLAYBOOK_VALIDATORS),
+                    (solve_tool_id, *PLAYBOOK_VALIDATOR_TOOL_IDS),
                     tool_inventory,
                 ),
                 missing_capabilities=[],
@@ -440,7 +436,7 @@ class DefaultCoverageResolver:
             missing.append(f"tool:{solve_tool_id}")
         elif not tool_inventory[solve_tool_id]:
             missing.append(f"tool:{solve_tool_id}:not_deterministic")
-        for validator_id in _PLAYBOOK_VALIDATORS:
+        for validator_id in PLAYBOOK_VALIDATOR_TOOL_IDS:
             if validator_id not in tool_inventory:
                 missing.append(f"validator:{validator_id}")
             elif not tool_inventory[validator_id]:
@@ -708,7 +704,7 @@ def _experimental_evidence(
     *,
     allow_scene_compile: bool,
 ) -> list[str]:
-    relevant = list(_PLAYBOOK_VALIDATORS)
+    relevant = list(PLAYBOOK_VALIDATOR_TOOL_IDS)
     if allow_scene_compile:
         relevant.append("scene_blueprint.compile")
     return _available_evidence(tuple(relevant), tool_inventory)

--- a/apps/api/app/application/services/skill_recipe_validator.py
+++ b/apps/api/app/application/services/skill_recipe_validator.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from app.application.agent.runtime_tool_hub import RuntimeToolHub
+from app.domain.contracts.playbook_contract import SUPPORTED_SNAPSHOT_KIND_SET
+from app.domain.contracts.quality_contract import (
+    FACT_VALIDATOR_TOOL_ID_SET,
+    PLAYBOOK_VALIDATOR_TOOL_ID_SET,
+)
+from app.domain.services.asset_manifest_resolver import list_asset_packs
+from app.domain.services.scene_blueprint_compiler import (
+    COMPILED_SCENE_DOMAINS,
+    COMPILED_SCENE_SNAPSHOT_KINDS,
+)
+from app.domain.services.skill_recipe_validator import SkillRecipeValidationContext
+
+
+def build_skill_recipe_validation_context(
+    runtime_tool_hub: RuntimeToolHub,
+) -> SkillRecipeValidationContext:
+    deterministic_tool_ids = frozenset(
+        tool.name for tool in runtime_tool_hub.list_tools() if tool.deterministic
+    )
+    available_asset_ids = frozenset(
+        (str(pack["packId"]), str(asset["id"]))
+        for pack in list_asset_packs()
+        for asset in pack.get("assets", [])
+        if pack.get("packId") and asset.get("id")
+    )
+    asset_pack_domains = {
+        str(pack["packId"]): str(pack["subject"])
+        for pack in list_asset_packs()
+        if pack.get("packId") and pack.get("subject")
+    }
+    return SkillRecipeValidationContext(
+        deterministic_tool_ids=deterministic_tool_ids,
+        validator_tool_ids=PLAYBOOK_VALIDATOR_TOOL_ID_SET & deterministic_tool_ids,
+        required_validator_tool_ids=PLAYBOOK_VALIDATOR_TOOL_ID_SET,
+        fact_validator_tool_ids=FACT_VALIDATOR_TOOL_ID_SET,
+        compiled_scene_snapshot_kinds=COMPILED_SCENE_SNAPSHOT_KINDS,
+        compiled_scene_domains=COMPILED_SCENE_DOMAINS,
+        supported_snapshot_kinds=SUPPORTED_SNAPSHOT_KIND_SET,
+        available_asset_ids=available_asset_ids,
+        asset_pack_domains=asset_pack_domains,
+    )
+
+
+__all__ = ["build_skill_recipe_validation_context"]

--- a/apps/api/app/domain/contracts/quality_contract.py
+++ b/apps/api/app/domain/contracts/quality_contract.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+# Canonical final-candidate validators shared by coverage and SkillRecipe.
+# Geometry assertions remain executable tools, but do not replace schema and semantic gates.
+PLAYBOOK_VALIDATOR_TOOL_IDS: tuple[str, ...] = (
+    "playbook.schema.validate",
+    "playbook.self_check",
+)
+PLAYBOOK_VALIDATOR_TOOL_ID_SET = frozenset(PLAYBOOK_VALIDATOR_TOOL_IDS)
+
+# Fact claims require the semantic self-check. Schema validation alone cannot verify knowledge.
+FACT_VALIDATOR_TOOL_IDS: tuple[str, ...] = ("playbook.self_check",)
+FACT_VALIDATOR_TOOL_ID_SET = frozenset(FACT_VALIDATOR_TOOL_IDS)

--- a/apps/api/app/domain/models/__init__.py
+++ b/apps/api/app/domain/models/__init__.py
@@ -51,6 +51,12 @@ from app.domain.models.review import (
     PlaybookReviewVerdict,
     ReviewSeverity,
 )
+from app.domain.models.skill_recipe import (
+    AssetRequirement,
+    FactRequirement,
+    QualityExpectation,
+    SkillRecipe,
+)
 from app.domain.models.topic import TopicDomain, VisualKind
 
 __all__ = [
@@ -71,4 +77,5 @@ __all__ = [
     "ReviewSeverity", "CirReviewIssue", "CirReviewReport",
     "PlaybookIssueSeverity", "PlaybookReviewIssue", "PlaybookReviewStatus",
     "PlaybookReviewVerdict", "QualityReport",
+    "AssetRequirement", "FactRequirement", "QualityExpectation", "SkillRecipe",
 ]

--- a/apps/api/app/domain/models/quality_report.py
+++ b/apps/api/app/domain/models/quality_report.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -13,6 +14,25 @@ from app.domain.models.review import (
 )
 
 QualityReportStatus = Literal["clean", "warnings", "repairable", "blocked"]
+
+
+class QualityScoreDimension(str, Enum):
+    SCHEMA = "schema"
+    KNOWLEDGE_CORRECTNESS = "knowledge_correctness"
+    PROMPT_COVERAGE = "prompt_coverage"
+    PEDAGOGY = "pedagogy"
+    SCENE_CONTRACT = "scene_contract"
+    VISUAL_STRUCTURE = "visual_structure"
+    CODE_SYNC = "code_sync"
+    NARRATION_VISUAL_CONSISTENCY = "narration_visual_consistency"
+    TIMELINE = "timeline"
+    ASSET_LICENSE = "asset_license"
+    EXPORT_READINESS = "export_readiness"
+
+
+QUALITY_SCORE_DIMENSIONS: tuple[str, ...] = tuple(
+    dimension.value for dimension in QualityScoreDimension
+)
 
 
 class QualityReport(BaseModel):
@@ -114,19 +134,7 @@ class QualityReport(BaseModel):
 
 
 def _scores_from_verdict(verdict: PlaybookReviewVerdict) -> dict[str, float]:
-    dimensions = {
-        "schema": 1.0,
-        "knowledge_correctness": 1.0,
-        "prompt_coverage": 1.0,
-        "pedagogy": 1.0,
-        "scene_contract": 1.0,
-        "visual_structure": 1.0,
-        "code_sync": 1.0,
-        "narration_visual_consistency": 1.0,
-        "timeline": 1.0,
-        "asset_license": 1.0,
-        "export_readiness": 1.0,
-    }
+    dimensions = dict.fromkeys(QUALITY_SCORE_DIMENSIONS, 1.0)
     for issue in verdict.issues:
         penalty = 0.35 if issue.severity == "error" else 0.15
         if issue.code.startswith("capability."):

--- a/apps/api/app/domain/models/skill_recipe.py
+++ b/apps/api/app/domain/models/skill_recipe.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.domain.models.lesson_plan import LessonPlan
+from app.domain.models.quality_report import QualityScoreDimension
+
+NonBlankString = Annotated[str, Field(min_length=1)]
+
+
+class FactRequirement(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    fact_id: NonBlankString
+    description: NonBlankString
+    validator_id: NonBlankString
+
+
+class AssetRequirement(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    semantic_role: NonBlankString
+    asset_id: NonBlankString | None = None
+    pack_id: NonBlankString | None = None
+    required: bool = True
+
+    @model_validator(mode="after")
+    def require_pack_for_explicit_asset(self) -> "AssetRequirement":
+        if self.required and (self.asset_id is None or self.pack_id is None):
+            raise ValueError("required asset needs an explicit pack_id and asset_id")
+        if self.asset_id is not None and self.pack_id is None:
+            raise ValueError("explicit asset_id requires an auditable pack_id")
+        if self.pack_id is not None and self.asset_id is None:
+            raise ValueError("pack_id cannot be selected without an asset_id")
+        return self
+
+
+class QualityExpectation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dimension: QualityScoreDimension
+    minimum_score: float = Field(ge=0.0, le=1.0)
+    blocking: bool = True
+
+
+class SkillRecipe(BaseModel):
+    """Transient, data-only execution recipe for composable coverage."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    schema_version: Literal["1.0.0"]
+    recipe_id: NonBlankString
+    domain: NonBlankString
+    lesson_plan: LessonPlan
+    required_facts: list[FactRequirement]
+    allowed_tool_ids: list[NonBlankString] = Field(min_length=1)
+    required_validator_ids: list[NonBlankString] = Field(min_length=1)
+    allowed_scene_types: list[NonBlankString] = Field(min_length=1)
+    allowed_snapshot_kinds: list[NonBlankString] = Field(min_length=1)
+    asset_requirements: list[AssetRequirement]
+    quality_expectations: list[QualityExpectation] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_recipe_contract(self) -> "SkillRecipe":
+        if self.domain != self.lesson_plan.domain:
+            raise ValueError("recipe domain must match lesson_plan.domain")
+
+        unique_lists = {
+            "allowed_tool_ids": self.allowed_tool_ids,
+            "required_validator_ids": self.required_validator_ids,
+            "allowed_scene_types": self.allowed_scene_types,
+            "allowed_snapshot_kinds": self.allowed_snapshot_kinds,
+        }
+        for field_name, values in unique_lists.items():
+            if len(values) != len(set(values)):
+                raise ValueError(f"{field_name} values must be unique")
+
+        fact_ids = [fact.fact_id for fact in self.required_facts]
+        if len(fact_ids) != len(set(fact_ids)):
+            raise ValueError("required_facts fact_id values must be unique")
+        planned_fact_ids = {
+            fact_id
+            for scene in self.lesson_plan.scenes
+            for fact_id in scene.required_fact_ids
+        }
+        if not planned_fact_ids <= set(fact_ids):
+            missing = sorted(planned_fact_ids - set(fact_ids))
+            raise ValueError(f"required_facts must cover LessonPlan facts: {missing}")
+
+        required_validators = set(self.required_validator_ids)
+        if not required_validators <= set(self.allowed_tool_ids):
+            raise ValueError("required validators must also be allowed tools")
+        if any(fact.validator_id not in required_validators for fact in self.required_facts):
+            raise ValueError("every fact validator_id must be required by the recipe")
+
+        preferred_scene_types = {
+            scene.preferred_scene_type
+            for scene in self.lesson_plan.scenes
+            if scene.preferred_scene_type is not None
+        }
+        if not preferred_scene_types <= set(self.allowed_scene_types):
+            raise ValueError("allowed_scene_types must cover LessonPlan scene preferences")
+
+        roles = [asset.semantic_role for asset in self.asset_requirements]
+        if len(roles) != len(set(roles)):
+            raise ValueError("asset requirement semantic_role values must be unique")
+        dimensions = [expectation.dimension for expectation in self.quality_expectations]
+        if len(dimensions) != len(set(dimensions)):
+            raise ValueError("quality expectation dimensions must be unique")
+        return self
+
+
+__all__ = [
+    "AssetRequirement",
+    "FactRequirement",
+    "QualityExpectation",
+    "SkillRecipe",
+]

--- a/apps/api/app/domain/services/scene_blueprint_compiler.py
+++ b/apps/api/app/domain/services/scene_blueprint_compiler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, NamedTuple
 
 from app.domain.models.playbook import (
     BioCellSceneSnapshot,
@@ -335,7 +335,48 @@ def _step_captions(scene_type: str, title: str, base_caption: str) -> list[str]:
     )
 
 
+class CompiledSceneCapability(NamedTuple):
+    domain: str
+    snapshot_kinds: frozenset[str]
+
+
+COMPILED_SCENE_CAPABILITIES: dict[str, CompiledSceneCapability] = {
+    "east_asia_monsoon": CompiledSceneCapability("geography", frozenset({"geo_map_scene"})),
+    "projectile_motion": CompiledSceneCapability("physics", frozenset({"physics_force_scene"})),
+    "cell_structure": CompiledSceneCapability("biology", frozenset({"bio_cell_scene"})),
+    "bio_cell_scene": CompiledSceneCapability("biology", frozenset({"bio_cell_scene"})),
+    "dna_replication": CompiledSceneCapability("biology", frozenset({"bio_process_scene"})),
+    "bio_process_scene": CompiledSceneCapability("biology", frozenset({"bio_process_scene"})),
+    "molecule_2d_scene": CompiledSceneCapability("chemistry", frozenset({"molecule_2d_scene"})),
+    "molecule_2d_water": CompiledSceneCapability("chemistry", frozenset({"molecule_2d_scene"})),
+    "molecule_2d_methane": CompiledSceneCapability("chemistry", frozenset({"molecule_2d_scene"})),
+    "molecule_2d_glucose": CompiledSceneCapability("chemistry", frozenset({"molecule_2d_scene"})),
+    "reaction_scene": CompiledSceneCapability("chemistry", frozenset({"reaction_scene"})),
+    "reaction_synthesis_water": CompiledSceneCapability("chemistry", frozenset({"reaction_scene"})),
+    "math_plot": CompiledSceneCapability("math", frozenset({"math_plot"})),
+    "derivative_tangent": CompiledSceneCapability("math", frozenset({"math_plot"})),
+    "bfs_graph": CompiledSceneCapability("algorithm", frozenset({"graph_scene"})),
+    "recursion_stack": CompiledSceneCapability("algorithm", frozenset({"call_stack_scene"})),
+    "binary_search": CompiledSceneCapability("algorithm", frozenset({"code_trace_scene"})),
+}
+COMPILED_SCENE_SNAPSHOT_KINDS = {
+    scene_type: capability.snapshot_kinds
+    for scene_type, capability in COMPILED_SCENE_CAPABILITIES.items()
+}
+COMPILED_SCENE_DOMAINS = {
+    scene_type: capability.domain
+    for scene_type, capability in COMPILED_SCENE_CAPABILITIES.items()
+}
+COMPILE_SUPPORTED_SCENE_TYPES = frozenset(COMPILED_SCENE_CAPABILITIES)
+
+
+def can_compile_scene_type(scene_type: str) -> bool:
+    return scene_type in COMPILE_SUPPORTED_SCENE_TYPES
+
+
 def _compile_snapshot(scene_type: str, blueprint: dict[str, Any]):
+    if not can_compile_scene_type(scene_type):
+        raise ValueError(f"Unsupported SceneBlueprint sceneType: {scene_type}")
     if scene_type == "east_asia_monsoon":
         return _east_asia_monsoon_snapshot(blueprint)
     if scene_type == "projectile_motion":
@@ -360,7 +401,7 @@ def _compile_snapshot(scene_type: str, blueprint: dict[str, Any]):
         return _recursion_stack_snapshot(blueprint)
     if scene_type == "binary_search":
         return compile_binary_search_code_trace_snapshot(blueprint)
-    raise ValueError(f"Unsupported SceneBlueprint sceneType: {scene_type}")
+    raise RuntimeError(f"SceneBlueprint compiler registry is incomplete for {scene_type}")
 
 
 def _east_asia_monsoon_snapshot(blueprint: dict[str, Any]) -> GeoMapSceneSnapshot:

--- a/apps/api/app/domain/services/skill_recipe_validator.py
+++ b/apps/api/app/domain/services/skill_recipe_validator.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.domain.models.coverage import CoverageDecision
+from app.domain.models.skill_recipe import SkillRecipe
+
+
+class SkillRecipeValidationIssue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: str = Field(min_length=1)
+    path: str = Field(min_length=1)
+    message: str = Field(min_length=1)
+
+
+class SkillRecipeValidationReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    valid: bool
+    issues: list[SkillRecipeValidationIssue]
+
+
+@dataclass(frozen=True)
+class SkillRecipeValidationContext:
+    deterministic_tool_ids: frozenset[str]
+    validator_tool_ids: frozenset[str]
+    required_validator_tool_ids: frozenset[str]
+    fact_validator_tool_ids: frozenset[str]
+    compiled_scene_snapshot_kinds: dict[str, frozenset[str]]
+    compiled_scene_domains: dict[str, str]
+    supported_snapshot_kinds: frozenset[str]
+    available_asset_ids: frozenset[tuple[str, str]]
+    asset_pack_domains: dict[str, str]
+    max_scene_count: int = 14
+
+
+def validate_skill_recipe(
+    recipe: SkillRecipe,
+    coverage: CoverageDecision,
+    context: SkillRecipeValidationContext,
+) -> SkillRecipeValidationReport:
+    issues: list[SkillRecipeValidationIssue] = []
+
+    def add(code: str, path: str, message: str) -> None:
+        issues.append(SkillRecipeValidationIssue(code=code, path=path, message=message))
+
+    if coverage.mode != "composable" or coverage.fallback_policy != "compose":
+        add(
+            "recipe.coverage_not_composable",
+            "coverage.mode",
+            "SkillRecipe execution requires composable coverage with compose policy.",
+        )
+    if recipe.domain != coverage.domain:
+        add(
+            "recipe.domain_mismatch",
+            "domain",
+            "Recipe domain must match the resolved coverage domain.",
+        )
+    if not set(recipe.allowed_tool_ids) <= set(coverage.available_tool_ids):
+        add(
+            "recipe.tool_outside_coverage",
+            "allowed_tool_ids",
+            "Recipe tools must be a subset of tools exposed by CoverageDecision.",
+        )
+
+    unknown_tools = sorted(set(recipe.allowed_tool_ids) - context.deterministic_tool_ids)
+    if unknown_tools:
+        add(
+            "recipe.tool_unavailable",
+            "allowed_tool_ids",
+            f"Tools are missing or non-deterministic: {unknown_tools}.",
+        )
+    unknown_validators = sorted(set(recipe.required_validator_ids) - context.validator_tool_ids)
+    if unknown_validators:
+        add(
+            "recipe.validator_unavailable",
+            "required_validator_ids",
+            f"Validators are missing or non-deterministic: {unknown_validators}.",
+        )
+    missing_validators = sorted(
+        context.required_validator_tool_ids - set(recipe.required_validator_ids)
+    )
+    if missing_validators:
+        add(
+            "recipe.validator_required",
+            "required_validator_ids",
+            f"Recipe omitted canonical final validators: {missing_validators}.",
+        )
+    invalid_fact_validators = sorted({
+        fact.validator_id
+        for fact in recipe.required_facts
+        if fact.validator_id not in context.fact_validator_tool_ids
+    })
+    if invalid_fact_validators:
+        add(
+            "recipe.fact_validator_invalid",
+            "required_facts",
+            f"Fact requirements use non-semantic validators: {invalid_fact_validators}.",
+        )
+    unsupported_scenes = sorted(
+        set(recipe.allowed_scene_types) - set(context.compiled_scene_snapshot_kinds)
+    )
+    if unsupported_scenes:
+        add(
+            "recipe.scene_not_compilable",
+            "allowed_scene_types",
+            f"SceneBlueprint compiler cannot execute: {unsupported_scenes}.",
+        )
+    wrong_domain_scenes = sorted(
+        scene_type
+        for scene_type in recipe.allowed_scene_types
+        if context.compiled_scene_domains.get(scene_type) not in {None, recipe.domain}
+    )
+    if wrong_domain_scenes:
+        add(
+            "recipe.scene_domain_mismatch",
+            "allowed_scene_types",
+            f"Scene types do not belong to domain {recipe.domain!r}: {wrong_domain_scenes}.",
+        )
+    unsupported_snapshots = sorted(
+        set(recipe.allowed_snapshot_kinds) - context.supported_snapshot_kinds
+    )
+    if unsupported_snapshots:
+        add(
+            "recipe.snapshot_unsupported",
+            "allowed_snapshot_kinds",
+            f"Snapshot kinds are outside the canonical contract: {unsupported_snapshots}.",
+        )
+    undeclared_outputs = {
+        scene_type: sorted(
+            context.compiled_scene_snapshot_kinds.get(scene_type, frozenset())
+            - set(recipe.allowed_snapshot_kinds)
+        )
+        for scene_type in recipe.allowed_scene_types
+    }
+    undeclared_outputs = {
+        scene_type: kinds for scene_type, kinds in undeclared_outputs.items() if kinds
+    }
+    if undeclared_outputs:
+        add(
+            "recipe.scene_snapshot_mismatch",
+            "allowed_snapshot_kinds",
+            f"Recipe does not authorize compiled scene outputs: {undeclared_outputs}.",
+        )
+    if len(recipe.lesson_plan.scenes) > context.max_scene_count:
+        add(
+            "recipe.scene_limit_exceeded",
+            "lesson_plan.scenes",
+            f"Recipe exceeds the {context.max_scene_count}-scene execution limit.",
+        )
+
+    for index, requirement in enumerate(recipe.asset_requirements):
+        if requirement.asset_id is None or requirement.pack_id is None:
+            continue
+        if (requirement.pack_id, requirement.asset_id) not in context.available_asset_ids:
+            add(
+                "recipe.asset_unavailable",
+                f"asset_requirements.{index}",
+                f"Asset {requirement.asset_id!r} is not in pack {requirement.pack_id!r}.",
+            )
+        pack_domain = context.asset_pack_domains.get(requirement.pack_id)
+        if pack_domain not in {None, "core", recipe.domain}:
+            add(
+                "recipe.asset_domain_mismatch",
+                f"asset_requirements.{index}",
+                f"Asset pack {requirement.pack_id!r} belongs to domain {pack_domain!r}.",
+            )
+
+    return SkillRecipeValidationReport(valid=not issues, issues=issues)
+
+
+__all__ = [
+    "SkillRecipeValidationContext",
+    "SkillRecipeValidationIssue",
+    "SkillRecipeValidationReport",
+    "validate_skill_recipe",
+]

--- a/apps/api/scripts/export_public_schemas.py
+++ b/apps/api/scripts/export_public_schemas.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.domain.models.coverage import CoverageDecision
+from app.domain.models.lesson_plan import LessonPlan
+from app.domain.models.skill_recipe import SkillRecipe
+
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_ROOT = ROOT / "apps" / "web" / "public" / "schemas"
+SCHEMAS = {
+    "coverage-decision.schema.json": CoverageDecision,
+    "lesson-plan.schema.json": LessonPlan,
+    "skill-recipe.schema.json": SkillRecipe,
+}
+
+
+def main() -> None:
+    for filename, model in SCHEMAS.items():
+        path = SCHEMA_ROOT / filename
+        payload = json.dumps(
+            model.model_json_schema(),
+            ensure_ascii=False,
+            indent=2,
+        )
+        path.write_text(f"{payload}\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/api/tests/test_skill_recipe_contract.py
+++ b/apps/api/tests/test_skill_recipe_contract.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.application.agent.runtime_tool_hub import RuntimeToolHub
+from app.application.services.skill_recipe_validator import (
+    build_skill_recipe_validation_context,
+)
+from app.domain.models.coverage import CoverageDecision
+from app.domain.models.lesson_plan import LessonPlan
+from app.domain.models.skill_recipe import SkillRecipe
+from app.domain.services.scene_blueprint_compiler import (
+    COMPILE_SUPPORTED_SCENE_TYPES,
+    COMPILED_SCENE_CAPABILITIES,
+)
+from app.domain.services.scene_blueprint_schema import scene_blueprint_schema
+from app.domain.services.skill_recipe_validator import (
+    SkillRecipeValidationContext,
+    validate_skill_recipe,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+RECIPE_SCHEMA = ROOT / "apps" / "web" / "public" / "schemas" / "skill-recipe.schema.json"
+PLAN_PATH = ROOT / "eval" / "benchmark_v2" / "lesson_plans" / "algorithm-bfs-tree.json"
+
+
+def _recipe_payload() -> dict[str, object]:
+    plan = json.loads(PLAN_PATH.read_text(encoding="utf-8"))
+    fact_ids = sorted({fact for scene in plan["scenes"] for fact in scene["required_fact_ids"]})
+    return {
+        "schema_version": "1.0.0",
+        "recipe_id": "recipe-bfs-001",
+        "domain": "algorithm",
+        "lesson_plan": plan,
+        "required_facts": [
+            {
+                "fact_id": fact_id,
+                "description": f"Verify {fact_id} for the BFS explanation.",
+                "validator_id": "playbook.self_check",
+            }
+            for fact_id in fact_ids
+        ],
+        "allowed_tool_ids": [
+            "playbook.schema.validate",
+            "playbook.self_check",
+            "scene_blueprint.compile",
+        ],
+        "required_validator_ids": [
+            "playbook.schema.validate",
+            "playbook.self_check",
+        ],
+        "allowed_scene_types": ["bfs_graph"],
+        "allowed_snapshot_kinds": ["graph_scene"],
+        "asset_requirements": [
+            {
+                "semantic_role": "node",
+                "asset_id": "bfs-graph-contract",
+                "pack_id": "algorithm-code-basic",
+                "required": True,
+            }
+        ],
+        "quality_expectations": [
+            {"dimension": "knowledge_correctness", "minimum_score": 0.9},
+            {"dimension": "visual_structure", "minimum_score": 0.85},
+            {"dimension": "code_sync", "minimum_score": 0.8},
+        ],
+    }
+
+
+def _coverage(recipe: SkillRecipe) -> CoverageDecision:
+    return CoverageDecision(
+        mode="composable",
+        domain=recipe.domain,
+        confidence=0.9,
+        matched_skill_ids=[],
+        available_tool_ids=recipe.allowed_tool_ids,
+        missing_capabilities=[],
+        fallback_policy="compose",
+        reason="Controlled tools cover this request.",
+    )
+
+
+def test_public_skill_recipe_schema_is_generated_from_domain_contract() -> None:
+    stored_schema = json.loads(RECIPE_SCHEMA.read_text(encoding="utf-8"))
+    assert stored_schema == SkillRecipe.model_json_schema()
+
+
+def test_skill_recipe_is_transient_data_only_contract() -> None:
+    recipe = SkillRecipe.model_validate(_recipe_payload())
+    serialized = recipe.model_dump(mode="json")
+
+    assert recipe.lesson_plan == LessonPlan.model_validate(serialized["lesson_plan"])
+    assert not ({"code", "path", "svg", "coordinates", "frame", "layers"} & _keys(serialized))
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda value: value.update(domain="physics"), "domain"),
+        (lambda value: value["required_facts"].pop(), "cover LessonPlan facts"),
+        (
+            lambda value: value["required_facts"][0].update(validator_id="geometry.assert_monotonic"),
+            "validator_id",
+        ),
+        (lambda value: value["allowed_scene_types"].clear(), "at least 1"),
+        (
+            lambda value: value["asset_requirements"][0].pop("pack_id"),
+            "pack_id",
+        ),
+        (
+            lambda value: value.update(shell_command="rm -rf /"),
+            "Extra inputs",
+        ),
+    ],
+)
+def test_skill_recipe_rejects_invalid_or_unsafe_contracts(mutation, message: str) -> None:
+    payload = copy.deepcopy(_recipe_payload())
+    mutation(payload)
+
+    with pytest.raises(ValidationError, match=message):
+        SkillRecipe.model_validate(payload)
+
+
+def test_recipe_validator_accepts_only_discovered_deterministic_capabilities() -> None:
+    recipe = SkillRecipe.model_validate(_recipe_payload())
+    context = build_skill_recipe_validation_context(RuntimeToolHub())
+
+    report = validate_skill_recipe(recipe, _coverage(recipe), context)
+
+    assert report.valid is True
+    assert report.issues == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_code"),
+    [
+        ("allowed_tool_ids", ["playbook.self_check", "unknown.execute"], "recipe.tool_unavailable"),
+        ("allowed_scene_types", ["graph_scene"], "recipe.scene_not_compilable"),
+        ("allowed_snapshot_kinds", ["imaginary_scene"], "recipe.snapshot_unsupported"),
+    ],
+)
+def test_recipe_validator_blocks_unavailable_runtime_capabilities(
+    field: str,
+    value: list[str],
+    expected_code: str,
+) -> None:
+    payload = _recipe_payload()
+    payload[field] = value
+    if field == "allowed_tool_ids":
+        payload["required_validator_ids"] = ["playbook.self_check"]
+        for fact in payload["required_facts"]:
+            fact["validator_id"] = "playbook.self_check"
+    if field == "allowed_scene_types":
+        for scene in payload["lesson_plan"]["scenes"]:
+            scene["preferred_scene_type"] = "graph_scene"
+    recipe = SkillRecipe.model_validate(payload)
+    coverage = _coverage(recipe)
+    context = build_skill_recipe_validation_context(RuntimeToolHub())
+
+    report = validate_skill_recipe(recipe, coverage, context)
+
+    assert report.valid is False
+    assert expected_code in {issue.code for issue in report.issues}
+
+
+def test_recipe_validator_blocks_asset_and_scene_limit_failures() -> None:
+    recipe = SkillRecipe.model_validate(_recipe_payload())
+    context = build_skill_recipe_validation_context(RuntimeToolHub())
+    context = SkillRecipeValidationContext(
+        deterministic_tool_ids=context.deterministic_tool_ids,
+        validator_tool_ids=context.validator_tool_ids,
+        required_validator_tool_ids=context.required_validator_tool_ids,
+        fact_validator_tool_ids=context.fact_validator_tool_ids,
+        compiled_scene_snapshot_kinds=context.compiled_scene_snapshot_kinds,
+        compiled_scene_domains=context.compiled_scene_domains,
+        supported_snapshot_kinds=context.supported_snapshot_kinds,
+        available_asset_ids=frozenset(),
+        asset_pack_domains=context.asset_pack_domains,
+        max_scene_count=2,
+    )
+
+    report = validate_skill_recipe(recipe, _coverage(recipe), context)
+
+    assert {issue.code for issue in report.issues} == {
+        "recipe.asset_unavailable",
+        "recipe.scene_limit_exceeded",
+    }
+
+
+def test_compiler_capability_set_is_a_subset_of_scene_blueprint_schema() -> None:
+    schema_types = set(scene_blueprint_schema()["properties"]["sceneType"]["enum"])
+    assert COMPILE_SUPPORTED_SCENE_TYPES <= schema_types
+    assert "graph_scene" in schema_types
+    assert "graph_scene" not in COMPILE_SUPPORTED_SCENE_TYPES
+
+
+def test_recipe_validator_rejects_non_validator_tool_for_fact_validation() -> None:
+    payload = _recipe_payload()
+    payload["allowed_tool_ids"] = ["scene_blueprint.compile"]
+    payload["required_validator_ids"] = ["scene_blueprint.compile"]
+    for fact in payload["required_facts"]:
+        fact["validator_id"] = "scene_blueprint.compile"
+    recipe = SkillRecipe.model_validate(payload)
+
+    report = validate_skill_recipe(
+        recipe,
+        _coverage(recipe),
+        build_skill_recipe_validation_context(RuntimeToolHub()),
+    )
+
+    assert "recipe.validator_unavailable" in {issue.code for issue in report.issues}
+
+
+def test_required_semantic_asset_cannot_bypass_manifest_resolution() -> None:
+    payload = _recipe_payload()
+    payload["asset_requirements"] = [
+        {"semantic_role": "does_not_exist", "required": True}
+    ]
+
+    with pytest.raises(ValidationError, match="required asset"):
+        SkillRecipe.model_validate(payload)
+
+
+def test_recipe_validator_requires_declared_snapshot_for_each_scene() -> None:
+    payload = _recipe_payload()
+    payload["allowed_snapshot_kinds"] = ["math_plot"]
+    recipe = SkillRecipe.model_validate(payload)
+
+    report = validate_skill_recipe(
+        recipe,
+        _coverage(recipe),
+        build_skill_recipe_validation_context(RuntimeToolHub()),
+    )
+
+    assert "recipe.scene_snapshot_mismatch" in {issue.code for issue in report.issues}
+
+
+def test_recipe_validator_rejects_scene_and_asset_from_another_domain() -> None:
+    payload = _recipe_payload()
+    payload["domain"] = "math"
+    payload["lesson_plan"]["domain"] = "math"
+    recipe = SkillRecipe.model_validate(payload)
+
+    report = validate_skill_recipe(
+        recipe,
+        _coverage(recipe),
+        build_skill_recipe_validation_context(RuntimeToolHub()),
+    )
+
+    assert {"recipe.scene_domain_mismatch", "recipe.asset_domain_mismatch"} <= {
+        issue.code for issue in report.issues
+    }
+
+
+def test_recipe_validator_requires_schema_and_semantic_final_gates() -> None:
+    payload = _recipe_payload()
+    payload["allowed_tool_ids"] = ["playbook.schema.validate", "scene_blueprint.compile"]
+    payload["required_validator_ids"] = ["playbook.schema.validate"]
+    for fact in payload["required_facts"]:
+        fact["validator_id"] = "playbook.schema.validate"
+    recipe = SkillRecipe.model_validate(payload)
+
+    report = validate_skill_recipe(
+        recipe,
+        _coverage(recipe),
+        build_skill_recipe_validation_context(RuntimeToolHub()),
+    )
+
+    assert {"recipe.validator_required", "recipe.fact_validator_invalid"} <= {
+        issue.code for issue in report.issues
+    }
+
+
+def test_all_compiler_capabilities_match_actual_snapshot_kind_and_domain() -> None:
+    from app.domain.services.scene_blueprint_compiler import compile_scene_blueprint_to_playbook
+
+    for scene_type, capability in COMPILED_SCENE_CAPABILITIES.items():
+        playbook = compile_scene_blueprint_to_playbook({
+            "id": scene_type,
+            "subject": capability.domain,
+            "sceneType": scene_type,
+            "title": scene_type,
+            "visualIntent": ["contract_check"],
+        })
+        actual_kinds = {str(step.snapshot.kind) for step in playbook.steps}
+        assert playbook.domain == capability.domain
+        assert actual_kinds == set(capability.snapshot_kinds)
+
+
+def _keys(value: object) -> set[str]:
+    if isinstance(value, dict):
+        return set(value) | {key for child in value.values() for key in _keys(child)}
+    if isinstance(value, list):
+        return {key for child in value for key in _keys(child)}
+    return set()

--- a/apps/web/public/schemas/skill-recipe.schema.json
+++ b/apps/web/public/schemas/skill-recipe.schema.json
@@ -1,0 +1,369 @@
+{
+  "$defs": {
+    "AssetRequirement": {
+      "additionalProperties": false,
+      "properties": {
+        "semantic_role": {
+          "minLength": 1,
+          "title": "Semantic Role",
+          "type": "string"
+        },
+        "asset_id": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asset Id"
+        },
+        "pack_id": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pack Id"
+        },
+        "required": {
+          "default": true,
+          "title": "Required",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "semantic_role"
+      ],
+      "title": "AssetRequirement",
+      "type": "object"
+    },
+    "FactRequirement": {
+      "additionalProperties": false,
+      "properties": {
+        "fact_id": {
+          "minLength": 1,
+          "title": "Fact Id",
+          "type": "string"
+        },
+        "description": {
+          "minLength": 1,
+          "title": "Description",
+          "type": "string"
+        },
+        "validator_id": {
+          "minLength": 1,
+          "title": "Validator Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fact_id",
+        "description",
+        "validator_id"
+      ],
+      "title": "FactRequirement",
+      "type": "object"
+    },
+    "LessonPlan": {
+      "additionalProperties": false,
+      "description": "Renderer-independent teaching plan shared by every generation path.",
+      "properties": {
+        "schema_version": {
+          "const": "1.0.0",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "domain": {
+          "minLength": 1,
+          "title": "Domain",
+          "type": "string"
+        },
+        "title": {
+          "minLength": 1,
+          "title": "Title",
+          "type": "string"
+        },
+        "learning_objectives": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Learning Objectives",
+          "type": "array"
+        },
+        "prerequisites": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Prerequisites",
+          "type": "array"
+        },
+        "misconceptions": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Misconceptions",
+          "type": "array"
+        },
+        "expected_conclusion": {
+          "minLength": 1,
+          "title": "Expected Conclusion",
+          "type": "string"
+        },
+        "lesson_arc": {
+          "enum": [
+            "intuition_to_abstraction",
+            "problem_to_solution",
+            "state_transition",
+            "comparison",
+            "derivation"
+          ],
+          "title": "Lesson Arc",
+          "type": "string"
+        },
+        "scenes": {
+          "items": {
+            "$ref": "#/$defs/SceneIntent"
+          },
+          "minItems": 1,
+          "title": "Scenes",
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "domain",
+        "title",
+        "learning_objectives",
+        "prerequisites",
+        "misconceptions",
+        "expected_conclusion",
+        "lesson_arc",
+        "scenes"
+      ],
+      "title": "LessonPlan",
+      "type": "object"
+    },
+    "QualityExpectation": {
+      "additionalProperties": false,
+      "properties": {
+        "dimension": {
+          "$ref": "#/$defs/QualityScoreDimension"
+        },
+        "minimum_score": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Minimum Score",
+          "type": "number"
+        },
+        "blocking": {
+          "default": true,
+          "title": "Blocking",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "dimension",
+        "minimum_score"
+      ],
+      "title": "QualityExpectation",
+      "type": "object"
+    },
+    "QualityScoreDimension": {
+      "enum": [
+        "schema",
+        "knowledge_correctness",
+        "prompt_coverage",
+        "pedagogy",
+        "scene_contract",
+        "visual_structure",
+        "code_sync",
+        "narration_visual_consistency",
+        "timeline",
+        "asset_license",
+        "export_readiness"
+      ],
+      "title": "QualityScoreDimension",
+      "type": "string"
+    },
+    "SceneIntent": {
+      "additionalProperties": false,
+      "description": "One pedagogical decision, without renderer or layout details.",
+      "properties": {
+        "scene_id": {
+          "minLength": 1,
+          "title": "Scene Id",
+          "type": "string"
+        },
+        "teaching_goal": {
+          "minLength": 1,
+          "title": "Teaching Goal",
+          "type": "string"
+        },
+        "strategy": {
+          "enum": [
+            "intuition",
+            "demonstration",
+            "derivation",
+            "comparison",
+            "state_transition",
+            "summary"
+          ],
+          "title": "Strategy",
+          "type": "string"
+        },
+        "required_fact_ids": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Required Fact Ids",
+          "type": "array"
+        },
+        "required_visual_roles": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Required Visual Roles",
+          "type": "array"
+        },
+        "preferred_scene_type": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Preferred Scene Type"
+        },
+        "narration_goal": {
+          "minLength": 1,
+          "title": "Narration Goal",
+          "type": "string"
+        }
+      },
+      "required": [
+        "scene_id",
+        "teaching_goal",
+        "strategy",
+        "required_fact_ids",
+        "required_visual_roles",
+        "preferred_scene_type",
+        "narration_goal"
+      ],
+      "title": "SceneIntent",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Transient, data-only execution recipe for composable coverage.",
+  "properties": {
+    "schema_version": {
+      "const": "1.0.0",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "recipe_id": {
+      "minLength": 1,
+      "title": "Recipe Id",
+      "type": "string"
+    },
+    "domain": {
+      "minLength": 1,
+      "title": "Domain",
+      "type": "string"
+    },
+    "lesson_plan": {
+      "$ref": "#/$defs/LessonPlan"
+    },
+    "required_facts": {
+      "items": {
+        "$ref": "#/$defs/FactRequirement"
+      },
+      "title": "Required Facts",
+      "type": "array"
+    },
+    "allowed_tool_ids": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Allowed Tool Ids",
+      "type": "array"
+    },
+    "required_validator_ids": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Required Validator Ids",
+      "type": "array"
+    },
+    "allowed_scene_types": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Allowed Scene Types",
+      "type": "array"
+    },
+    "allowed_snapshot_kinds": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Allowed Snapshot Kinds",
+      "type": "array"
+    },
+    "asset_requirements": {
+      "items": {
+        "$ref": "#/$defs/AssetRequirement"
+      },
+      "title": "Asset Requirements",
+      "type": "array"
+    },
+    "quality_expectations": {
+      "items": {
+        "$ref": "#/$defs/QualityExpectation"
+      },
+      "minItems": 1,
+      "title": "Quality Expectations",
+      "type": "array"
+    }
+  },
+  "required": [
+    "schema_version",
+    "recipe_id",
+    "domain",
+    "lesson_plan",
+    "required_facts",
+    "allowed_tool_ids",
+    "required_validator_ids",
+    "allowed_scene_types",
+    "allowed_snapshot_kinds",
+    "asset_requirements",
+    "quality_expectations"
+  ],
+  "title": "SkillRecipe",
+  "type": "object"
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@
 | [pipeline.md](./pipeline.md) | single / agent 生成路径、PlaybookScript、DirectorScript 挂载点、视频导出管线 |
 | [lesson-plan.md](./lesson-plan.md) | 三条生成路径共享的教学规划契约、持久化、边界与当前限制 |
 | [coverage-and-fallback.md](./coverage-and-fallback.md) | CoverageDecision 四种能力模式、受控组合、阻断与持久化边界 |
+| [skill-recipe.md](./skill-recipe.md) | composable 请求的临时执行契约、确定性验证和安全边界 |
 | [quality-gate.md](./quality-gate.md) | 后端 Canonical QualityReport、修复、持久化、Director 与导出阻断语义 |
 | [frontend-shell.md](./frontend-shell.md) | Stage 路由、GlobalTopbar、Studio 布局、Provider 配置、snapshot support levels |
 | [animation-tool-registry.md](./animation-tool-registry.md) | 后端 animation tool registry 的扩展流程、当前工具和新增规则 |

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -15,7 +15,7 @@ User input
   -> subject understanding / router
   -> CoverageDecision
   -> LessonPlan
-  -> SkillPack / agent / legacy CIR
+  -> SkillPack / SkillRecipe (composable) / agent / legacy CIR
   -> PlaybookScript
   -> canonical backend QualityReport
   -> DirectorScript
@@ -50,12 +50,13 @@ Agent mode is an active verification path, not the default production claim. To 
 2. `docs/pipeline.md` — generation modes, PlaybookScript, and export path.
 3. `docs/lesson-plan.md` — shared teaching decisions and the renderer-free contract.
 4. `docs/coverage-and-fallback.md` — capability modes, controlled composition and fail-closed boundaries.
-5. `docs/quality-gate.md` — backend success semantics, repair, persistence, and export recheck.
-6. `docs/benchmark-v2.md` — four Gold Cases and strict product-quality scoring.
-7. `docs/agent-demo-acceptance.md` — how to prove agent / runtime-tool mode actually works.
-8. `docs/skill-pack-architecture.md` — deterministic SkillPack contract.
-9. `docs/frontend-shell.md` — frontend page and studio shell structure.
-10. `AGENTS.md` — required working rules for coding agents.
+5. `docs/skill-recipe.md` — transient composable execution contract and validator boundary.
+6. `docs/quality-gate.md` — backend success semantics, repair, persistence, and export recheck.
+7. `docs/benchmark-v2.md` — four Gold Cases and strict product-quality scoring.
+8. `docs/agent-demo-acceptance.md` — how to prove agent / runtime-tool mode actually works.
+9. `docs/skill-pack-architecture.md` — deterministic SkillPack contract.
+10. `docs/frontend-shell.md` — frontend page and studio shell structure.
+11. `AGENTS.md` — required working rules for coding agents.
 
 ## What not to do now
 

--- a/docs/coverage-and-fallback.md
+++ b/docs/coverage-and-fallback.md
@@ -74,19 +74,22 @@ same domain is not enough to claim `composable`.
 
 `available_tool_ids` contains the minimum relevant tools that discovery proved available for
 this decision. It is audit evidence, not an authorization boundary and not proof that a tool was
-executed. The planned `SkillRecipe`/RecipeExecutor phase will enforce per-request tool allowlists.
+executed. The `SkillRecipe` contract and RecipeValidator now enforce a narrower per-request
+allowlist; production wiring to the planned RecipeExecutor is not active yet.
 
 ## Current execution status
 
 - Production/verified: contract, deterministic resolver, SQLite persistence, API response,
   QualityReport mode propagation, fail-closed unsupported/experimental behavior, Agent/CIR
   prompt binding, and History diagnostics.
+- Production/verified: the transient `SkillRecipe` contract, canonical public schema and
+  deterministic RecipeValidator.
 - Transitional: a `composable` decision continues through the existing agent or legacy CIR
-  generation path with the boundary attached. It does not yet create or execute a
-  `SkillRecipe`, so this is not the final Generalist execution architecture.
+  generation path with the boundary attached. It does not yet create or execute a recipe in the
+  live pipeline, so this is not the final Generalist execution architecture.
 - Legacy: `RouteDecision` and topic `SkillMode` remain prompt/routing context. Neither is a
   substitute for CoverageDecision.
-- Planned: Generalist Composer, SkillRecipe validation/execution, Capability Gap recording and
+- Planned: Generalist Composer, SkillRecipe production execution, Capability Gap recording and
   offline SkillForge. Generalist Composer must not be registered as a universal SkillPack.
 
 ## Persistence and UI

--- a/docs/skill-recipe.md
+++ b/docs/skill-recipe.md
@@ -1,0 +1,57 @@
+# SkillRecipe
+
+Status: Active contract and validator; execution and Generalist Composer are planned.
+
+`SkillRecipe` is a transient, data-only execution plan for a request whose
+`CoverageDecision` is `composable`. It is never written to the SkillPack registry and cannot
+create code, choose filesystem paths, embed raw SVG, invoke shell commands, or bypass the
+canonical Quality Gate.
+
+```text
+CoverageDecision(composable)
+  + LessonPlan
+  -> SkillRecipe
+  -> RecipeValidator
+  -> planned RecipeExecutor / RuntimeToolHub
+  -> SceneBlueprint
+  -> PlaybookScript
+  -> Canonical QualityReport
+```
+
+## Contract
+
+The canonical Pydantic contract is
+`apps/api/app/domain/models/skill_recipe.py`. Its checked-in public schema is
+`apps/web/public/schemas/skill-recipe.schema.json` and is generated with:
+
+```bash
+cd apps/api
+uv run python -m scripts.export_public_schemas
+```
+
+The recipe contains verified fact requirements, an exact RuntimeToolHub allowlist, required
+validators, compilable SceneBlueprint templates, canonical snapshot kinds, semantic asset
+requirements and QualityReport score expectations. Its embedded LessonPlan remains free of
+renderer/layout data.
+
+## Validation boundary
+
+The pure domain validator accepts a validation context assembled at the application edge. The
+context derives from existing sources of truth:
+
+- deterministic tools: `RuntimeToolHub.list_tools()`;
+- snapshots: `SUPPORTED_SNAPSHOT_KIND_SET`;
+- scenes: the compiler's executable scene set, not the broader JSON Schema enum;
+- assets: checked-in Asset Manifest packs;
+- quality dimensions: `QualityScoreDimension` used by `QualityReport`.
+
+Validation fails when coverage is not composable, the recipe exceeds coverage's tool evidence,
+a tool/validator is missing or non-deterministic, a scene is schema-valid but not compilable, a
+snapshot kind is unsupported, an explicit asset cannot be resolved, or the lesson exceeds the
+bounded scene count.
+
+## Current limitation
+
+Production does not yet ask a Generalist Composer to create this object and does not yet execute
+it. Until the RecipeExecutor lands, composable requests continue through the transitional
+generation path documented in `coverage-and-fallback.md`.


### PR DESCRIPTION
## Summary

- add the transient SkillRecipe domain contract and generated public JSON schema
- validate composable coverage, deterministic tool/validator allowlists, compiler-backed scene/snapshot/domain mappings, and manifest-backed assets
- expose canonical QualityReport score dimensions and shared final validator IDs
- document the production contract versus the still-planned Generalist Composer/RecipeExecutor wiring

## Safety boundary

- no registry writes, code generation, shell execution, filesystem paths, raw SVG, or alternate rendering protocol
- recipe tools must remain within CoverageDecision evidence and RuntimeToolHub deterministic capabilities
- schema-valid renderer aliases that the backend cannot compile are rejected
- required facts retain semantic self-check; scene and asset domains must match the recipe

## Verification

- `make check`
  - API: 944 passed, 2 skipped
  - Web: 958 passed
  - Agent: 63 passed
  - MCP: 18 passed
  - Web and Agent builds passed
- focused SkillRecipe/coverage/compiler suite: 95 passed
- independent read-only review reproduced and then verified closure of validator, asset, scene/snapshot, and domain allowlist bypasses

## Follow-up

Recipe execution and Generalist Composer production wiring remain a separate rollbackable PR.