### PR TITLE
feat: add MetaView public landing page

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,6 @@
 # MetaView Design Language
 
-> 状态：Draft v0.1  
+> 状态：Current baseline v0.2
 > 适用范围：`apps/web` 公共页面、输入页、工作台、播放器、历史、模板、设置与共享组件  
 > 更新日期：2026-07-11
 
@@ -71,6 +71,18 @@ Director 层决定顺序、节奏、镜头和焦点，因此这些概念应在�
 - 焦点高亮；
 - 高级参数的渐进披露。
 
+### 2.4 当前界面分层
+
+整个前端共享同一套品牌原则，但不同表面承担不同任务，不强制使用完全相同的局部色板：
+
+1. **公共品牌层**：Landing、公共导航和默认产品截图使用暖白 / 克制深色与 Sage Accent；
+2. **应用壳层**：工作台、历史、模板、设置共享 `themeVars()` 注入的语义 Token，并允许用户选择工作区主题；
+3. **学习播放器层**：播放器使用独立的纸面 Token，保持画布、时间线和控制台之间的阅读层级；
+4. **Renderer 层**：数学、算法、科学等 Renderer 可维护表达数据关系所需的局部语义色，但不得反向覆盖应用壳层品牌变量；
+5. **运维层**：Ops 页面优先信息密度、状态辨识和操作效率，不套用官网 Hero 语言。
+
+因此，“品牌一致”指层级、语气、交互与默认主题一致，不表示所有数据可视化颜色都必须替换成 Sage。
+
 ---
 
 ## 3. 禁止方向
@@ -134,7 +146,7 @@ THEORETICAL CANVAS
 | Token | Value | Usage |
 |---|---:|---|
 | `--bg` | `#F4F1EA` | 页面背景 |
-| `--surface` | `#FFFFFF` | 主表面 |
+| `--surface` | `#FFFFFF` | 主表面；由 `themeVars()` 注入 |
 | `--surface-2` | `#FAF8F3` | 次级表面 |
 | `--ink` | `#161A18` | 主文字 |
 | `--ink-2` | `#5D655F` | 次级文字 |
@@ -142,16 +154,15 @@ THEORETICAL CANVAS
 | `--line` | `#E6E2D5` | 默认边框 |
 | `--line-2` | `#D6D1C2` | 强边框 |
 | `--accent` | `#82976F` | 品牌强调色 |
-| `--accent-soft` | `rgba(130,151,111,.14)` | 选择和弱高亮 |
+| `--accent-soft` | `#82976F26` | 选择和弱高亮；约 15% 透明度 |
 | `--warn` | `#E9A23B` | 警告 |
-| `--danger` | `#B7664B` | 错误和危险操作 |
 
 ### 5.2 深色主题
 
 | Token | Value |
 |---|---:|
 | `--bg` | `#0B0F0D` |
-| `--surface` | `#111715` |
+| `--surface` | `#11171580` |
 | `--surface-2` | `#0E1412` |
 | `--ink` | `#E8EFE9` |
 | `--ink-2` | `#9BA8A0` |
@@ -159,9 +170,12 @@ THEORETICAL CANVAS
 | `--line` | `#1D2A23` |
 | `--line-2` | `#27332C` |
 | `--accent` | `#9FB48D` |
-| `--accent-soft` | `rgba(159,180,141,.16)` |
+| `--accent-soft` | `#9FB48D26` |
 | `--warn` | `#E9A23B` |
-| `--danger` | `#FF9E8A` |
+
+`--bg-2`、`--accent-2`、`--accent-dim`、`--radius` 和 `--radius-sm` 也由
+`themeVars()` 提供。成功、失败等运行状态目前使用页面或组件边界内的语义变量，
+例如 History 的 `--mv-status-*`；项目尚未提供全局 `--danger` Token，不应在新代码中假定它存在。
 
 ### 5.3 强调色规则
 
@@ -184,7 +198,8 @@ THEORETICAL CANVAS
 
 一个视口通常只有一个主要强调焦点。
 
-Monokai、Nord 和 Solarized 属于工作区个性化主题，不属于 MetaView 品牌色板。
+Monokai、Nord 和 Solarized 属于工作区个性化主题，不属于 MetaView 品牌色板。公共 Landing
+固定跟随品牌 light / dark 类型，不直接继承这些命名工作区主题。
 
 ---
 
@@ -261,8 +276,8 @@ font-family: "IBM Plex Mono", ui-monospace, monospace;
 
 - 密度模式用于工作台，不控制官网间距；
 - 默认密度为 `regular`；
-- Landing 分区上下间距通常为 `80–112px`；
-- 公共页面左右 Padding 为 `24–32px`；
+- Landing 分区上下间距使用 `clamp(78px, 9vw, 116px)`，手机收敛为 `70px`；
+- 公共页面左右 Padding 默认由 `clamp(18px, 3vw, 32px)` 控制，`640px` 以下为 `14px`；
 - 卡片内部 Padding 为 `14–24px`；
 - 密度变化不得降低触控目标。
 
@@ -532,15 +547,17 @@ comet
 
 ## 14. 响应式与可访问性
 
-优先复用现有断点：
+断点按表面复用，不建立一套脱离现有布局的全局断点：
 
-```text
-900px
-720px
-680px
-640px
-380px
-```
+| Surface | Current breakpoints |
+|---|---|
+| Landing | `1080px`, `820px`, `640px`, `390px` |
+| App shell / Studio | `900px`, `720px`, `680px`, `640px`, `380px` |
+| Player | `1180px`, `920px`, `680px` |
+| Tools / Ops | `1024px`, `640px` |
+
+新样式优先加入对应表面的现有断点。只有真实布局在区间内失效时才增加断点，并在同一 PR
+中补充相应视口验证。
 
 移动端：
 
@@ -613,13 +630,21 @@ AI 正在施展魔法…
 
 ### 16.1 Source of Truth
 
-1. `DESIGN.md`：产品设计决策；
-2. `shared/config/themePalette.ts`：主题色板；
-3. `useTweaks.ts`：运行时 CSS Variable；
-4. `styles/tokens.css`：共享 Token；
-5. 页面 CSS：布局和页面特有组合。
+当前实现的权威边界按以下顺序理解：
 
-不得在 JSX 中新增固定颜色、圆角和动效时长；Inline Style 仅用于运行时几何和数据值。
+1. `DESIGN.md`：产品设计原则、表面分层和新功能约束；
+2. `shared/config/themePalette.ts`：工作区主题中可配置的语义色板；
+3. `features/studio-editor/hooks/useTweaks.ts` 的 `themeVars()`：浏览器实际收到的壳层 CSS Variable；
+4. `styles/tokens.css`：当前已落地的共享 Density Token；
+5. `styles/pages/*.css`：页面布局、页面局部变量和响应式行为；
+6. `features/playbook/engine/**`：Renderer / Remotion 所需的局部可视化色板和回退值。
+
+文档描述目标与约束，运行时文件描述当前可用契约。二者不一致时，不得静默选择其中一方：
+修改代码时同步更新文档，修改规范时明确标记尚未落地的迁移项。
+
+应用壳层和页面 JSX 不新增固定颜色、圆角和动效时长；Inline Style 仅用于运行时几何和数据值。
+Renderer 中与数据语义或导出一致性绑定的颜色可以保留在 Renderer 边界，但应集中为命名色板，
+并同时覆盖 light / dark 与 SSR / Remotion 回退路径。
 
 ### 16.2 CSS 目录
 
@@ -634,11 +659,13 @@ styles/
       shell.css
       content.css
       responsive.css
+      compat.css
     studio.css
     playbook.css
     history.css
     templates.css
     settings.css
+    tools.css
 ```
 
 - Page CSS 负责页面布局；
@@ -660,12 +687,14 @@ styles/
 
 ## 17. 当前已知迁移项
 
-1. 全局旧 Accent `#10B981` 与播放器 Sage Accent 不一致；默认品牌主题统一为 `#82976F / #9FB48D`。
-2. `tokens.css` 当前主要记录 Density，后续应补齐状态色、间距、圆角、阴影和动效 Token。
-3. `studio.css` 职责过多，Landing 已拆入独立目录，其他共享控件继续逐步迁移。
-4. 当前页面仍存在 `6px–14px` 的圆角漂移，新功能遵守本文尺度。
-5. 模板页仍包含 Raw Prompt 和开发者路径，公共产品化时应改为真实结果预览。
-6. `/` 已作为公共 Landing，输入页使用 `/create`，应用内首项统一称为“工作台”。
+1. 默认品牌与播放器已采用 `#82976F / #9FB48D`，但部分旧 Renderer 仍使用各自的数据色板；迁移时先判断是否属于数据语义，不能机械替换。
+2. `tokens.css` 当前主要记录 Density；状态色、间距、圆角、阴影和动效尚未形成完整的全局 Token 契约。
+3. `themeVars()` 仍直接提供部分壳层值，`ThemePalette` 尚未覆盖 `--bg`、`--surface`、圆角和完整状态色。
+4. `studio.css` 职责较多，Landing 已拆入独立目录，其他共享控件继续按真实复用需求渐进迁移。
+5. 当前页面仍存在 `6px–14px` 的圆角漂移；新功能遵守本文角色尺度，不为统一数值进行无关重构。
+6. 播放器与 Renderer 存在局部 Token 和硬编码回退，这是渲染 / 导出边界的一部分；新增值应集中管理并保持浏览器与 Remotion 一致。
+7. 模板页仍包含 Raw Prompt 和开发者路径，公共产品化时应改为真实结果预览。
+8. `/` 已作为公共 Landing，输入页使用 `/create`，应用内首项统一称为“工作台”。
 
 ---
 
@@ -700,10 +729,10 @@ styles/
 
 ### 响应式
 
-- [ ] 1440px 桌面检查
-- [ ] 1024px 平板检查
-- [ ] 720px 窄屏检查
-- [ ] 390px 手机检查
+- [ ] `1440 × 900` 桌面检查
+- [ ] `1024 × 768` 平板 / 小桌面检查
+- [ ] `720 × 900` 窄屏检查
+- [ ] `390 × 844` 手机检查
 - [ ] Safe Area / Visual Viewport 检查
 
 ### 产品诚实

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -237,8 +237,8 @@ font-family: "IBM Plex Mono", ui-monospace, monospace;
 
 | Role | Size | Weight | Line Height |
 |---|---:|---:|---:|
-| Landing Display | `clamp(40px, 5vw, 68px)` | `600–650` | `1.06–1.12` |
-| Landing Lead | `17–20px` | `400–500` | `1.55–1.7` |
+| Landing Display | `clamp(44px, 5.4vw, 72px)`; mobile `clamp(39px, 12vw, 52px)` | `600–650` | `1.03–1.12` |
+| Landing Lead | `clamp(15px, 1.3vw, 17px)`; mobile `14px` | `400–500` | `1.68–1.75` |
 | App Hero | `clamp(24px, 2.4vw, 32px)` | `600–650` | `1.25–1.3` |
 | Page Title | `26px` | `600` | `1.25` |
 | Section Title | `15–18px` | `600` | `1.3` |
@@ -398,9 +398,12 @@ Hero 必须展示：
 
 ```css
 background: var(--accent);
-color: white;
+color: var(--accent-contrast);
 border-color: transparent;
 ```
+
+`--accent-contrast` 必须根据当前 Accent 动态选择高对比前景色；不得假设白色在浅色和深色
+品牌 Accent 上都满足可读性。新主题或用户自定义 Accent 也必须通过同一 Token。
 
 ### 10.2 Soft Primary
 
@@ -693,8 +696,9 @@ styles/
 4. `studio.css` 职责较多，Landing 已拆入独立目录，其他共享控件继续按真实复用需求渐进迁移。
 5. 当前页面仍存在 `6px–14px` 的圆角漂移；新功能遵守本文角色尺度，不为统一数值进行无关重构。
 6. 播放器与 Renderer 存在局部 Token 和硬编码回退，这是渲染 / 导出边界的一部分；新增值应集中管理并保持浏览器与 Remotion 一致。
-7. 模板页仍包含 Raw Prompt 和开发者路径，公共产品化时应改为真实结果预览。
-8. `/` 已作为公共 Landing，输入页使用 `/create`，应用内首项统一称为“工作台”。
+7. `styles/pages/tools.css` 仍保留未接入的 `--primary` / `--surface-container` 等旧 Token，且当前未由 `index.css` 导入；它不是当前品牌系统的有效来源，迁移前不得继续扩展。
+8. 模板页仍包含 Raw Prompt 和开发者路径，公共产品化时应改为真实结果预览。
+9. `/` 已作为公共 Landing，输入页使用 `/create`，应用内首项统一称为“工作台”。
 
 ---
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,714 @@
+# MetaView Design Language
+
+> 状态：Draft v0.1  
+> 适用范围：`apps/web` 公共页面、输入页、工作台、播放器、历史、模板、设置与共享组件  
+> 更新日期：2026-07-11
+
+---
+
+## 1. 设计目标
+
+MetaView 是一个面向教育场景的 AI 可视化讲解系统。它不是通用聊天壳、PPT 生成器或单纯的文本转视频工具，而是将知识问题转化为结构化、可播放、可追问和可导出的理解过程：
+
+```text
+学科理解
+→ LessonPlan
+→ PlaybookScript
+→ DirectorScript
+→ RenderPlan
+→ 交互预览 / 视频导出
+```
+
+设计北极星：
+
+> MetaView 应当像一张会推演、会讲解的教材画布，而不是一个会发光的 AI 控制台。
+
+界面必须表达：
+
+- 学术克制，而不是营销喧闹；
+- 结构清晰，而不是卡片堆叠；
+- 动态但安静，动效服务于因果和焦点；
+- 工具可信，过程、状态和版本可被理解；
+- 对能力边界诚实，不把 Benchmark 结果冒充上线能力。
+
+---
+
+## 2. 核心视觉隐喻
+
+### 2.1 理论画布
+
+知识在一张可观察、可聚焦、可变化的画布上展开。
+
+可使用：
+
+- 暖白纸张表面；
+- 低对比细网格；
+- 坐标轴、轨迹、节点和连线；
+- 注释、步骤和焦点标记；
+- 轻边框，而不是厚重容器。
+
+### 2.2 实验仪器
+
+运行状态和处理过程需要准确、稳定、可控制。
+
+可使用：
+
+- 技术标签；
+- Scene / Frame 编号；
+- 状态、时间码和版本；
+- 参数与明确反馈；
+- 等宽字体元信息。
+
+### 2.3 导演工作台
+
+Director 层决定顺序、节奏、镜头和焦点，因此这些概念应在工作台中可见。
+
+可使用：
+
+- 有序步骤；
+- 当前场景；
+- 时间线或纵向轨道；
+- 焦点高亮；
+- 高级参数的渐进披露。
+
+---
+
+## 3. 禁止方向
+
+不得将 MetaView 设计成：
+
+- 蓝紫渐变的通用 AI SaaS；
+- 满屏发光球体或粒子爆炸；
+- 类似 Canva 的模板商城；
+- 低龄卡通教育产品；
+- 默认黑底霓虹的程序员工具；
+- 由大量相同卡片组成的 Dashboard。
+
+避免：
+
+- 每个按钮都使用胶囊形；
+- 每张卡片都添加阴影；
+- 多套图标风格混用；
+- 无意义的 3D 装饰；
+- 大幅度悬浮、弹跳和缩放；
+- 一个视口内存在多个竞争性动态背景。
+
+---
+
+## 4. 品牌系统
+
+主要名称：
+
+```text
+MetaView
+```
+
+可选中文组合：
+
+```text
+演算视界 MetaView
+```
+
+可选技术副标：
+
+```text
+THEORETICAL CANVAS
+```
+
+规则：
+
+- `MetaView` 是主要可读名称；
+- `THEORETICAL CANVAS` 只作为小尺寸品牌元信息；
+- 一个视口不同时堆叠多个英文口号；
+- 中文用于产品叙事，英文用于技术标签和品牌辅助；
+- 当前 `.mv-brand-strip` 是小型 UI 品牌标记，不作为大型 Hero 插画。
+
+---
+
+## 5. 色彩
+
+### 5.1 浅色品牌主题
+
+浅色主题是官网、面试演示和默认产品截图的首选。
+
+| Token | Value | Usage |
+|---|---:|---|
+| `--bg` | `#F4F1EA` | 页面背景 |
+| `--surface` | `#FFFFFF` | 主表面 |
+| `--surface-2` | `#FAF8F3` | 次级表面 |
+| `--ink` | `#161A18` | 主文字 |
+| `--ink-2` | `#5D655F` | 次级文字 |
+| `--ink-3` | `#9AA39D` | 元信息、占位符 |
+| `--line` | `#E6E2D5` | 默认边框 |
+| `--line-2` | `#D6D1C2` | 强边框 |
+| `--accent` | `#82976F` | 品牌强调色 |
+| `--accent-soft` | `rgba(130,151,111,.14)` | 选择和弱高亮 |
+| `--warn` | `#E9A23B` | 警告 |
+| `--danger` | `#B7664B` | 错误和危险操作 |
+
+### 5.2 深色主题
+
+| Token | Value |
+|---|---:|
+| `--bg` | `#0B0F0D` |
+| `--surface` | `#111715` |
+| `--surface-2` | `#0E1412` |
+| `--ink` | `#E8EFE9` |
+| `--ink-2` | `#9BA8A0` |
+| `--ink-3` | `#5B6862` |
+| `--line` | `#1D2A23` |
+| `--line-2` | `#27332C` |
+| `--accent` | `#9FB48D` |
+| `--accent-soft` | `rgba(159,180,141,.16)` |
+| `--warn` | `#E9A23B` |
+| `--danger` | `#FF9E8A` |
+
+### 5.3 强调色规则
+
+强调色用于：
+
+- 当前步骤；
+- 选中状态；
+- 主要操作；
+- Focus Ring；
+- 当前知识对象；
+- 进度和在线状态。
+
+不得用于：
+
+- 整页大面积背景；
+- 长段正文；
+- 每张卡片的装饰；
+- 所有图标的默认颜色；
+- 替代字号和布局层级。
+
+一个视口通常只有一个主要强调焦点。
+
+Monokai、Nord 和 Solarized 属于工作区个性化主题，不属于 MetaView 品牌色板。
+
+---
+
+## 6. 字体与排版
+
+### 6.1 字体
+
+界面与正文：
+
+```css
+font-family:
+  "Inter",
+  -apple-system,
+  system-ui,
+  "PingFang SC",
+  "Noto Sans SC",
+  sans-serif;
+```
+
+品牌与展示标题：
+
+```css
+font-family: "Space Grotesk", "Inter", sans-serif;
+```
+
+技术元信息：
+
+```css
+font-family: "IBM Plex Mono", ui-monospace, monospace;
+```
+
+等宽字体只用于 Run ID、时间码、Scene、Frame、代码、状态和技术标签，不用于长段教学正文。
+
+### 6.2 字号
+
+| Role | Size | Weight | Line Height |
+|---|---:|---:|---:|
+| Landing Display | `clamp(40px, 5vw, 68px)` | `600–650` | `1.06–1.12` |
+| Landing Lead | `17–20px` | `400–500` | `1.55–1.7` |
+| App Hero | `clamp(24px, 2.4vw, 32px)` | `600–650` | `1.25–1.3` |
+| Page Title | `26px` | `600` | `1.25` |
+| Section Title | `15–18px` | `600` | `1.3` |
+| Body | `13–14.5px` | `400` | `1.55–1.65` |
+| Control | `11.5–13px` | `500–600` | `1.3–1.45` |
+| Metadata | `9.5–11px` | `400–600` | `1.3–1.45` |
+
+规则：
+
+- 中文标题不增加人工字间距；
+- 宽字距和大写只用于短技术标签；
+- 避免超粗字体；
+- 正文默认左对齐；
+- 居中仅用于短 Hero、空状态和单一结论。
+
+---
+
+## 7. 间距与密度
+
+基础间距尺度：
+
+```text
+4, 6, 8, 10, 12, 14, 18, 24, 32, 48, 64, 96
+```
+
+现有密度模式：
+
+```css
+.mv-density-compact { --pad: 12px; --gap: 10px; --radius-card: 12px; }
+.mv-density-regular { --pad: 18px; --gap: 14px; --radius-card: 14px; }
+.mv-density-comfy   { --pad: 24px; --gap: 18px; --radius-card: 16px; }
+```
+
+规则：
+
+- 密度模式用于工作台，不控制官网间距；
+- 默认密度为 `regular`；
+- Landing 分区上下间距通常为 `80–112px`；
+- 公共页面左右 Padding 为 `24–32px`；
+- 卡片内部 Padding 为 `14–24px`；
+- 密度变化不得降低触控目标。
+
+---
+
+## 8. 形状、边框与阴影
+
+### 8.1 圆角
+
+| Role | Radius |
+|---|---:|
+| 状态 Badge / 代码标签 | `4px` |
+| 紧凑控件 | `6–8px` |
+| 按钮 / 输入框 | `8–10px` |
+| 标准卡片 | `12px` |
+| 主 Composer / 大卡片 | `14px` |
+| Comfy 卡片 | `16px` |
+| 附件 / 建议 / Pill | `999px` |
+
+不是所有按钮都做成 Pill。Pill 只承载短、原子化信息。
+
+### 8.2 边框
+
+```css
+border: 1px solid var(--line);
+```
+
+Focus 或强边框：
+
+```css
+border-color: color-mix(in srgb, var(--accent) 30%, var(--line-2));
+```
+
+虚线仅用于建议问题、拖拽区域、空状态和可选操作。
+
+### 8.3 阴影
+
+MetaView 遵循“边框优先，阴影其次”。
+
+阴影只用于：
+
+- 主输入 Composer；
+- 学习画布；
+- 浮动步骤面板；
+- Modal 和 Popover。
+
+普通卡片网格不得全部添加阴影。
+
+---
+
+## 9. 布局
+
+### 9.1 Landing Page
+
+建议容器：
+
+```css
+width: min(1200px, calc(100vw - 48px));
+margin-inline: auto;
+```
+
+结构：
+
+```text
+公共导航
+Hero：价值主张 + 理论画布
+工作原理
+四视图联动能力
+真实案例预留区
+生成链说明
+最终 CTA
+Footer
+```
+
+Hero 必须展示：
+
+```text
+题目
+→ 教学结构
+→ 导演焦点
+→ 可视化讲解
+```
+
+不得只放通用 Dashboard 截图。
+
+### 9.2 应用 Topbar
+
+- 最小高度 `56px`；
+- 半透明 Surface；
+- 底部 `1px` 边框；
+- 品牌左侧、应用导航居中、工具右侧；
+- 应用内首项叫“工作台”，公共 `/` 才叫首页；
+- Topbar 的视觉权重低于当前任务。
+
+### 9.3 播放器
+
+桌面结构：
+
+```text
+52px 步骤轨道
++ 自适应学习画布
++ 280–348px 控制台
+```
+
+学习画布是绝对视觉中心。移动端不得压缩桌面三栏，应改为纵向布局或抽屉。
+
+### 9.4 卡片原则
+
+卡片必须代表真实信息分组。不得仅为了填补空白、重复父级边框或让页面看起来“有设计”而创建卡片。
+
+---
+
+## 10. 组件
+
+### 10.1 Primary Button
+
+一个区域只允许一个主操作：
+
+```css
+background: var(--accent);
+color: white;
+border-color: transparent;
+```
+
+### 10.2 Soft Primary
+
+用于明显但不厚重的操作：
+
+```css
+background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+color: color-mix(in srgb, var(--accent) 68%, var(--ink));
+border-color: color-mix(in srgb, var(--accent) 16%, transparent);
+```
+
+### 10.3 Secondary / Ghost
+
+```css
+/* Secondary */
+background: var(--surface);
+color: var(--ink-2);
+border: 1px solid var(--line);
+
+/* Ghost */
+background: transparent;
+border-color: transparent;
+color: var(--ink-2);
+```
+
+按钮状态：
+
+- Hover 改变颜色、边框或背景；
+- 不使用大幅位移和缩放；
+- Disabled 使用 `opacity: .5–.6`；
+- Focus 必须可见。
+
+### 10.4 Icon Button
+
+- 桌面紧凑工具 `32–36px`；
+- 移动端触控目标最小 `44px`；
+- 图标视觉尺寸 `14–16px`；
+- Stroke Width `1.75–1.8`；
+- 同一组不混用 Filled 与 Outline；
+- Icon-only Button 必须有 `aria-label`。
+
+### 10.5 Input
+
+- 使用 `--surface` 或 `--surface-2`；
+- `1px` 中性边框；
+- Focus 使用 Accent Border；
+- 不使用高饱和外发光；
+- 大尺寸生成 Composer 可以使用轻阴影。
+
+### 10.6 Chip / Pill
+
+- `8px` Chip：筛选、设置、小操作；
+- `999px` Pill：附件、建议问题、短状态；
+- 长句不得放入 Pill。
+
+---
+
+## 11. 学习画布与 Renderer
+
+学习 Stage：
+
+- 比例 `16:9`；
+- 暖白纸张或克制深色表面；
+- 圆角约 `8px`；
+- 低对比细边框；
+- 轻微悬浮；
+- 浅色模式不使用厚重黑框。
+
+视觉层级：
+
+1. 核心知识对象；
+2. 当前焦点；
+3. 辅助结构；
+4. 元信息与注释。
+
+数学与科学画面：
+
+- 坐标轴弱于数据；
+- 网格保持低对比；
+- 公式优先可读；
+- 使用空间关系和运动说明因果；
+- 跨场景保持对象身份与颜色一致；
+- 不为了“高级感”增加无意义粒子。
+
+Director 动效必须表达焦点、顺序、对比、因果、尺度或节奏，不得只为了“更动态”移动镜头。
+
+---
+
+## 12. 装饰性视觉母题
+
+`MetaParticleField` 提供：
+
+```text
+canvas
+singularity
+orbit
+comet
+```
+
+正式使用规则：
+
+- 只作为装饰；
+- 必须 `aria-hidden="true"`；
+- 一个主要视口最多一种母题；
+- 低透明度；
+- 动画周期通常大于 `8s`；
+- 移动端简化或隐藏；
+- Reduced Motion 下停止。
+
+它应表达“知识轨迹”，而不是宇宙粒子特效。
+
+---
+
+## 13. 动效
+
+| Interaction | Duration |
+|---|---:|
+| Hover / Color / Border | `150–160ms` |
+| Shell / 小面板 | `180ms` |
+| Modal | `180–220ms` |
+| 环境装饰循环 | `8–44s` |
+
+优先使用：
+
+- `opacity`；
+- `transform`；
+- `background-color`；
+- `border-color`。
+
+建议幅度：
+
+- Translate `2–8px`；
+- Scale `0.98–1.02`。
+
+禁止弹跳、大幅缩放、Elastic Easing 和引发布局跳动的动画。
+
+所有装饰动效必须支持：
+
+```css
+@media (prefers-reduced-motion: reduce)
+```
+
+---
+
+## 14. 响应式与可访问性
+
+优先复用现有断点：
+
+```text
+900px
+720px
+680px
+640px
+380px
+```
+
+移动端：
+
+- 单主列；
+- Composer 全宽；
+- 减少装饰密度；
+- 保留导航能力；
+- 页面不产生横向滚动；
+- 只有 Chip 或时间线允许局部横向滚动；
+- 使用 Safe Area 与 Visual Viewport Height；
+- 触控目标最小 `44 × 44px`。
+
+可访问性：
+
+- 优先语义化 HTML；
+- 支持键盘；
+- 使用可见 `:focus-visible`；
+- 状态不只依赖颜色；
+- 关键信息不能只通过 Hover 出现；
+- Modal 正确管理 Focus；
+- 异步生成状态使用 `role="status"`、`aria-live` 或等价语义。
+
+Focus 基准：
+
+```css
+outline: 2px solid color-mix(in srgb, var(--accent) 46%, transparent);
+outline-offset: 2px;
+```
+
+---
+
+## 15. 文案
+
+语气：精确、平静、教育导向、动作明确、对能力诚实。
+
+推荐状态：
+
+```text
+正在理解题目…
+正在生成教学计划…
+正在编排画面…
+正在准备预览…
+```
+
+禁止：
+
+```text
+AI 正在施展魔法…
+正在创造无限可能…
+```
+
+推荐官网表达：
+
+```text
+把一道题转化为可播放、可追问、可导出的分步讲解。
+```
+
+避免无法验证的口号：
+
+```text
+重新定义未来教育。
+释放 AI 无限潜力。
+```
+
+短英文技术标签可用于 `SCENE 03`、`FRAME 120`、`DIRECTOR`、`RENDER PLAN`，但不能替代正常中文内容。
+
+---
+
+## 16. 实现约束
+
+### 16.1 Source of Truth
+
+1. `DESIGN.md`：产品设计决策；
+2. `shared/config/themePalette.ts`：主题色板；
+3. `useTweaks.ts`：运行时 CSS Variable；
+4. `styles/tokens.css`：共享 Token；
+5. 页面 CSS：布局和页面特有组合。
+
+不得在 JSX 中新增固定颜色、圆角和动效时长；Inline Style 仅用于运行时几何和数据值。
+
+### 16.2 CSS 目录
+
+```text
+styles/
+  tokens.css
+  global.css
+  layout.css
+  pages/
+    landing.css
+    landing/
+      shell.css
+      content.css
+      responsive.css
+    studio.css
+    playbook.css
+    history.css
+    templates.css
+    settings.css
+```
+
+- Page CSS 负责页面布局；
+- 共享控件应逐步进入独立组件样式；
+- 不继续向 `studio.css` 添加 Landing 内容；
+- Renderer 样式保持在 Renderer 边界。
+
+### 16.3 React 边界
+
+继续遵守 Feature-Sliced Design：
+
+- `shared/` 不导入 `features/` 或 `pages/`；
+- `entities/` 不导入 `features/`；
+- Feature 之间不直接互相导入；
+- 跨页面 UI 进入 `shared/ui`；
+- 页面组合进入 `pages/<Page>`。
+
+---
+
+## 17. 当前已知迁移项
+
+1. 全局旧 Accent `#10B981` 与播放器 Sage Accent 不一致；默认品牌主题统一为 `#82976F / #9FB48D`。
+2. `tokens.css` 当前主要记录 Density，后续应补齐状态色、间距、圆角、阴影和动效 Token。
+3. `studio.css` 职责过多，Landing 已拆入独立目录，其他共享控件继续逐步迁移。
+4. 当前页面仍存在 `6px–14px` 的圆角漂移，新功能遵守本文尺度。
+5. 模板页仍包含 Raw Prompt 和开发者路径，公共产品化时应改为真实结果预览。
+6. `/` 已作为公共 Landing，输入页使用 `/create`，应用内首项统一称为“工作台”。
+
+---
+
+## 18. Review Checklist
+
+### 品牌
+
+- [ ] 是否像 MetaView，而不是通用 AI SaaS？
+- [ ] 视觉焦点是否与学习、推演或知识结构相关？
+- [ ] Sage Accent 是否克制使用？
+- [ ] 是否避免蓝紫渐变和粒子爆炸？
+
+### 层级
+
+- [ ] 是否只有一个主要操作？
+- [ ] 用户能否在五秒内理解页面用途？
+- [ ] 卡片是否只用于真实分组？
+- [ ] 元信息是否弱于主要内容？
+
+### 组件
+
+- [ ] 颜色、间距、圆角和动效是否 Token 化？
+- [ ] 图标风格是否统一？
+- [ ] Hover、Active、Disabled、Focus 是否完整？
+- [ ] 移动端触控目标是否足够？
+
+### 动效
+
+- [ ] 动效是否说明状态或知识关系？
+- [ ] 装饰动效是否足够安静？
+- [ ] Reduced Motion 是否可用？
+
+### 响应式
+
+- [ ] 1440px 桌面检查
+- [ ] 1024px 平板检查
+- [ ] 720px 窄屏检查
+- [ ] 390px 手机检查
+- [ ] Safe Area / Visual Viewport 检查
+
+### 产品诚实
+
+- [ ] 是否只展示真实支持能力？
+- [ ] Experimental 能力是否清楚标记？
+- [ ] 案例是否来自真实可运行结果？
+- [ ] 文案是否避免夸张 AI 承诺？

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>MetaView · 工作台</title>
+    <title>演算视界 MetaView · 让理解过程被看见</title>
+    <meta
+      name="description"
+      content="MetaView 把题目和代码转化为可播放、可追问、可调整并可导出的分步可视化讲解。"
+    />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />

--- a/apps/web/src/app/App.edition.test.tsx
+++ b/apps/web/src/app/App.edition.test.tsx
@@ -23,7 +23,7 @@ describe("App edition shells", () => {
     window.history.pushState({}, "", "/");
   });
 
-  it("self edition does not load account state on the intake screen", async () => {
+  it("self edition keeps the public landing route independent from account state", async () => {
     let accountHits = 0;
     let opsHits = 0;
     server.use(
@@ -45,15 +45,16 @@ describe("App edition shells", () => {
     vi.stubEnv("VITE_APP_EDITION", "self");
 
     const { App } = await import("./App");
-    const { container } = render(<App />);
-    expect(container.textContent).toContain("MetaView");
-    expect(container.querySelectorAll(".mv-top")).toHaveLength(1);
+    const { container, getByText } = render(<App />);
 
+    expect(getByText("真实案例将在这里出现")).toBeTruthy();
+    expect(container.querySelectorAll(".mv-landing-header")).toHaveLength(1);
+    expect(container.querySelectorAll(".mv-top")).toHaveLength(0);
     expect(accountHits).toBe(0);
     expect(opsHits).toBe(0);
   }, 20000);
 
-  it("self edition keeps the intake hero calm without decorative debug controls", async () => {
+  it("public landing uses one calm canvas motif without debug controls", async () => {
     vi.stubEnv("VITE_APP_EDITION", "self");
 
     const { App } = await import("./App");
@@ -62,12 +63,13 @@ describe("App edition shells", () => {
     expect(container.textContent).toContain("MetaView");
     expect(
       container.querySelector('[data-testid="meta-particle-field"][data-variant="canvas"]'),
-    ).toBeNull();
+    ).toBeTruthy();
+    expect(container.querySelectorAll('[data-testid="meta-particle-field"]')).toHaveLength(1);
     expect(container.querySelector('[aria-label="MetaView logo animation"]')).toBeNull();
     expect(queryByLabelText("打开设计调节面板")).toBeNull();
   }, 10000);
 
-  it("ops edition shows the login gate when account session is missing", async () => {
+  it("ops edition shows the login gate when account session is missing on /create", async () => {
     let accountHits = 0;
     server.use(
       http.get(`${API_BASE_URL}/api/v1/account/me`, () => {
@@ -79,6 +81,7 @@ describe("App edition shells", () => {
       }),
     );
     vi.stubEnv("VITE_APP_EDITION", "ops");
+    window.history.pushState({}, "", "/create");
 
     const { App } = await import("./App");
     const { container } = render(<App />);
@@ -87,7 +90,7 @@ describe("App edition shells", () => {
     await waitFor(() =>
       expect(container.textContent).toContain("登录暂未开放"),
     );
-    expect(container.textContent).not.toContain("把一道题变成可播放的理论画布");
+    expect(container.textContent).not.toContain("让每一个理解过程都能被看见");
   });
 
   it("ops edition opens the intake screen after WeChat login", async () => {
@@ -116,6 +119,7 @@ describe("App edition shells", () => {
       }),
     );
     vi.stubEnv("VITE_APP_EDITION", "ops");
+    window.history.pushState({}, "", "/create");
 
     const { App } = await import("./App");
     const { container } = render(<App />);
@@ -153,6 +157,7 @@ describe("App edition shells", () => {
         status: "succeeded",
       }),
     }));
+    window.history.pushState({}, "", "/create");
 
     const { App } = await import("./App");
     const { container, getByRole, getByText } = render(<App />);

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,13 +1,14 @@
-import { BrowserRouter, Route, Routes, useNavigate } from 'react-router-dom';
-import type { AppEdition } from '../shared/config/constants';
-import { OpsAppShell } from './OpsAppShell';
-import { SelfAppShell } from './SelfAppShell';
-import { PaymentResultPage } from '../pages/PaymentResultPage';
-import { OpsDashboardPage } from '../pages/OpsDashboard/OpsDashboardPage';
-import { AssetShowcasePage } from '../pages/AssetShowcase/AssetShowcasePage';
+import { BrowserRouter, Route, Routes, useNavigate } from "react-router-dom";
+import type { AppEdition } from "../shared/config/constants";
+import { PaymentResultPage } from "../pages/PaymentResultPage";
+import { OpsDashboardPage } from "../pages/OpsDashboard/OpsDashboardPage";
+import { AssetShowcasePage } from "../pages/AssetShowcase/AssetShowcasePage";
+import { LandingRoute } from "./LandingRoute";
+import { OpsAppShell } from "./OpsAppShell";
+import { SelfAppShell } from "./SelfAppShell";
 
 function resolveAppEdition(): AppEdition {
-  return import.meta.env.VITE_APP_EDITION === 'ops' ? 'ops' : 'self';
+  return import.meta.env.VITE_APP_EDITION === "ops" ? "ops" : "self";
 }
 
 export function App() {
@@ -23,11 +24,12 @@ function AppRoutes() {
 
   return (
     <Routes>
+      <Route path="/" element={<LandingRoute appEdition={appEdition} />} />
       <Route path="/payment/result" element={<PaymentResultPage />} />
       <Route
         path="/admin"
         element={
-          appEdition === 'ops' ? (
+          appEdition === "ops" ? (
             <OpsDashboardPage onNavigate={() => {}} />
           ) : (
             <AdminUnavailable />
@@ -37,7 +39,7 @@ function AppRoutes() {
       <Route path="/asset-showcase" element={<AssetShowcasePage />} />
       <Route
         path="/*"
-        element={appEdition === 'ops' ? <OpsAppShell /> : <SelfAppShell />}
+        element={appEdition === "ops" ? <OpsAppShell /> : <SelfAppShell />}
       />
     </Routes>
   );
@@ -51,7 +53,7 @@ function AdminUnavailable() {
         <h1>运营后台仅在 ops edition 可用</h1>
         <p>当前是 self edition。后端仍会继续执行管理员权限校验。</p>
         <button type="button" className="mv-chip" onClick={() => navigate("/")}>
-          返回工作台
+          返回首页
         </button>
       </section>
     </main>

--- a/apps/web/src/app/LandingRoute.tsx
+++ b/apps/web/src/app/LandingRoute.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+
+import {
+  TWEAK_DEFAULTS,
+  themeMode,
+  themeVars,
+  useTweaks,
+} from "../features/studio-editor/hooks/useTweaks";
+import { LandingPage } from "../pages/Landing/LandingPage";
+import type { AppEdition } from "../shared/config/constants";
+import { useVisualViewportHeight } from "../shared/hooks/useVisualViewportHeight";
+
+export function LandingRoute({ appEdition }: { appEdition: AppEdition }) {
+  useVisualViewportHeight();
+
+  const navigate = useNavigate();
+  const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+  const css = useMemo(() => themeVars(t), [t]);
+  const mode = themeMode(t);
+
+  const toggleTheme = () =>
+    setTweak("theme", mode === "dark" ? "light" : "dark");
+
+  return (
+    <div
+      className={`mv-root mv-${mode} mv-theme-${t.theme} mv-density-${t.density}`}
+      data-theme={t.theme}
+      style={css}
+    >
+      <LandingPage
+        appEdition={appEdition}
+        isDark={mode === "dark"}
+        onToggleTheme={toggleTheme}
+        onStart={() => navigate("/create")}
+        onOpenTemplates={() => navigate("/templates")}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/LandingRoute.tsx
+++ b/apps/web/src/app/LandingRoute.tsx
@@ -9,6 +9,7 @@ import {
 } from "../features/studio-editor/hooks/useTweaks";
 import { LandingPage } from "../pages/Landing/LandingPage";
 import type { AppEdition } from "../shared/config/constants";
+import { THEME_PALETTE } from "../shared/config/themePalette";
 import { useVisualViewportHeight } from "../shared/hooks/useVisualViewportHeight";
 
 export function LandingRoute({ appEdition }: { appEdition: AppEdition }) {
@@ -16,16 +17,25 @@ export function LandingRoute({ appEdition }: { appEdition: AppEdition }) {
 
   const navigate = useNavigate();
   const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
-  const css = useMemo(() => themeVars(t), [t]);
   const mode = themeMode(t);
+  const landingTheme = mode;
+  const css = useMemo(
+    () =>
+      themeVars({
+        ...t,
+        theme: landingTheme,
+        accent: THEME_PALETTE[landingTheme].accent,
+      }),
+    [landingTheme, t],
+  );
 
   const toggleTheme = () =>
     setTweak("theme", mode === "dark" ? "light" : "dark");
 
   return (
     <div
-      className={`mv-root mv-${mode} mv-theme-${t.theme} mv-density-${t.density}`}
-      data-theme={t.theme}
+      className={`mv-root mv-${mode} mv-theme-${landingTheme} mv-density-${t.density}`}
+      data-theme={landingTheme}
       style={css}
     >
       <LandingPage

--- a/apps/web/src/app/OpsAppShell.tsx
+++ b/apps/web/src/app/OpsAppShell.tsx
@@ -97,7 +97,7 @@ export function OpsAppShell() {
 
   useEffect(() => {
     if (stage === "intake" && intakePrompt) {
-      routerNavigate("/", { replace: true, state: null });
+      routerNavigate("/create", { replace: true, state: null });
     }
   }, [stage, intakePrompt, routerNavigate]);
 
@@ -143,7 +143,7 @@ export function OpsAppShell() {
 
   const handleEditPrompt = (prompt: string) => {
     setTopbarCollapsed(false);
-    routerNavigate("/", { state: { prompt } });
+    routerNavigate("/create", { state: { prompt } });
   };
 
   const handleUseTemplate = async (prompt: string) => {
@@ -205,7 +205,7 @@ export function OpsAppShell() {
 
       <Routes>
         <Route
-          path="/"
+          path="/create"
           element={
             <IntakeScreen
               onSubmit={handleSubmit}
@@ -234,7 +234,7 @@ export function OpsAppShell() {
             </ErrorBoundary>
           }
         />
-        <Route path="/run" element={<Navigate to="/" replace />} />
+        <Route path="/run" element={<Navigate to="/create" replace />} />
         <Route
           path="/history"
           element={

--- a/apps/web/src/app/SelfAppShell.tsx
+++ b/apps/web/src/app/SelfAppShell.tsx
@@ -92,7 +92,7 @@ export function SelfAppShell() {
 
   useEffect(() => {
     if (stage === "intake" && intakePrompt) {
-      routerNavigate("/", { replace: true, state: null });
+      routerNavigate("/create", { replace: true, state: null });
     }
   }, [stage, intakePrompt, routerNavigate]);
 
@@ -145,7 +145,7 @@ export function SelfAppShell() {
 
   const handleEditPrompt = (prompt: string) => {
     setTopbarCollapsed(false);
-    routerNavigate("/", { state: { prompt } });
+    routerNavigate("/create", { state: { prompt } });
   };
 
   const handleUseTemplate = async (prompt: string) => {
@@ -177,7 +177,7 @@ export function SelfAppShell() {
 
       <Routes>
         <Route
-          path="/"
+          path="/create"
           element={
             <IntakeScreen
               onSubmit={handleSubmit}
@@ -207,7 +207,7 @@ export function SelfAppShell() {
             </ErrorBoundary>
           }
         />
-        <Route path="/run" element={<Navigate to="/" replace />} />
+        <Route path="/run" element={<Navigate to="/create" replace />} />
         <Route
           path="/history"
           element={

--- a/apps/web/src/app/routes.test.ts
+++ b/apps/web/src/app/routes.test.ts
@@ -3,20 +3,21 @@ import { describe, expect, it } from "vitest";
 import { pathToStage, stageToPath } from "./routes";
 
 describe("app route helpers", () => {
-  it("maps top-level stages to shareable paths", () => {
-    expect(stageToPath("intake")).toBe("/");
+  it("maps app-shell stages to shareable paths", () => {
+    expect(stageToPath("intake")).toBe("/create");
     expect(stageToPath("workbench", "run-1")).toBe("/run/run-1");
     expect(stageToPath("history")).toBe("/history");
     expect(stageToPath("templates")).toBe("/templates");
     expect(stageToPath("settings")).toBe("/settings");
   });
 
-  it("falls back to intake when workbench has no run id", () => {
-    expect(stageToPath("workbench")).toBe("/");
+  it("falls back to create when workbench has no run id", () => {
+    expect(stageToPath("workbench")).toBe("/create");
   });
 
-  it("derives the active stage from location pathnames", () => {
-    expect(pathToStage("/")).toBe("intake");
+  it("derives the active app stage from location pathnames", () => {
+    expect(pathToStage("/create")).toBe("intake");
+    expect(pathToStage("/create/")).toBe("intake");
     expect(pathToStage("/run/run-1")).toBe("workbench");
     expect(pathToStage("/run/run-1/")).toBe("workbench");
     expect(pathToStage("/history")).toBe("history");
@@ -25,6 +26,7 @@ describe("app route helpers", () => {
   });
 
   it("treats unknown shell paths as intake for navigation state", () => {
+    expect(pathToStage("/")).toBe("intake");
     expect(pathToStage("/nope")).toBe("intake");
     expect(pathToStage("/run")).toBe("intake");
   });

--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -10,9 +10,9 @@ function normalizePath(pathname: string): string {
 export function stageToPath(stage: Stage, runId?: string | null): string {
   switch (stage) {
     case "intake":
-      return "/";
+      return "/create";
     case "workbench":
-      return runId ? `/run/${encodeURIComponent(runId)}` : "/";
+      return runId ? `/run/${encodeURIComponent(runId)}` : "/create";
     case "history":
       return "/history";
     case "templates":
@@ -24,7 +24,7 @@ export function stageToPath(stage: Stage, runId?: string | null): string {
 
 export function pathToStage(pathname: string): Stage {
   const path = normalizePath(pathname);
-  if (path === "/") return "intake";
+  if (path === "/create") return "intake";
   if (path.startsWith("/run/") && path.length > "/run/".length) return "workbench";
   if (path === "/history") return "history";
   if (path === "/templates") return "templates";

--- a/apps/web/src/app/routing.test.tsx
+++ b/apps/web/src/app/routing.test.tsx
@@ -32,6 +32,26 @@ describe("App routing", () => {
     window.history.pushState({}, "", "/");
   });
 
+  it("renders the public landing page at /", async () => {
+    vi.stubEnv("VITE_APP_EDITION", "self");
+
+    const { App } = await import("./App");
+    const { getByText } = render(<App />);
+
+    expect(getByText("真实案例将在这里出现")).toBeTruthy();
+    expect(window.location.pathname).toBe("/");
+  });
+
+  it("opens the creation intake directly from /create", async () => {
+    vi.stubEnv("VITE_APP_EDITION", "self");
+    window.history.pushState({}, "", "/create");
+
+    const { App } = await import("./App");
+    const { getByText } = render(<App />);
+
+    expect(getByText("输入题目或代码，生成可播放的分步讲解")).toBeTruthy();
+  });
+
   it("restores the workbench from a direct /run/:runId link", async () => {
     const seenRunIds: Array<string | null> = [];
     vi.stubEnv("VITE_APP_EDITION", "self");
@@ -64,7 +84,7 @@ describe("App routing", () => {
     expect(getByRole("searchbox")).toBeTruthy();
   });
 
-  it("redirects unknown app paths back to intake", async () => {
+  it("redirects unknown app paths back to the public landing page", async () => {
     vi.stubEnv("VITE_APP_EDITION", "self");
     window.history.pushState({}, "", "/nope");
 
@@ -72,7 +92,7 @@ describe("App routing", () => {
     const { getByText } = render(<App />);
 
     await waitFor(() => expect(window.location.pathname).toBe("/"));
-    expect(getByText("输入题目或代码，生成可播放的分步讲解")).toBeTruthy();
+    expect(getByText("真实案例将在这里出现")).toBeTruthy();
   });
 
   it("shows the ops login gate for logged-out /run/:runId deep links", async () => {

--- a/apps/web/src/features/studio-editor/hooks/useTweaks.test.tsx
+++ b/apps/web/src/features/studio-editor/hooks/useTweaks.test.tsx
@@ -41,5 +41,9 @@ describe("useTweaks", () => {
       swapFrames: TWEAK_DEFAULTS.swapFrames,
     });
     expect(themeVars(tweaks)["--accent"]).toBe(THEME_PALETTE.light.accent);
+    expect(themeVars(tweaks)["--accent-contrast"]).toBe("#0b0f0d");
+    expect(
+      themeVars({ ...tweaks, accent: "#111111" })["--accent-contrast"],
+    ).toBe("#ffffff");
   });
 });

--- a/apps/web/src/features/studio-editor/hooks/useTweaks.ts
+++ b/apps/web/src/features/studio-editor/hooks/useTweaks.ts
@@ -66,6 +66,23 @@ function numberInRange(
     : fallback;
 }
 
+function relativeLuminance(hex: string): number {
+  const channels = [0, 2, 4].map((offset) =>
+    Number.parseInt(hex.slice(offset + 1, offset + 3), 16) / 255,
+  );
+  const linear = channels.map((channel) =>
+    channel <= 0.03928
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4,
+  );
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+function accentContrastColor(accent: string, fallback: string): string {
+  const safeAccent = isHexColor(accent) ? accent : fallback;
+  return relativeLuminance(safeAccent) > 0.179 ? "#0b0f0d" : "#ffffff";
+}
+
 function sanitizeTweaks(
   candidate: Partial<TweakValues>,
   defaults: TweakValues,
@@ -114,6 +131,7 @@ export function themeVars(t: TweakValues): Record<string, string> {
     // ``t.accent`` defaults to the theme's accent (see useTweaks initializer);
     // users can still override via the color picker.
     "--accent": t.accent,
+    "--accent-contrast": accentContrastColor(t.accent, p.accent),
     "--accent-2": t.accent + "CC",
     "--accent-dim": t.accent + "80",
     "--accent-soft": t.accent + "26",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,6 +1,7 @@
 @import './styles/tokens.css';
 @import './styles/global.css';
 @import './styles/layout.css';
+@import './styles/pages/landing.css';
 @import './styles/pages/studio.css';
 @import './styles/pages/playbook.css';
 @import './styles/pages/history.css';

--- a/apps/web/src/pages/Landing/LandingPage.test.tsx
+++ b/apps/web/src/pages/Landing/LandingPage.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { LandingPage } from "./LandingPage";
+
+const baseProps = {
+  appEdition: "self" as const,
+  isDark: false,
+  onToggleTheme: vi.fn(),
+  onStart: vi.fn(),
+  onOpenTemplates: vi.fn(),
+};
+
+describe("LandingPage", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("states the product promise and keeps the case area explicitly reserved", () => {
+    const { getByRole, getByText, getAllByText, container } = render(
+      <LandingPage {...baseProps} />,
+    );
+
+    expect(
+      getByRole("heading", { name: /让每一个.*理解过程.*都能被看见/ }),
+    ).toBeTruthy();
+    expect(getByText("真实案例将在这里出现")).toBeTruthy();
+    expect(getAllByText("待接入真实案例")).toHaveLength(3);
+    expect(
+      container.querySelector(
+        '[data-testid="meta-particle-field"][data-variant="canvas"]',
+      ),
+    ).toBeTruthy();
+  });
+
+  it("opens the workspace from the primary calls to action", () => {
+    const onStart = vi.fn();
+    const { getByRole } = render(
+      <LandingPage {...baseProps} onStart={onStart} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "开始生成讲解" }));
+    fireEvent.click(getByRole("button", { name: "进入 MetaView" }));
+
+    expect(onStart).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps theme and template actions wired", () => {
+    const onToggleTheme = vi.fn();
+    const onOpenTemplates = vi.fn();
+    const { getByRole } = render(
+      <LandingPage
+        {...baseProps}
+        onToggleTheme={onToggleTheme}
+        onOpenTemplates={onOpenTemplates}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "切换主题" }));
+    fireEvent.click(getByRole("button", { name: "查看现有模板结构" }));
+
+    expect(onToggleTheme).toHaveBeenCalledOnce();
+    expect(onOpenTemplates).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/pages/Landing/LandingPage.tsx
+++ b/apps/web/src/pages/Landing/LandingPage.tsx
@@ -1,0 +1,508 @@
+import { MetaParticleField } from "../../shared/ui/MetaParticleField";
+
+interface LandingPageProps {
+  appEdition: "self" | "ops";
+  isDark: boolean;
+  onToggleTheme: () => void;
+  onStart: () => void;
+  onOpenTemplates: () => void;
+}
+
+const SUBJECTS = ["数学", "物理", "化学", "生物", "地理", "算法与代码"];
+
+const PROCESS_STEPS = [
+  {
+    index: "01",
+    label: "UNDERSTAND",
+    title: "先理解题目",
+    description: "识别学科、学习目标、关键量与能力边界，不把所有输入都粗暴地交给同一条生成链。",
+  },
+  {
+    index: "02",
+    label: "PLAN",
+    title: "规划讲解顺序",
+    description: "形成 LessonPlan，明确教学弧线、结论、误区与每一个场景要完成的任务。",
+  },
+  {
+    index: "03",
+    label: "DIRECT",
+    title: "编排焦点与节奏",
+    description: "DirectorScript 决定镜头意图、强调对象、观看节奏与场景之间的连续关系。",
+  },
+  {
+    index: "04",
+    label: "RENDER",
+    title: "生成可交互画布",
+    description: "将结构化讲解转化为可播放、可追问、可调整并可导出的视频与学习内容。",
+  },
+];
+
+const PRINCIPLES = [
+  {
+    marker: "A",
+    title: "教学计划先于画面",
+    description: "先确定为什么讲、按什么顺序讲，再决定画面中出现什么。",
+  },
+  {
+    marker: "B",
+    title: "焦点贯穿所有视图",
+    description: "动画、代码、时间线与数据状态围绕同一个当前步骤同步变化。",
+  },
+  {
+    marker: "C",
+    title: "生成之后仍可继续",
+    description: "用户可以继续追问、要求调整讲解，并保留可恢复的版本记录。",
+  },
+];
+
+function ArrowIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+      <path d="M5 12h14" />
+      <path d="m13 6 6 6-6 6" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+      <path d="M20.5 14.5A7.5 7.5 0 0 1 9.5 3.5 8 8 0 1 0 20.5 14.5Z" />
+    </svg>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2" />
+      <path d="M12 20v2" />
+      <path d="m4.9 4.9 1.4 1.4" />
+      <path d="m17.7 17.7 1.4 1.4" />
+      <path d="M2 12h2" />
+      <path d="M20 12h2" />
+      <path d="m4.9 19.1 1.4-1.4" />
+      <path d="m17.7 6.3 1.4-1.4" />
+    </svg>
+  );
+}
+
+function HeroCanvas() {
+  return (
+    <article className="mv-landing-canvas" aria-label="MetaView 讲解画布概念预览">
+      <header className="mv-landing-canvas__head">
+        <div>
+          <span>THEORETICAL CANVAS</span>
+          <strong>抛体运动 · 速度分解</strong>
+        </div>
+        <div className="mv-landing-canvas__status">
+          <span className="mv-landing-canvas__status-dot" />
+          SCENE 03 / 05
+        </div>
+      </header>
+
+      <div className="mv-landing-canvas__stage">
+        <div className="mv-landing-canvas__grid" aria-hidden="true" />
+        <svg
+          className="mv-landing-canvas__plot"
+          viewBox="0 0 640 350"
+          role="img"
+          aria-label="抛体运动轨迹、速度分解和重力方向示意"
+        >
+          <defs>
+            <marker
+              id="mv-landing-arrow"
+              markerWidth="8"
+              markerHeight="8"
+              refX="6"
+              refY="4"
+              orient="auto"
+            >
+              <path d="M0 0 8 4 0 8Z" fill="currentColor" />
+            </marker>
+          </defs>
+          <path className="mv-landing-canvas__axis" d="M92 286H574M92 286V60" />
+          <path
+            className="mv-landing-canvas__trajectory"
+            d="M116 270C214 92 378 76 528 244"
+          />
+          <circle className="mv-landing-canvas__object" cx="334" cy="112" r="8" />
+          <path
+            className="mv-landing-canvas__vector mv-landing-canvas__vector--velocity"
+            d="M334 112 420 132"
+            markerEnd="url(#mv-landing-arrow)"
+          />
+          <path
+            className="mv-landing-canvas__vector mv-landing-canvas__vector--x"
+            d="M334 112 420 112"
+            markerEnd="url(#mv-landing-arrow)"
+          />
+          <path
+            className="mv-landing-canvas__vector mv-landing-canvas__vector--y"
+            d="M334 112 334 166"
+            markerEnd="url(#mv-landing-arrow)"
+          />
+          <path
+            className="mv-landing-canvas__vector mv-landing-canvas__vector--gravity"
+            d="M526 112 526 196"
+            markerEnd="url(#mv-landing-arrow)"
+          />
+          <text className="mv-landing-canvas__label" x="425" y="139">
+            v
+          </text>
+          <text className="mv-landing-canvas__label" x="423" y="104">
+            vₓ
+          </text>
+          <text className="mv-landing-canvas__label" x="344" y="166">
+            vᵧ
+          </text>
+          <text className="mv-landing-canvas__label" x="538" y="176">
+            g
+          </text>
+        </svg>
+
+        <div className="mv-landing-canvas__note mv-landing-canvas__note--goal">
+          <span>LEARNING GOAL</span>
+          <strong>把速度拆成两个独立方向</strong>
+        </div>
+        <div className="mv-landing-canvas__note mv-landing-canvas__note--director">
+          <span>DIRECTOR</span>
+          <strong>聚焦速度矢量 · 慢速推进</strong>
+        </div>
+      </div>
+
+      <footer className="mv-landing-canvas__timeline">
+        {["建立坐标", "绘制轨迹", "分解速度", "引入重力", "形成结论"].map(
+          (label, index) => (
+            <div
+              key={label}
+              className={`mv-landing-canvas__beat${index === 2 ? " is-active" : ""}`}
+            >
+              <span>{String(index + 1).padStart(2, "0")}</span>
+              <strong>{label}</strong>
+            </div>
+          ),
+        )}
+      </footer>
+    </article>
+  );
+}
+
+function LinkedExplorer() {
+  return (
+    <div className="mv-landing-linked" aria-label="联动学习界面示意">
+      <header className="mv-landing-linked__head">
+        <div>
+          <span>LINKED EXPLORER</span>
+          <strong>同一个焦点，贯穿四种视图</strong>
+        </div>
+        <span className="mv-landing-linked__time">00:18.40</span>
+      </header>
+
+      <div className="mv-landing-linked__body">
+        <section className="mv-landing-linked__panel mv-landing-linked__panel--visual">
+          <span className="mv-landing-linked__label">ANIMATION</span>
+          <div className="mv-landing-linked__bars" aria-hidden="true">
+            {[56, 84, 38, 70, 46, 62].map((height, index) => (
+              <i
+                key={`${height}-${index}`}
+                className={index === 2 ? "is-active" : ""}
+                style={{ height: `${height}%` }}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className="mv-landing-linked__panel mv-landing-linked__panel--code">
+          <span className="mv-landing-linked__label">CODE</span>
+          <code>
+            <span>while low &lt;= high:</span>
+            <span className="is-active">mid = (low + high) // 2</span>
+            <span>compare(target, items[mid])</span>
+          </code>
+        </section>
+
+        <section className="mv-landing-linked__panel mv-landing-linked__panel--timeline">
+          <span className="mv-landing-linked__label">TIMELINE</span>
+          <div className="mv-landing-linked__track" aria-hidden="true">
+            <i />
+            <i />
+            <i className="is-active" />
+            <i />
+            <i />
+          </div>
+        </section>
+
+        <section className="mv-landing-linked__panel mv-landing-linked__panel--state">
+          <span className="mv-landing-linked__label">STATE</span>
+          <dl>
+            <div>
+              <dt>low</dt>
+              <dd>0</dd>
+            </div>
+            <div className="is-active">
+              <dt>mid</dt>
+              <dd>3</dd>
+            </div>
+            <div>
+              <dt>high</dt>
+              <dd>6</dd>
+            </div>
+          </dl>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export function LandingPage({
+  appEdition,
+  isDark,
+  onToggleTheme,
+  onStart,
+  onOpenTemplates,
+}: LandingPageProps) {
+  return (
+    <div className="mv-landing" id="top">
+      <header className="mv-landing-header">
+        <div className="mv-landing-container mv-landing-header__inner">
+          <a className="mv-landing-brand" href="#top" aria-label="MetaView 首页">
+            <span className="mv-brand-strip" />
+            <span className="mv-brand-copy">
+              <span className="mv-brand-name">MetaView</span>
+              <span className="mv-brand-meta">THEORETICAL CANVAS</span>
+            </span>
+          </a>
+
+          <nav className="mv-landing-nav" aria-label="官网导航">
+            <a href="#process">工作原理</a>
+            <a href="#capabilities">产品能力</a>
+            <a href="#cases">案例</a>
+          </nav>
+
+          <div className="mv-landing-header__actions">
+            <button
+              className="mv-landing-theme"
+              type="button"
+              onClick={onToggleTheme}
+              aria-label="切换主题"
+              title="切换主题"
+            >
+              {isDark ? <SunIcon /> : <MoonIcon />}
+            </button>
+            <button className="mv-landing-button mv-landing-button--compact" type="button" onClick={onStart}>
+              {appEdition === "ops" ? "进入 MetaView" : "打开工作台"}
+              <ArrowIcon />
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main>
+        <section className="mv-landing-hero">
+          <MetaParticleField
+            variant="canvas"
+            className="mv-landing-hero__field mv-motion-decorative"
+          />
+          <div className="mv-landing-container mv-landing-hero__grid">
+            <div className="mv-landing-hero__copy">
+              <div className="mv-landing-eyebrow">
+                <span>AI-NATIVE EDUCATIONAL VISUALIZATION</span>
+                <i aria-hidden="true" />
+                <span>V2</span>
+              </div>
+              <h1>
+                让每一个
+                <span>理解过程</span>
+                都能被看见
+              </h1>
+              <p>
+                MetaView 把一道题转化为可播放、可追问、可调整并可导出的分步讲解。
+                从教学规划到导演编排，再到交互式画布，每一步都有结构。
+              </p>
+              <div className="mv-landing-hero__actions">
+                <button className="mv-landing-button mv-landing-button--primary" type="button" onClick={onStart}>
+                  开始生成讲解
+                  <ArrowIcon />
+                </button>
+                <a className="mv-landing-button mv-landing-button--secondary" href="#process">
+                  查看生成过程
+                </a>
+              </div>
+              <div className="mv-landing-subjects" aria-label="支持领域">
+                <span>覆盖</span>
+                {SUBJECTS.map((subject) => (
+                  <i key={subject}>{subject}</i>
+                ))}
+              </div>
+            </div>
+
+            <div className="mv-landing-hero__visual">
+              <HeroCanvas />
+              <div className="mv-landing-hero__caption">
+                <span>CONCEPT PREVIEW</span>
+                <p>教学目标、画面对象与导演焦点在同一条生成链中保持一致。</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mv-landing-section mv-landing-process" id="process">
+          <div className="mv-landing-container">
+            <header className="mv-landing-section__head">
+              <div className="mv-landing-kicker">FROM ANSWER TO UNDERSTANDING</div>
+              <h2>不是把答案搬进视频，而是生成理解发生的过程</h2>
+              <p>
+                MetaView 先建立教学结构，再决定画面和节奏。每一层都有明确职责，也能被检查、回放和继续修改。
+              </p>
+            </header>
+
+            <div className="mv-landing-process__rail">
+              {PROCESS_STEPS.map((step) => (
+                <article key={step.index} className="mv-landing-process__step">
+                  <div className="mv-landing-process__index">
+                    <span>{step.index}</span>
+                    <i aria-hidden="true" />
+                  </div>
+                  <div className="mv-landing-process__content">
+                    <span>{step.label}</span>
+                    <h3>{step.title}</h3>
+                    <p>{step.description}</p>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="mv-landing-section mv-landing-capabilities" id="capabilities">
+          <div className="mv-landing-container mv-landing-capabilities__grid">
+            <div className="mv-landing-capabilities__copy">
+              <div className="mv-landing-kicker">ONE LEARNING FOCUS</div>
+              <h2>动画、代码、时间线与数据状态，不再彼此割裂</h2>
+              <p>
+                学习者看到的不是四块独立信息，而是同一个推理步骤在不同视图中的同步表达。
+              </p>
+
+              <div className="mv-landing-principles">
+                {PRINCIPLES.map((item) => (
+                  <article key={item.marker}>
+                    <span>{item.marker}</span>
+                    <div>
+                      <h3>{item.title}</h3>
+                      <p>{item.description}</p>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </div>
+
+            <LinkedExplorer />
+          </div>
+        </section>
+
+        <section className="mv-landing-section mv-landing-cases" id="cases">
+          <div className="mv-landing-container">
+            <header className="mv-landing-section__head mv-landing-section__head--split">
+              <div>
+                <div className="mv-landing-kicker">SELECTED CASES</div>
+                <h2>真实案例将在这里出现</h2>
+              </div>
+              <p>
+                该区域只接入已经通过线上播放、移动端和导出验收的案例，不使用仅存在于 Benchmark
+                中的结果冒充产品能力。
+              </p>
+            </header>
+
+            <div className="mv-landing-case-grid" aria-label="案例展示预留区域">
+              {[1, 2, 3].map((slot) => (
+                <article key={slot} className="mv-landing-case-slot">
+                  <div className="mv-landing-case-slot__visual" aria-hidden="true">
+                    <span>CASE SLOT {String(slot).padStart(2, "0")}</span>
+                    <i />
+                    <i />
+                    <i />
+                  </div>
+                  <div className="mv-landing-case-slot__meta">
+                    <span>待接入真实案例</span>
+                    <p>标题、学科、预览画面与可播放入口将在 Gold Case 完成产品化后补充。</p>
+                  </div>
+                </article>
+              ))}
+            </div>
+
+            <div className="mv-landing-cases__foot">
+              <span>案例内容暂时留空，但展示结构已经固定。</span>
+              <button type="button" onClick={onOpenTemplates}>
+                查看现有模板结构
+                <ArrowIcon />
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <section className="mv-landing-section mv-landing-architecture">
+          <div className="mv-landing-container mv-landing-architecture__grid">
+            <div>
+              <div className="mv-landing-kicker">VISIBLE SYSTEM</div>
+              <h2>一条可以解释、验证和持续演进的生成链</h2>
+              <p>
+                内容、导演和渲染不是混在一个 Prompt 里的黑盒。它们通过独立契约连接，使能力边界、
+                质量评测和后续编辑都更清楚。
+              </p>
+            </div>
+
+            <div className="mv-landing-pipeline" aria-label="MetaView 核心生成链">
+              {[
+                ["INPUT", "题目 / 代码"],
+                ["LESSON PLAN", "目标与教学弧线"],
+                ["PLAYBOOK", "内容与场景对象"],
+                ["DIRECTOR", "镜头、焦点与节奏"],
+                ["RENDER PLAN", "预览与视频导出"],
+              ].map(([label, value], index, rows) => (
+                <div key={label} className="mv-landing-pipeline__row">
+                  <span>{label}</span>
+                  <strong>{value}</strong>
+                  {index < rows.length - 1 && <i aria-hidden="true">↓</i>}
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="mv-landing-final">
+          <div className="mv-landing-container mv-landing-final__inner">
+            <div>
+              <span>START WITH A QUESTION</span>
+              <h2>把下一道题，变成可见的理解过程</h2>
+            </div>
+            <button className="mv-landing-button mv-landing-button--primary" type="button" onClick={onStart}>
+              进入 MetaView
+              <ArrowIcon />
+            </button>
+          </div>
+        </section>
+      </main>
+
+      <footer className="mv-landing-footer">
+        <div className="mv-landing-container mv-landing-footer__inner">
+          <div className="mv-landing-brand">
+            <span className="mv-brand-strip" />
+            <span>
+              <strong>MetaView</strong>
+              <small>THEORETICAL CANVAS</small>
+            </span>
+          </div>
+          <p>让知识不只被展示，而是被演绎。</p>
+          <div>
+            <a href="https://github.com/jry21223/MetaView" target="_blank" rel="noreferrer">
+              GitHub
+            </a>
+            <button type="button" onClick={onStart}>工作台</button>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/shared/config/themePalette.ts
+++ b/apps/web/src/shared/config/themePalette.ts
@@ -30,7 +30,8 @@ export interface ThemePalette {
   warn: string;
 }
 
-const DEFAULT_ACCENT = "#10b981";
+const LIGHT_ACCENT = "#82976f";
+const DARK_ACCENT = "#9fb48d";
 
 /**
  * Identifier for every theme MetaView knows about. The pair "dark" / "light"
@@ -77,8 +78,8 @@ export const THEME_PALETTE: Record<ThemeName, ThemeDescriptor> = {
     ink3: "#5b6862",
     line: "#1d2a23",
     line2: "#27332c",
-    accent: DEFAULT_ACCENT,
-    accentSoft: `${DEFAULT_ACCENT}26`,
+    accent: DARK_ACCENT,
+    accentSoft: `${DARK_ACCENT}26`,
     warn: "#e9a23b",
   },
   light: {
@@ -90,8 +91,8 @@ export const THEME_PALETTE: Record<ThemeName, ThemeDescriptor> = {
     ink3: "#9aa39d",
     line: "#e6e2d5",
     line2: "#d6d1c2",
-    accent: DEFAULT_ACCENT,
-    accentSoft: `${DEFAULT_ACCENT}26`,
+    accent: LIGHT_ACCENT,
+    accentSoft: `${LIGHT_ACCENT}26`,
     warn: "#e9a23b",
   },
   monokai: {
@@ -103,7 +104,7 @@ export const THEME_PALETTE: Record<ThemeName, ThemeDescriptor> = {
     ink3: "#75715e",
     line: "#3e3d32",
     line2: "#49483e",
-    accent: "#f92672", // signature pink
+    accent: "#f92672",
     accentSoft: "#f9267226",
     warn: "#fd971f",
   },

--- a/apps/web/src/shared/ui/GlobalTopbar.test.tsx
+++ b/apps/web/src/shared/ui/GlobalTopbar.test.tsx
@@ -42,8 +42,8 @@ describe("GlobalTopbar account avatar", () => {
     const { queryByText } = render(<GlobalTopbar {...baseProps} stage="workbench" appEdition="ops" />);
 
     expect(queryByText("运营面板")).toBeFalsy();
-    expect(queryByText("首页")).toBeTruthy();
-    expect(queryByText("工作台")).toBeNull();
+    expect(queryByText("工作台")).toBeTruthy();
+    expect(queryByText("首页")).toBeNull();
     expect(queryByText("任务历史")).toBeTruthy();
     expect(queryByText("模板")).toBeTruthy();
     expect(queryByText("设置")).toBeTruthy();
@@ -60,7 +60,7 @@ describe("GlobalTopbar account avatar", () => {
     );
 
     expect(getByText("MetaView")).toBeTruthy();
-    expect(queryByText("首页")).toBeNull();
+    expect(queryByText("工作台")).toBeNull();
     expect(queryByText("任务历史")).toBeNull();
     expect(queryByText("模板")).toBeNull();
     expect(queryByText("设置")).toBeNull();
@@ -82,7 +82,7 @@ describe("GlobalTopbar account avatar", () => {
       <GlobalTopbar {...baseProps} onNavigate={onNavigate} />,
     );
 
-    fireEvent.click(getByRole("button", { name: "首页" }));
+    fireEvent.click(getByRole("button", { name: "工作台" }));
     fireEvent.click(getByRole("button", { name: "任务历史" }));
     fireEvent.click(getByRole("button", { name: "模板" }));
     fireEvent.click(getByRole("button", { name: "设置" }));

--- a/apps/web/src/shared/ui/GlobalTopbar.tsx
+++ b/apps/web/src/shared/ui/GlobalTopbar.tsx
@@ -62,7 +62,7 @@ export function GlobalTopbar({
   hidePrimaryNav = false,
 }: GlobalTopbarProps) {
   const [failedAvatarUrl, setFailedAvatarUrl] = useState<string | null>(null);
-  const isHome = stage === "workbench" || stage === "intake";
+  const isWorkbench = stage === "workbench" || stage === "intake";
   const isHistory = stage === "history";
   const isTemplates = stage === "templates";
   const isSettings = stage === "settings";
@@ -90,15 +90,17 @@ export function GlobalTopbar({
       {!hidePrimaryNav && (
         <nav className="mv-nav">
           <button
-            className={`mv-nav-item ${isHome ? "is-active" : ""}`}
-            aria-current={isHome ? "page" : undefined}
+            className={`mv-nav-item ${isWorkbench ? "is-active" : ""}`}
+            aria-current={isWorkbench ? "page" : undefined}
             onClick={() => onNavigate("intake")}
             type="button"
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
-              <path d="M4 10.5 12 4l8 6.5V20H5v-7" />
+              <path d="M5 5h14v14H5z" />
+              <path d="M9 5v14" />
+              <path d="M9 10h10" />
             </svg>
-            首页
+            工作台
           </button>
           <button
             className={`mv-nav-item ${isHistory ? "is-active" : ""}`}
@@ -176,9 +178,6 @@ export function GlobalTopbar({
                 </span>
               </>
             ) : (
-              // Configured self edition: a quiet dot is enough. The
-              // unconfigured state stays silent here — provider onboarding
-              // lives in the follow-up panel and submit flow instead.
               <span
                 className="mv-pulse"
                 role="img"

--- a/apps/web/src/styles/pages/landing.css
+++ b/apps/web/src/styles/pages/landing.css
@@ -1,3 +1,4 @@
 @import './landing/shell.css';
 @import './landing/content.css';
 @import './landing/responsive.css';
+@import './landing/compat.css';

--- a/apps/web/src/styles/pages/landing.css
+++ b/apps/web/src/styles/pages/landing.css
@@ -1,0 +1,3 @@
+@import './landing/shell.css';
+@import './landing/content.css';
+@import './landing/responsive.css';

--- a/apps/web/src/styles/pages/landing/compat.css
+++ b/apps/web/src/styles/pages/landing/compat.css
@@ -1,0 +1,18 @@
+.mv-landing-container {
+  width: min(
+    var(--mv-landing-max),
+    calc(
+      100vw - var(--mv-landing-gutter) - var(--mv-landing-gutter)
+    )
+  );
+}
+
+.mv-landing section[id] {
+  scroll-margin-top: calc(76px + var(--mv-safe-top));
+}
+
+@media (max-width: 640px) {
+  .mv-landing section[id] {
+    scroll-margin-top: calc(68px + var(--mv-safe-top));
+  }
+}

--- a/apps/web/src/styles/pages/landing/content.css
+++ b/apps/web/src/styles/pages/landing/content.css
@@ -1,0 +1,373 @@
+/* ───── Shared sections ───── */
+
+.mv-landing-section {
+  position: relative;
+  padding: var(--mv-landing-section-y) 0;
+}
+
+.mv-landing-section__head {
+  max-width: 790px;
+}
+
+.mv-landing-kicker {
+  margin-bottom: 14px;
+  color: var(--accent);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.13em;
+}
+
+.mv-landing-section h2,
+.mv-landing-capabilities__copy > h2,
+.mv-landing-architecture h2,
+.mv-landing-final h2 {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-headline, "Space Grotesk", "Inter", sans-serif);
+  font-size: clamp(30px, 3.4vw, 48px);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.13;
+  text-wrap: balance;
+}
+
+.mv-landing-section__head > p,
+.mv-landing-capabilities__copy > p,
+.mv-landing-architecture__grid > div:first-child > p {
+  max-width: 680px;
+  margin: 20px 0 0;
+  color: var(--ink-2);
+  font-size: 14px;
+  line-height: 1.75;
+}
+
+/* ───── Process ───── */
+
+.mv-landing-process {
+  background: color-mix(in srgb, var(--surface-2) 52%, var(--bg));
+}
+
+.mv-landing-process__rail {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: clamp(48px, 6vw, 72px);
+  border-top: 1px solid var(--line-2);
+}
+
+.mv-landing-process__step {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 16px;
+  padding: 24px 22px 0 0;
+}
+
+.mv-landing-process__step:not(:last-child) {
+  border-right: 1px solid var(--line);
+  padding-right: 24px;
+  margin-right: 24px;
+}
+
+.mv-landing-process__index {
+  display: grid;
+  align-content: start;
+  justify-items: center;
+  gap: 10px;
+  transform: translateY(-30px);
+}
+
+.mv-landing-process__index span {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line-2);
+  border-radius: 50%;
+  background: var(--bg);
+  color: var(--accent);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 10px;
+}
+
+.mv-landing-process__index i {
+  width: 1px;
+  height: 52px;
+  background: linear-gradient(var(--line-2), transparent);
+}
+
+.mv-landing-process__content > span {
+  color: var(--ink-3);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+}
+
+.mv-landing-process__content h3 {
+  margin: 10px 0 0;
+  color: var(--ink);
+  font-size: 16px;
+  font-weight: 620;
+}
+
+.mv-landing-process__content p {
+  margin: 12px 0 0;
+  color: var(--ink-2);
+  font-size: 12.5px;
+  line-height: 1.7;
+}
+
+/* ───── Capabilities ───── */
+
+.mv-landing-capabilities {
+  overflow: hidden;
+}
+
+.mv-landing-capabilities__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(520px, 1.18fr);
+  align-items: center;
+  gap: clamp(52px, 7vw, 100px);
+}
+
+.mv-landing-principles {
+  display: grid;
+  gap: 0;
+  margin-top: 38px;
+  border-top: 1px solid var(--line);
+}
+
+.mv-landing-principles article {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 14px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.mv-landing-principles article > span {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--line));
+  border-radius: 7px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 10px;
+}
+
+.mv-landing-principles h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 620;
+}
+
+.mv-landing-principles p {
+  margin: 6px 0 0;
+  color: var(--ink-3);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+/* ───── Linked explorer ───── */
+
+.mv-landing-linked {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--line-2) 82%, transparent);
+  border-radius: 12px;
+  background: var(--surface);
+  box-shadow: 0 24px 72px rgba(41, 38, 30, 0.08);
+}
+
+.mv-dark .mv-landing-linked {
+  box-shadow: 0 24px 72px rgba(0, 0, 0, 0.24);
+}
+
+.mv-landing-linked__head {
+  min-height: 62px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface-2);
+}
+
+.mv-landing-linked__head > div {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.mv-landing-linked__head span {
+  color: var(--ink-3);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+}
+
+.mv-landing-linked__head strong {
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.mv-landing-linked__time {
+  flex: 0 0 auto;
+  color: var(--accent) !important;
+  letter-spacing: 0.04em !important;
+}
+
+.mv-landing-linked__body {
+  display: grid;
+  grid-template-columns: 1.16fr 0.84fr;
+  grid-template-rows: 220px 128px;
+}
+
+.mv-landing-linked__panel {
+  min-width: 0;
+  min-height: 0;
+  position: relative;
+  padding: 18px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface) 86%, transparent);
+}
+
+.mv-landing-linked__panel:nth-child(2n) {
+  border-right: 0;
+}
+
+.mv-landing-linked__panel:nth-child(n + 3) {
+  border-bottom: 0;
+}
+
+.mv-landing-linked__label {
+  position: relative;
+  z-index: 2;
+  color: var(--ink-3);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+}
+
+.mv-landing-linked__panel--visual {
+  display: flex;
+  flex-direction: column;
+}
+
+.mv-landing-linked__bars {
+  flex: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 11px;
+  padding: 32px 20px 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 64%, transparent);
+  background:
+    linear-gradient(
+      color-mix(in srgb, var(--line) 48%, transparent) 1px,
+      transparent 1px
+    );
+  background-size: 100% 28px;
+}
+
+.mv-landing-linked__bars i {
+  width: 22px;
+  max-height: 100%;
+  border-radius: 5px 5px 2px 2px;
+  background: color-mix(in srgb, var(--ink-3) 26%, transparent);
+}
+
+.mv-landing-linked__bars i.is-active {
+  background: var(--accent);
+  box-shadow: 0 0 0 5px var(--accent-soft);
+}
+
+.mv-landing-linked__panel--code code {
+  display: grid;
+  gap: 0;
+  margin-top: 28px;
+  color: var(--ink-2);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 10px;
+  line-height: 1.7;
+}
+
+.mv-landing-linked__panel--code code span {
+  padding: 7px 8px;
+  border-left: 2px solid transparent;
+  overflow-wrap: anywhere;
+}
+
+.mv-landing-linked__panel--code code span.is-active {
+  border-left-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--ink);
+}
+
+.mv-landing-linked__panel--timeline {
+  display: flex;
+  flex-direction: column;
+}
+
+.mv-landing-linked__track {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 6px;
+}
+
+.mv-landing-linked__track i {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--line);
+}
+
+.mv-landing-linked__track i.is-active {
+  height: 12px;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
+.mv-landing-linked__panel--state dl {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 25px 0 0;
+}
+
+.mv-landing-linked__panel--state dl > div {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  gap: 5px;
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--surface-2);
+}
+
+.mv-landing-linked__panel--state dl > div.is-active {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--line));
+  background: var(--accent-soft);
+}
+
+.mv-landing-linked__panel--state dt {
+  color: var(--ink-3);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 8px;
+}
+
+.mv-landing-linked__panel--state dd {
+  margin: 0;
+  color: var(--ink);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 15px;
+}

--- a/apps/web/src/styles/pages/landing/responsive.css
+++ b/apps/web/src/styles/pages/landing/responsive.css
@@ -1,0 +1,692 @@
+/* ───── Case reserve ───── */
+
+.mv-landing-cases {
+  background: color-mix(in srgb, var(--surface-2) 52%, var(--bg));
+}
+
+.mv-landing-section__head--split {
+  max-width: none;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.72fr);
+  align-items: end;
+  gap: 48px;
+}
+
+.mv-landing-section__head--split > p {
+  margin: 0;
+}
+
+.mv-landing-case-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 48px;
+}
+
+.mv-landing-case-slot {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+}
+
+.mv-landing-case-slot__visual {
+  min-height: 190px;
+  position: relative;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-bottom: 1px solid var(--line);
+  background:
+    linear-gradient(
+      color-mix(in srgb, var(--line) 52%, transparent) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--line) 52%, transparent) 1px,
+      transparent 1px
+    ),
+    var(--surface-2);
+  background-size: 28px 28px;
+}
+
+.mv-landing-case-slot__visual > span {
+  position: relative;
+  z-index: 2;
+  padding: 6px 9px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--surface) 80%, transparent);
+  color: var(--ink-3);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+}
+
+.mv-landing-case-slot__visual i {
+  position: absolute;
+  display: block;
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--line));
+  border-radius: 50%;
+}
+
+.mv-landing-case-slot__visual i:nth-child(2) {
+  width: 130px;
+  height: 130px;
+}
+
+.mv-landing-case-slot__visual i:nth-child(3) {
+  width: 84px;
+  height: 84px;
+}
+
+.mv-landing-case-slot__visual i:nth-child(4) {
+  width: 8px;
+  height: 8px;
+  border: 0;
+  background: var(--accent);
+  box-shadow: 0 0 0 5px var(--accent-soft);
+}
+
+.mv-landing-case-slot__meta {
+  min-height: 126px;
+  padding: 17px 18px;
+}
+
+.mv-landing-case-slot__meta > span {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.mv-landing-case-slot__meta p {
+  margin: 10px 0 0;
+  color: var(--ink-3);
+  font-size: 11.5px;
+  line-height: 1.6;
+}
+
+.mv-landing-cases__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+  color: var(--ink-3);
+  font-size: 11.5px;
+}
+
+.mv-landing-cases__foot button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-weight: 560;
+  cursor: pointer;
+}
+
+.mv-landing-cases__foot svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 1.8;
+}
+
+/* ───── Architecture ───── */
+
+.mv-landing-architecture__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.88fr) minmax(420px, 0.72fr);
+  align-items: center;
+  gap: clamp(64px, 9vw, 132px);
+}
+
+.mv-landing-pipeline {
+  display: grid;
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background:
+    linear-gradient(
+      color-mix(in srgb, var(--line) 44%, transparent) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--line) 44%, transparent) 1px,
+      transparent 1px
+    ),
+    var(--surface-2);
+  background-size: 28px 28px;
+}
+
+.mv-landing-pipeline__row {
+  position: relative;
+  min-height: 64px;
+  display: grid;
+  grid-template-columns: 112px minmax(0, 1fr);
+  align-items: center;
+  gap: 16px;
+  padding: 0 15px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+}
+
+.mv-landing-pipeline__row:not(:last-child) {
+  margin-bottom: 18px;
+}
+
+.mv-landing-pipeline__row > span {
+  color: var(--accent);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 8.5px;
+  letter-spacing: 0.08em;
+}
+
+.mv-landing-pipeline__row > strong {
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 580;
+}
+
+.mv-landing-pipeline__row > i {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 50%;
+  transform: translateX(-50%);
+  color: var(--ink-3);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 10px;
+  font-style: normal;
+}
+
+/* ───── Final CTA / footer ───── */
+
+.mv-landing-final {
+  padding: 0 0 clamp(70px, 8vw, 104px);
+}
+
+.mv-landing-final__inner {
+  min-height: 250px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 48px;
+  padding: clamp(38px, 5vw, 62px);
+  overflow: hidden;
+  position: relative;
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--line));
+  border-radius: 14px;
+  background:
+    radial-gradient(
+      circle at 86% 12%,
+      color-mix(in srgb, var(--accent) 16%, transparent),
+      transparent 38%
+    ),
+    color-mix(in srgb, var(--accent) 5%, var(--surface));
+}
+
+.mv-landing-final__inner::after {
+  content: "";
+  position: absolute;
+  right: 4%;
+  bottom: -160px;
+  width: 360px;
+  height: 360px;
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 48px color-mix(in srgb, var(--accent) 4%, transparent),
+    0 0 0 96px color-mix(in srgb, var(--accent) 3%, transparent);
+  pointer-events: none;
+}
+
+.mv-landing-final__inner > div,
+.mv-landing-final__inner > button {
+  position: relative;
+  z-index: 2;
+}
+
+.mv-landing-final__inner > div > span {
+  display: block;
+  margin-bottom: 14px;
+  color: var(--accent);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+}
+
+.mv-landing-final h2 {
+  max-width: 650px;
+}
+
+.mv-landing-footer {
+  padding: 30px 0 calc(30px + var(--mv-safe-bottom));
+  border-top: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface-2) 54%, var(--bg));
+}
+
+.mv-landing-footer__inner {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 28px;
+}
+
+.mv-landing-footer .mv-landing-brand > span:last-child {
+  display: grid;
+  gap: 3px;
+}
+
+.mv-landing-footer .mv-landing-brand strong {
+  color: var(--ink);
+  font-family: var(--font-headline, "Space Grotesk", sans-serif);
+  font-size: 13px;
+}
+
+.mv-landing-footer .mv-landing-brand small {
+  color: var(--ink-3);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 7px;
+  letter-spacing: 0.12em;
+}
+
+.mv-landing-footer p {
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 11px;
+  text-align: center;
+}
+
+.mv-landing-footer__inner > div:last-child {
+  display: flex;
+  align-items: center;
+  justify-self: end;
+  gap: 16px;
+}
+
+.mv-landing-footer a,
+.mv-landing-footer button {
+  appearance: none;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink-2);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.mv-landing-footer a:hover,
+.mv-landing-footer button:hover {
+  color: var(--accent);
+}
+
+/* ───── Responsive ───── */
+
+@media (max-width: 1080px) {
+  .mv-landing-header__inner {
+    grid-template-columns: 1fr auto;
+  }
+
+  .mv-landing-nav {
+    display: none;
+  }
+
+  .mv-landing-hero {
+    min-height: auto;
+  }
+
+  .mv-landing-hero__grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 58px;
+  }
+
+  .mv-landing-hero__copy {
+    max-width: 720px;
+  }
+
+  .mv-landing-hero h1 {
+    max-width: 10em;
+  }
+
+  .mv-landing-hero__copy > p {
+    max-width: 650px;
+  }
+
+  .mv-landing-hero__visual {
+    width: min(820px, 100%);
+    margin-inline: auto;
+  }
+
+  .mv-landing-process__rail {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    row-gap: 56px;
+  }
+
+  .mv-landing-process__step:nth-child(2) {
+    border-right: 0;
+    margin-right: 0;
+  }
+
+  .mv-landing-capabilities__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .mv-landing-capabilities__copy {
+    max-width: 760px;
+  }
+
+  .mv-landing-linked {
+    width: min(820px, 100%);
+    margin-inline: auto;
+  }
+}
+
+@media (max-width: 820px) {
+  .mv-landing-section__head--split,
+  .mv-landing-architecture__grid {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .mv-landing-section__head--split {
+    gap: 20px;
+  }
+
+  .mv-landing-section__head--split > p {
+    max-width: 680px;
+  }
+
+  .mv-landing-case-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .mv-landing-case-slot {
+    display: grid;
+    grid-template-columns: minmax(250px, 0.9fr) minmax(0, 1.1fr);
+  }
+
+  .mv-landing-case-slot__visual {
+    min-height: 170px;
+    border-right: 1px solid var(--line);
+    border-bottom: 0;
+  }
+
+  .mv-landing-case-slot__meta {
+    min-height: 0;
+    display: grid;
+    align-content: center;
+  }
+
+  .mv-landing-pipeline {
+    width: min(620px, 100%);
+  }
+
+  .mv-landing-final__inner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 640px) {
+  .mv-landing {
+    --mv-landing-gutter: 14px;
+    --mv-landing-section-y: 70px;
+  }
+
+  .mv-landing-header {
+    min-height: calc(60px + var(--mv-safe-top));
+  }
+
+  .mv-landing-header__inner {
+    min-height: 60px;
+    gap: 10px;
+  }
+
+  .mv-landing-brand .mv-brand-meta {
+    display: none;
+  }
+
+  .mv-landing-header__actions {
+    gap: 6px;
+  }
+
+  .mv-landing-theme {
+    width: 40px;
+    height: 40px;
+  }
+
+  .mv-landing-button--compact {
+    min-height: 40px;
+    padding-inline: 12px;
+  }
+
+  .mv-landing-button--compact svg {
+    display: none;
+  }
+
+  .mv-landing-hero {
+    padding: 62px 0 70px;
+  }
+
+  .mv-landing-hero__field {
+    opacity: 0.32;
+  }
+
+  .mv-landing-eyebrow {
+    margin-bottom: 18px;
+    font-size: 8px;
+  }
+
+  .mv-landing-hero h1 {
+    max-width: 8.5em;
+    font-size: clamp(39px, 12vw, 52px);
+  }
+
+  .mv-landing-hero__copy > p {
+    margin-top: 22px;
+    font-size: 14px;
+    line-height: 1.68;
+  }
+
+  .mv-landing-hero__actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .mv-landing-hero__actions .mv-landing-button {
+    width: 100%;
+    min-height: 46px;
+  }
+
+  .mv-landing-subjects {
+    gap: 7px 10px;
+  }
+
+  .mv-landing-hero__caption {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .mv-landing-hero__caption p {
+    text-align: left;
+  }
+
+  .mv-landing-canvas__head {
+    min-height: 56px;
+    padding-inline: 13px;
+  }
+
+  .mv-landing-canvas__status {
+    font-size: 8px;
+  }
+
+  .mv-landing-canvas__stage,
+  .mv-landing-canvas__plot {
+    min-height: 290px;
+  }
+
+  .mv-landing-canvas__note {
+    max-width: 160px;
+    padding: 8px 9px;
+  }
+
+  .mv-landing-canvas__note--goal {
+    top: 12px;
+    left: 12px;
+  }
+
+  .mv-landing-canvas__note--director {
+    right: 12px;
+    bottom: 12px;
+  }
+
+  .mv-landing-canvas__timeline {
+    grid-template-columns: repeat(5, 112px);
+    overflow-x: auto;
+  }
+
+  .mv-landing-process__rail {
+    grid-template-columns: minmax(0, 1fr);
+    border-top: 0;
+    row-gap: 0;
+  }
+
+  .mv-landing-process__step,
+  .mv-landing-process__step:not(:last-child) {
+    min-height: 0;
+    grid-template-columns: 32px minmax(0, 1fr);
+    margin: 0;
+    padding: 22px 0;
+    border-top: 1px solid var(--line);
+    border-right: 0;
+  }
+
+  .mv-landing-process__index {
+    transform: none;
+  }
+
+  .mv-landing-process__index span {
+    width: 30px;
+    height: 30px;
+  }
+
+  .mv-landing-process__index i {
+    display: none;
+  }
+
+  .mv-landing-linked__body {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: 190px auto 112px auto;
+  }
+
+  .mv-landing-linked__panel,
+  .mv-landing-linked__panel:nth-child(2n),
+  .mv-landing-linked__panel:nth-child(n + 3) {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .mv-landing-linked__panel:last-child {
+    border-bottom: 0;
+  }
+
+  .mv-landing-linked__panel--state dl {
+    margin-top: 18px;
+  }
+
+  .mv-landing-case-slot {
+    display: block;
+  }
+
+  .mv-landing-case-slot__visual {
+    min-height: 180px;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .mv-landing-cases__foot {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .mv-landing-pipeline {
+    padding: 12px;
+  }
+
+  .mv-landing-pipeline__row {
+    grid-template-columns: 92px minmax(0, 1fr);
+    padding-inline: 11px;
+  }
+
+  .mv-landing-final__inner {
+    min-height: 0;
+    gap: 32px;
+    padding: 34px 24px;
+  }
+
+  .mv-landing-final__inner > button {
+    width: 100%;
+    min-height: 46px;
+  }
+
+  .mv-landing-footer__inner {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .mv-landing-footer p {
+    display: none;
+  }
+
+  .mv-landing-footer__inner > div:last-child {
+    gap: 12px;
+  }
+}
+
+@media (max-width: 390px) {
+  .mv-landing-button--compact {
+    max-width: 122px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mv-landing-canvas__head > div:first-child span {
+    display: none;
+  }
+
+  .mv-landing-canvas__note--director {
+    display: none;
+  }
+
+  .mv-landing-linked__panel--state dl {
+    gap: 5px;
+  }
+
+  .mv-landing-linked__panel--state dl > div {
+    padding-inline: 7px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mv-landing *,
+  .mv-landing *::before,
+  .mv-landing *::after {
+    scroll-behavior: auto !important;
+  }
+
+  .mv-landing-hero__field {
+    opacity: 0.24;
+  }
+}

--- a/apps/web/src/styles/pages/landing/shell.css
+++ b/apps/web/src/styles/pages/landing/shell.css
@@ -1,0 +1,629 @@
+/* MetaView — public landing page */
+
+.mv-landing {
+  --mv-landing-max: 1200px;
+  --mv-landing-gutter: clamp(18px, 3vw, 32px);
+  --mv-landing-section-y: clamp(78px, 9vw, 116px);
+
+  width: 100%;
+  min-height: var(--mv-vvh, 100vh);
+  overflow-x: hidden;
+  background: var(--bg);
+  color: var(--ink);
+}
+
+.mv-landing,
+.mv-landing button,
+.mv-landing a {
+  font-family:
+    "Inter",
+    -apple-system,
+    system-ui,
+    "PingFang SC",
+    "Noto Sans SC",
+    sans-serif;
+}
+
+.mv-landing button,
+.mv-landing a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mv-landing a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.mv-landing-container {
+  width: min(
+    var(--mv-landing-max),
+    calc(100vw - var(--mv-landing-gutter) * 2)
+  );
+  margin-inline: auto;
+}
+
+/* ───── Header ───── */
+
+.mv-landing-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  min-height: calc(68px + var(--mv-safe-top));
+  padding-top: var(--mv-safe-top);
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 78%, transparent);
+  background: color-mix(in srgb, var(--bg) 84%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.mv-landing-header__inner {
+  min-height: 68px;
+  display: grid;
+  grid-template-columns: minmax(190px, 1fr) auto minmax(190px, 1fr);
+  align-items: center;
+  gap: 24px;
+}
+
+.mv-landing-brand {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  justify-self: start;
+}
+
+.mv-landing-brand .mv-brand-name {
+  font-size: 14px;
+}
+
+.mv-landing-brand .mv-brand-meta {
+  font-size: 8px;
+  letter-spacing: 0.2em;
+}
+
+.mv-landing-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid color-mix(in srgb, var(--line) 70%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--surface-2) 52%, transparent);
+}
+
+.mv-landing-nav a {
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border-radius: 7px;
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 520;
+  transition:
+    color 150ms ease,
+    background-color 150ms ease;
+}
+
+.mv-landing-nav a:hover,
+.mv-landing-nav a:focus-visible {
+  color: var(--ink);
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+}
+
+.mv-landing-header__actions {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-self: end;
+  gap: 8px;
+}
+
+.mv-landing-theme {
+  appearance: none;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+  color: var(--ink-2);
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    color 150ms ease,
+    background-color 150ms ease;
+}
+
+.mv-landing-theme:hover {
+  color: var(--ink);
+  border-color: var(--line-2);
+  background: var(--surface);
+}
+
+.mv-landing-theme svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 1.75;
+}
+
+/* ───── Shared controls ───── */
+
+.mv-landing-button {
+  appearance: none;
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  padding: 0 17px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 560;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease,
+    background-color 150ms ease,
+    opacity 150ms ease;
+}
+
+.mv-landing-button svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 1.8;
+}
+
+.mv-landing-button:hover {
+  border-color: var(--line-2);
+  background: var(--surface-2);
+}
+
+.mv-landing-button--compact {
+  min-height: 36px;
+  padding-inline: 13px;
+  font-size: 12px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--surface));
+  border-color: color-mix(in srgb, var(--accent) 18%, var(--line));
+  color: color-mix(in srgb, var(--accent) 64%, var(--ink));
+}
+
+.mv-landing-button--compact:hover {
+  background: color-mix(in srgb, var(--accent) 13%, var(--surface));
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--line));
+}
+
+.mv-landing-button--primary {
+  background: var(--accent);
+  border-color: transparent;
+  color: #fff;
+}
+
+.mv-landing-button--primary:hover {
+  background: color-mix(in srgb, var(--accent) 90%, var(--ink));
+  border-color: transparent;
+}
+
+.mv-landing-button--secondary {
+  background: color-mix(in srgb, var(--surface) 76%, transparent);
+  color: var(--ink-2);
+}
+
+.mv-landing-button:focus-visible,
+.mv-landing-theme:focus-visible,
+.mv-landing-nav a:focus-visible,
+.mv-landing-footer a:focus-visible,
+.mv-landing-footer button:focus-visible,
+.mv-landing-cases__foot button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 46%, transparent);
+  outline-offset: 2px;
+}
+
+/* ───── Hero ───── */
+
+.mv-landing-hero {
+  position: relative;
+  isolation: isolate;
+  min-height: min(840px, calc(var(--mv-vvh, 100vh) - 68px));
+  display: grid;
+  align-items: center;
+  padding: clamp(72px, 9vw, 112px) 0 clamp(76px, 8vw, 104px);
+  overflow: hidden;
+  background:
+    radial-gradient(
+      circle at 18% 8%,
+      color-mix(in srgb, var(--accent) 9%, transparent),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 84% 32%,
+      color-mix(in srgb, #a99562 7%, transparent),
+      transparent 28%
+    ),
+    var(--bg);
+}
+
+.mv-landing-hero::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--line-2) 70%, transparent),
+    transparent
+  );
+}
+
+.mv-landing-hero__field {
+  z-index: -1;
+  inset: 2% -3% auto;
+  height: min(520px, 62vh);
+  opacity: 0.52;
+  mask-image: linear-gradient(to bottom, black 22%, transparent 94%);
+}
+
+.mv-landing-hero__field .mv-meta-particle__svg {
+  transform: scale(1.08);
+}
+
+.mv-landing-hero__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.88fr) minmax(520px, 1.12fr);
+  align-items: center;
+  gap: clamp(48px, 6vw, 88px);
+}
+
+.mv-landing-hero__copy {
+  max-width: 560px;
+  position: relative;
+  z-index: 2;
+}
+
+.mv-landing-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 22px;
+  color: var(--ink-3);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 9.5px;
+  font-weight: 560;
+  letter-spacing: 0.12em;
+}
+
+.mv-landing-eyebrow i {
+  width: 22px;
+  height: 1px;
+  background: var(--line-2);
+}
+
+.mv-landing-hero h1 {
+  margin: 0;
+  max-width: 8.7em;
+  color: var(--ink);
+  font-family: var(--font-headline, "Space Grotesk", "Inter", sans-serif);
+  font-size: clamp(44px, 5.4vw, 72px);
+  font-weight: 620;
+  letter-spacing: -0.052em;
+  line-height: 1.03;
+  text-wrap: balance;
+}
+
+.mv-landing-hero h1 > span {
+  display: block;
+  color: color-mix(in srgb, var(--accent) 76%, var(--ink));
+}
+
+.mv-landing-hero__copy > p {
+  max-width: 520px;
+  margin: 26px 0 0;
+  color: var(--ink-2);
+  font-size: clamp(15px, 1.3vw, 17px);
+  line-height: 1.75;
+}
+
+.mv-landing-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 32px;
+}
+
+.mv-landing-subjects {
+  max-width: 520px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px 12px;
+  margin-top: 28px;
+  color: var(--ink-3);
+  font-size: 11px;
+}
+
+.mv-landing-subjects > span {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  letter-spacing: 0.1em;
+}
+
+.mv-landing-subjects i {
+  position: relative;
+  font-style: normal;
+  color: var(--ink-2);
+}
+
+.mv-landing-subjects i:not(:last-child)::after {
+  content: "·";
+  position: absolute;
+  left: calc(100% + 5px);
+  color: var(--line-2);
+}
+
+.mv-landing-hero__visual {
+  min-width: 0;
+  position: relative;
+  z-index: 2;
+}
+
+.mv-landing-hero__caption {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 13px 10px 0;
+}
+
+.mv-landing-hero__caption span {
+  flex: 0 0 auto;
+  color: var(--ink-3);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+}
+
+.mv-landing-hero__caption p {
+  max-width: 360px;
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1.5;
+  text-align: right;
+}
+
+/* ───── Hero canvas ───── */
+
+.mv-landing-canvas {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--line-2) 82%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  box-shadow:
+    0 26px 80px rgba(41, 38, 30, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(14px);
+}
+
+.mv-dark .mv-landing-canvas {
+  box-shadow:
+    0 28px 80px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.mv-landing-canvas__head {
+  min-height: 62px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface-2) 72%, transparent);
+}
+
+.mv-landing-canvas__head > div:first-child {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.mv-landing-canvas__head span,
+.mv-landing-canvas__status {
+  color: var(--ink-3);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+}
+
+.mv-landing-canvas__head strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mv-landing-canvas__status {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.mv-landing-canvas__status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.mv-landing-canvas__stage {
+  min-height: 390px;
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(
+      circle at 58% 30%,
+      color-mix(in srgb, var(--accent) 7%, transparent),
+      transparent 34%
+    ),
+    var(--surface-2);
+}
+
+.mv-landing-canvas__grid {
+  position: absolute;
+  inset: 0;
+  opacity: 0.54;
+  background:
+    linear-gradient(
+      color-mix(in srgb, var(--line) 64%, transparent) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--line) 64%, transparent) 1px,
+      transparent 1px
+    );
+  background-size: 30px 30px;
+  mask-image: linear-gradient(to bottom, black, transparent 94%);
+}
+
+.mv-landing-canvas__plot {
+  width: 100%;
+  height: 100%;
+  min-height: 390px;
+  position: relative;
+  z-index: 1;
+  color: var(--accent);
+}
+
+.mv-landing-canvas__axis {
+  fill: none;
+  stroke: color-mix(in srgb, var(--ink-3) 34%, transparent);
+  stroke-width: 1.2;
+}
+
+.mv-landing-canvas__trajectory {
+  fill: none;
+  stroke: color-mix(in srgb, var(--accent) 74%, var(--ink-2));
+  stroke-width: 3;
+  stroke-linecap: round;
+}
+
+.mv-landing-canvas__object {
+  fill: var(--surface);
+  stroke: var(--accent);
+  stroke-width: 3;
+  filter: drop-shadow(0 4px 8px color-mix(in srgb, var(--accent) 24%, transparent));
+}
+
+.mv-landing-canvas__vector {
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.mv-landing-canvas__vector--velocity {
+  stroke: color-mix(in srgb, var(--accent) 72%, var(--ink));
+}
+
+.mv-landing-canvas__vector--x,
+.mv-landing-canvas__vector--y {
+  stroke: color-mix(in srgb, var(--ink-2) 62%, transparent);
+  stroke-dasharray: 5 5;
+}
+
+.mv-landing-canvas__vector--gravity {
+  stroke: color-mix(in srgb, #a99562 66%, var(--ink-2));
+}
+
+.mv-landing-canvas__label {
+  fill: var(--ink-2);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 14px;
+}
+
+.mv-landing-canvas__note {
+  position: absolute;
+  z-index: 2;
+  display: grid;
+  gap: 4px;
+  padding: 10px 11px;
+  border: 1px solid color-mix(in srgb, var(--line-2) 76%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  box-shadow: 0 10px 28px rgba(41, 38, 30, 0.07);
+  backdrop-filter: blur(10px);
+}
+
+.mv-landing-canvas__note span {
+  color: var(--ink-3);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 8px;
+  letter-spacing: 0.1em;
+}
+
+.mv-landing-canvas__note strong {
+  color: var(--ink-2);
+  font-size: 10.5px;
+  font-weight: 560;
+}
+
+.mv-landing-canvas__note--goal {
+  top: 18px;
+  left: 18px;
+}
+
+.mv-landing-canvas__note--director {
+  right: 18px;
+  bottom: 18px;
+}
+
+.mv-landing-canvas__timeline {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface) 82%, transparent);
+}
+
+.mv-landing-canvas__beat {
+  min-width: 0;
+  min-height: 64px;
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  padding: 0 12px;
+  border-right: 1px solid var(--line);
+  color: var(--ink-3);
+}
+
+.mv-landing-canvas__beat:last-child {
+  border-right: 0;
+}
+
+.mv-landing-canvas__beat span {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 9px;
+}
+
+.mv-landing-canvas__beat strong {
+  overflow: hidden;
+  font-size: 10px;
+  font-weight: 520;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mv-landing-canvas__beat.is-active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}

--- a/apps/web/src/styles/pages/landing/shell.css
+++ b/apps/web/src/styles/pages/landing/shell.css
@@ -202,7 +202,7 @@
 .mv-landing-button--primary {
   background: var(--accent);
   border-color: transparent;
-  color: #fff;
+  color: var(--accent-contrast, var(--ink));
 }
 
 .mv-landing-button--primary:hover {

--- a/docs/frontend-shell.md
+++ b/docs/frontend-shell.md
@@ -1,14 +1,34 @@
-# 前端外壳：Topbar / Stage / Provider
+# 前端外壳：Landing / Topbar / Stage / Provider
+
+## 公共 Landing 路由
+
+`App.tsx` 在 edition shell 之外注册公共首页：
+
+```text
+/             -> LandingRoute
+/create       -> IntakeScreen
+/run/:runId   -> StudioPage
+/history      -> HistoryPage
+/templates    -> TemplatesPage
+/settings     -> SettingsPage
+```
+
+`LandingRoute` 负责加载与应用内一致的主题变量，并把“开始创建”导航到 `/create`。公共首页不复用应用内 `GlobalTopbar`，避免把营销叙事和工具导航塞进同一个 Shell。
 
 ## Stage 路由
 
-`App.tsx` 用本地状态管理三个 Stage：
+`SelfAppShell` / `OpsAppShell` 使用当前路径派生五个应用 Stage：
 
 ```ts
-type Stage = 'intake' | 'workbench' | 'history';
+type Stage =
+  | "intake"
+  | "workbench"
+  | "history"
+  | "templates"
+  | "settings";
 ```
 
-切换通过 `setStage`（即 `onNavigate` 回调）。每个页面接收同一签名：
+切换通过 `onNavigate(stage)`。每个页面接收同一签名：
 
 ```ts
 onNavigate: (stage: Stage) => void
@@ -16,9 +36,22 @@ onNavigate: (stage: Stage) => void
 
 避免每页定义 `onHome / onHistory / onTemplate` 等 N×M 回调。
 
+Stage 与路径映射：
+
+```text
+intake                -> /create
+workbench + runId     -> /run/:runId
+workbench without id  -> /create
+history               -> /history
+templates             -> /templates
+settings              -> /settings
+```
+
+未知应用路径回到公共首页 `/`。
+
 ## GlobalTopbar
 
-`apps/web/src/shared/ui/GlobalTopbar.tsx` 是三个 stage 共享的顶部栏。**不要**在页面级别复制 topbar JSX。
+`apps/web/src/shared/ui/GlobalTopbar.tsx` 是应用内五个 Stage 共享的顶部栏。**不要**在页面级别复制 Topbar JSX，也不要在公共 Landing Page 中强行复用它。
 
 接口：
 
@@ -33,20 +66,21 @@ interface GlobalTopbarProps {
 }
 ```
 
-- `stage='intake' | 'workbench'` 时 “工作台” 高亮（intake 是 workbench 的子态）。
-- “模板/设置” 当前 disabled，待实现。
-- Provider 状态指示：`isProviderConfigured` → `CORE NODES ONLINE` / `NO PROVIDER SET`。
+- `stage="intake" | "workbench"` 时“工作台”高亮。
+- “任务历史 / 模板 / 设置”分别对应独立路由。
+- Provider 状态在 self edition 中保持安静；未配置引导由输入和追问流程承担。
+- 工作台可在桌面端折叠 Topbar，移动端始终恢复可见。
 
 ## Provider 配置
 
 - Hook：`useProviderSettings`（`apps/web/src/features/providers/hooks/useProviderSettings.ts`）
 - 模态：`ProviderSettingsModal`
   - **关闭逻辑**：`onMouseDown` 触发关闭，内层 `onMouseDown` `stopPropagation`。这样从内部拖拽到外部释放鼠标不会误关。
-- 凭据保存在 localStorage（用户自带 key），前端调用 OpenAI 兼容接口（`baseUrl + /chat/completions`）。
+- 凭据保存在 localStorage（用户自带 Key），前端调用 OpenAI 兼容接口（`baseUrl + /chat/completions`）。
 
 ## Snapshot support levels
 
-前端 renderer registry 可以注册比首发产品面更宽的 snapshot kind。`registered` 只表示有渲染器入口；`launch-supported` 才表示生成、review、导出和产品验收都按首发质量承诺覆盖。
+前端 Renderer Registry 可以注册比首发产品面更宽的 Snapshot Kind。`registered` 只表示有渲染器入口；`launch-supported` 才表示生成、Review、导出和产品验收都按首发质量承诺覆盖。
 
 Launch-supported:
 
@@ -65,7 +99,7 @@ Parked:
 - `phase_portrait_scene`, `complex_plane_scene`
 - `optimization_scene`, `modeling_scene`, `manifold_scene`
 
-任何已注册但未列入 launch-supported 的 kind，都不能仅因为 registry 可渲染就进入首发生成承诺。
+任何已注册但未列入 launch-supported 的 Kind，都不能仅因为 Registry 可渲染就进入首发生成承诺。
 
 ## Studio 布局
 
@@ -73,28 +107,34 @@ Parked:
 
 ```ts
 mainStyle = {
-  '--left-w': leftCollapsed ? '0px' : `${t.leftRatio}%`,
-  gridTemplateColumns: leftCollapsed ? '1fr' : 'var(--left-w) 1fr',
+  "--left-w": leftCollapsed ? "0px" : `${t.leftRatio}%`,
+  gridTemplateColumns: leftCollapsed ? "1fr" : "var(--left-w) 1fr",
 };
 ```
 
 - `t.leftRatio` 范围 `[12, 50]`（`TweaksPanel` 滑块）。
-- 折叠时左 aside 不渲染（不只是隐藏），由 `mv-left-handle` 浮按钮切回。
+- 折叠时左 Aside 不渲染（不只是隐藏），由 `mv-left-handle` 浮按钮切回。
 
 ### 卡片折叠
+
 左栏两张卡片（`ProblemCard` / `ChatPanel`）各自独立折叠，状态在 `StudioPage` 里持有。
+
 折叠样式见 `studio.css` `.is-collapsed` 选择器。
 
 ### ChatPanel
-- 直连用户配置的 LLM provider（不走后端）。
-- 每次发送会先 abort 上一次请求。
-- 历史不持久化，stage 切换即丢失。
+
+- 直连用户配置的 LLM Provider（不走后端）。
+- 每次发送会先 Abort 上一次请求。
+- 历史不持久化，Stage 切换即丢失。
 - 输入框 Enter 发送，Shift+Enter 换行。
-- 未配置 provider 时禁用输入并显示去配置入口。
+- 未配置 Provider 时禁用输入并显示去配置入口。
 
 ## 文件位置约定
 
-- 跨 stage 共享 UI → `apps/web/src/shared/ui/`
-- 单 stage 专用 → `apps/web/src/pages/<Stage>/` 或 `apps/web/src/features/<feature>/ui/`
+- 公共 Landing 页面组合 → `apps/web/src/pages/Landing/`
+- 公共 Landing 路由与主题装配 → `apps/web/src/app/LandingRoute.tsx`
+- 跨 Stage 共享 UI → `apps/web/src/shared/ui/`
+- 单 Stage 专用 → `apps/web/src/pages/<Stage>/` 或 `apps/web/src/features/<feature>/ui/`
+- Landing 样式 → `apps/web/src/styles/pages/landing.css`
 
 `shared/` 不得反向导入 `features/` 或 `pages/`。


### PR DESCRIPTION
## What changed

- add a public MetaView landing page at `/`
- move the existing creation intake to `/create`
- keep `/run/:runId`, history, templates, and settings inside the existing app shell
- add a theory-canvas hero, generation-process narrative, linked learning explorer, architecture section, and responsive layout
- reserve the case gallery for real launch-validated cases instead of presenting benchmark-only outputs as shipped examples
- rename the app-shell first navigation item from `首页` to `工作台`
- align the default brand accent with the existing sage player palette
- add `DESIGN.md` and update frontend-shell documentation
- add landing, routing, edition, and topbar tests

## Design constraints

- warm off-white paper surfaces and restrained sage accent
- no blue-purple AI gradients or generic dashboard hero
- low-intensity canvas/path motif only
- public landing stays on the MetaView brand light/dark palettes even when the workspace uses a named editor theme
- reduced-motion and mobile layouts included

## Validation

- `Check` workflow passed
- dependency installation passed
- `make check` passed, including lint, tests, TypeScript, and Vite build
- PR coverage step passed

## Review focus

- visual hierarchy and copy tone on the public landing page
- hero canvas proportions at desktop and mobile breakpoints
- whether the reserved case section should remain three slots before real launch cases are connected
