### PR TITLE
refactor(web): simplify intake and enforce backend-owned routing

### DIFF
--- a/apps/api/app/application/dto/pipeline_dto.py
+++ b/apps/api/app/application/dto/pipeline_dto.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.domain.models.coverage import CoverageDecision
 from app.domain.models.director import DirectorScript
@@ -15,7 +15,9 @@ class PipelineRequest(BaseModel):
     prompt: str = Field(min_length=1, max_length=4000)
     domain: str | None = None
     source_code: str | None = None
-    language: str = "python"
+    language: str | None = None
+    source_filename: str | None = Field(default=None, max_length=255)
+    source_size_bytes: int | None = Field(default=None, ge=0, le=256 * 1024)
     skill_mode_override: str | None = None
     # Per-request provider override (takes precedence over env-var config)
     provider_api_key: str | None = None
@@ -57,6 +59,9 @@ class PipelineRequest(BaseModel):
         "provider_base_url",
         "provider_model",
         "router_model",
+        "domain",
+        "language",
+        "source_filename",
         mode="before",
     )
     @classmethod
@@ -65,6 +70,15 @@ class PipelineRequest(BaseModel):
             return None
         normalized = str(value).strip()
         return normalized or None
+
+    @model_validator(mode="after")
+    def validate_source_metadata(self):
+        metadata = (self.language, self.source_filename, self.source_size_bytes)
+        if self.source_code is None and any(value is not None for value in metadata):
+            raise ValueError("source metadata requires source_code")
+        if self.source_code is not None and len(self.source_code.encode("utf-8")) > 256 * 1024:
+            raise ValueError("source_code cannot exceed 256 KB")
+        return self
 
 
 class PipelineRunResponse(BaseModel):

--- a/apps/api/app/domain/services/cir_prompt.py
+++ b/apps/api/app/domain/services/cir_prompt.py
@@ -308,7 +308,7 @@ def build_cir_prompt(
     prompt: str,
     domain_hint: TopicDomain | None,
     source_code: str | None = None,
-    language: str = "python",
+    language: str | None = None,
     skill_mode: SkillMode = SkillMode.SPECIALIZED,
     route_decision: RouteDecision | dict[str, Any] | None = None,
     coverage_decision: CoverageDecision | None = None,
@@ -343,7 +343,7 @@ You may change this if the topic clearly belongs to a different domain."""
     code_track = ""
     if source_code and source_code.strip():
         code_track = _CODE_TRACK_INSTRUCTION.format(
-            language=language or "python",
+            language=language or "unknown",
             numbered_source=_number_source(source_code),
         )
     # For algorithm domain: add pseudocode generation instruction.

--- a/apps/api/app/domain/services/playbook_builder.py
+++ b/apps/api/app/domain/services/playbook_builder.py
@@ -95,13 +95,13 @@ def _infer_algorithm_id(title: str, execution_map: ExecutionMap | None = None) -
 
 def _resolve_source(
     user_source: str | None,
-    user_language: str,
+    user_language: str | None,
     algorithm_id: str | None,
     execution_map: ExecutionMap | None,
 ) -> tuple[list[str], str]:
     """Return (source_lines, language) using priority: user upload > library > LLM generated."""
     if user_source and user_source.strip():
-        return user_source.splitlines(), user_language
+        return user_source.splitlines(), user_language or "text"
     if algorithm_id:
         library_entry = get_by_id(algorithm_id)
         if library_entry:
@@ -109,7 +109,7 @@ def _resolve_source(
     if execution_map and execution_map.algorithm_code:
         lang = getattr(execution_map, "algorithm_language", "pseudocode") or "pseudocode"
         return list(execution_map.algorithm_code), lang
-    return [], user_language
+    return [], user_language or "text"
 
 
 def build_playbook(
@@ -117,7 +117,7 @@ def build_playbook(
     execution_map: ExecutionMap | None,
     fps: int = _DEFAULT_FPS,
     source_code: str | None = None,
-    source_language: str = "python",
+    source_language: str | None = None,
 ) -> PlaybookScript:
     # Expand high-level animation macros before processing steps.
     cir = expand_cir_animation_calls(cir)

--- a/apps/api/tests/test_cir_prompt.py
+++ b/apps/api/tests/test_cir_prompt.py
@@ -17,6 +17,18 @@ def test_user_prompt_equals_original_input() -> None:
     assert user == prompt
 
 
+def test_source_code_with_unknown_language_is_not_labeled_python() -> None:
+    system, _ = build_cir_prompt(
+        "解释这段代码",
+        TopicDomain.CODE,
+        source_code="custom syntax",
+        language=None,
+    )
+
+    assert "provided source code in `unknown`" in system
+    assert "provided source code in `python`" not in system
+
+
 def test_canonical_lesson_plan_guides_cir_without_changing_user_prompt() -> None:
     prompt = "用 BFS 解释广度优先遍历为什么需要队列"
     lesson_plan = build_rule_based_lesson_plan(prompt=prompt, domain="algorithm")

--- a/apps/api/tests/test_coverage_resolver.py
+++ b/apps/api/tests/test_coverage_resolver.py
@@ -57,6 +57,38 @@ def test_gold_templates_use_exact_controlled_composition_profiles(
     assert "physics.projectile_motion" not in decision.available_tool_ids
 
 
+@pytest.mark.parametrize(
+    ("prompt", "expected_domain"),
+    (
+        (GOLD_COMPOSABLE_CASES[0][0], "math"),
+        (GOLD_COMPOSABLE_CASES[3][0], "physics"),
+    ),
+)
+def test_text_requests_auto_route_without_domain_or_language(
+    prompt: str,
+    expected_domain: str,
+) -> None:
+    decision = DefaultCoverageResolver().resolve(
+        prompt=prompt,
+        explicit_domain=None,
+        language=None,
+    )
+
+    assert decision.domain == expected_domain
+    assert decision.mode == "composable"
+
+
+def test_code_attachment_routes_from_source_evidence_without_explicit_domain() -> None:
+    decision = DefaultCoverageResolver().resolve(
+        prompt="讲解这个附件中的程序",
+        source_code="def factorial(n):\n    return 1 if n <= 1 else n * factorial(n - 1)",
+        language="python",
+        explicit_domain=None,
+    )
+
+    assert decision.domain == "code"
+
+
 def test_registered_supported_skill_with_valid_spec_is_specialized() -> None:
     registry = build_default_skill_registry()
     prompt = "质量 2kg 的物体受到 10N 水平拉力，忽略摩擦，求加速度"

--- a/apps/api/tests/test_router_pipeline.py
+++ b/apps/api/tests/test_router_pipeline.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
+from app.application.dto.pipeline_dto import PipelineRequest
 from app.config import get_settings
 from app.domain.models.pipeline_run import PipelineRunStatus
 from app.infrastructure.persistence.db_init import init_db
@@ -213,6 +214,41 @@ def test_deleted_run_is_absent_from_list(client) -> None:
 def test_post_pipeline_rejects_empty_prompt(client) -> None:
     resp = client.post("/api/v1/pipeline", json={"prompt": ""})
     assert resp.status_code == 422
+
+
+def test_pipeline_request_defaults_text_language_to_none() -> None:
+    request = PipelineRequest(prompt="解释导数的几何意义")
+
+    assert request.domain is None
+    assert request.source_code is None
+    assert request.language is None
+    assert request.source_filename is None
+    assert request.source_size_bytes is None
+
+
+def test_post_pipeline_rejects_language_without_source_code(client) -> None:
+    response = client.post(
+        "/api/v1/pipeline",
+        json={"prompt": "解释导数", "language": "python"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_post_pipeline_accepts_single_code_file_metadata(client) -> None:
+    response = client.post(
+        "/api/v1/pipeline",
+        json={
+            "prompt": "讲解 solution.py 中的代码。",
+            "domain": None,
+            "source_code": "def solve():\n    return 42\n",
+            "language": "python",
+            "source_filename": "solution.py",
+            "source_size_bytes": 27,
+        },
+    )
+
+    assert response.status_code == 202
 
 
 def test_post_pipeline_returns_prompt_in_response(client) -> None:

--- a/apps/api/tests/test_run_pipeline_routed.py
+++ b/apps/api/tests/test_run_pipeline_routed.py
@@ -8,7 +8,7 @@ import pytest
 from app.application.dto.pipeline_dto import PipelineRequest
 from app.application.use_cases.run_pipeline import RunPipelineUseCase
 from app.domain.models.pipeline_run import PipelineRunStatus
-from app.domain.skills.base import SkillRouteMatch
+from app.domain.skills.base import SkillRouteInput, SkillRouteMatch
 from tests.coverage_test_utils import ComposableCoverageResolver
 
 _SOLID_PROMPT = (
@@ -66,12 +66,35 @@ class _StaticRouter:
         self._route = route
         self.model_name = "router-test"
         self.calls = 0
+        self.last_request: SkillRouteInput | None = None
 
-    async def route(self, **_: Any) -> SkillRouteMatch | None:
+    async def route(self, *, request: SkillRouteInput, **_: Any) -> SkillRouteMatch | None:
         self.calls += 1
+        self.last_request = request
         if isinstance(self._route, Exception):
             raise self._route
         return self._route
+
+
+@pytest.mark.asyncio
+async def test_text_request_does_not_send_a_false_python_signal_to_router() -> None:
+    router = _StaticRouter(None)
+    repo = _RecordingRepo()
+    use_case = RunPipelineUseCase(
+        repo,
+        _CapturingLLM(_generic_cir_json("math")),
+        router_provider=router,
+        coverage_resolver=ComposableCoverageResolver(default_domain="math"),
+    )
+
+    await use_case.execute(
+        "run-null-language",
+        PipelineRequest(prompt="用动画解释导数的几何意义"),
+    )
+
+    assert router.last_request is not None
+    assert router.last_request.source_code is None
+    assert router.last_request.language is None
 
 
 class _Agent:

--- a/apps/web/src/app/OpsAppShell.tsx
+++ b/apps/web/src/app/OpsAppShell.tsx
@@ -19,7 +19,7 @@ import {
 } from "../features/studio-editor/hooks/useTweaks";
 import {
   IntakeScreen,
-  IntakeContext,
+  type IntakeContext,
 } from "../features/studio-editor/ui/IntakeScreen";
 import { StudioPage } from "../pages/Studio/StudioPage";
 import { HistoryPage } from "../pages/History/HistoryPage";
@@ -121,23 +121,32 @@ export function OpsAppShell() {
 
   const submitWithPlatformProvider = async (
     prompt: string,
-    domain?: string | null,
-    sourceCode?: string,
-    language?: string,
-  ): Promise<string> => submit({ prompt, domain, sourceCode, language });
+    sourceCode?: string | null,
+    language?: string | null,
+    sourceFilename?: string | null,
+    sourceSizeBytes?: number | null,
+  ): Promise<string> =>
+    submit({
+      prompt,
+      sourceCode,
+      language,
+      sourceFilename,
+      sourceSizeBytes,
+    });
 
   const handleSubmit = async (ctx: IntakeContext) => {
     const nextRunId = await submitWithPlatformProvider(
-      ctx.raw || ctx.title,
-      ctx.domain,
+      ctx.prompt,
       ctx.sourceCode,
       ctx.language,
+      ctx.sourceFilename,
+      ctx.sourceSizeBytes,
     );
     enterRun(nextRunId);
   };
 
   const handleResubmitPrompt = async (prompt: string) => {
-    const nextRunId = await submitWithPlatformProvider(prompt, null);
+    const nextRunId = await submitWithPlatformProvider(prompt);
     enterRun(nextRunId);
   };
 
@@ -147,7 +156,7 @@ export function OpsAppShell() {
   };
 
   const handleUseTemplate = async (prompt: string) => {
-    const nextRunId = await submitWithPlatformProvider(prompt, null);
+    const nextRunId = await submitWithPlatformProvider(prompt);
     enterRun(nextRunId);
   };
 

--- a/apps/web/src/app/SelfAppShell.tsx
+++ b/apps/web/src/app/SelfAppShell.tsx
@@ -16,7 +16,7 @@ import {
 } from "../features/studio-editor/hooks/useTweaks";
 import {
   IntakeScreen,
-  IntakeContext,
+  type IntakeContext,
 } from "../features/studio-editor/ui/IntakeScreen";
 import { StudioPage } from "../pages/Studio/StudioPage";
 import { HistoryPage } from "../pages/History/HistoryPage";
@@ -116,30 +116,33 @@ export function SelfAppShell() {
 
   const submitWithProvider = async (
     prompt: string,
-    domain?: string | null,
-    sourceCode?: string,
-    language?: string,
+    sourceCode?: string | null,
+    language?: string | null,
+    sourceFilename?: string | null,
+    sourceSizeBytes?: number | null,
   ): Promise<string> =>
     submit({
       prompt,
-      domain,
       sourceCode,
       language,
+      sourceFilename,
+      sourceSizeBytes,
       provider: isConfigured ? providerSettings : undefined,
     });
 
   const handleSubmit = async (ctx: IntakeContext) => {
     const nextRunId = await submitWithProvider(
-      ctx.raw || ctx.title,
-      ctx.domain,
+      ctx.prompt,
       ctx.sourceCode,
       ctx.language,
+      ctx.sourceFilename,
+      ctx.sourceSizeBytes,
     );
     enterRun(nextRunId);
   };
 
   const handleResubmitPrompt = async (prompt: string) => {
-    const nextRunId = await submitWithProvider(prompt, null);
+    const nextRunId = await submitWithProvider(prompt);
     enterRun(nextRunId);
   };
 
@@ -149,7 +152,7 @@ export function SelfAppShell() {
   };
 
   const handleUseTemplate = async (prompt: string) => {
-    const nextRunId = await submitWithProvider(prompt, null);
+    const nextRunId = await submitWithProvider(prompt);
     enterRun(nextRunId);
   };
 

--- a/apps/web/src/features/pipeline/api/pipelineApi.test.ts
+++ b/apps/web/src/features/pipeline/api/pipelineApi.test.ts
@@ -12,9 +12,11 @@ describe("pipelineApi", () => {
         expect(request.credentials).toBe("include");
         expect(await request.json()).toMatchObject({
           prompt: "hello",
-          domain: "algorithm",
+          domain: null,
           source_code: "print('hello')",
           language: "python",
+          source_filename: "hello.py",
+          source_size_bytes: 14,
         });
         return HttpResponse.json({
           run_id: "run-1",
@@ -39,9 +41,11 @@ describe("pipelineApi", () => {
 
     const submitted = await submitPipeline({
       prompt: "hello",
-      domain: "algorithm",
+      domain: null,
       source_code: "print('hello')",
       language: "python",
+      source_filename: "hello.py",
+      source_size_bytes: 14,
     });
     const run = await getPipelineRun(submitted.run_id);
 

--- a/apps/web/src/features/pipeline/api/pipelineApi.ts
+++ b/apps/web/src/features/pipeline/api/pipelineApi.ts
@@ -7,7 +7,9 @@ export interface SubmitPipelineRequest {
   prompt: string;
   domain?: string | null;
   source_code?: string | null;
-  language?: string;
+  language?: string | null;
+  source_filename?: string | null;
+  source_size_bytes?: number | null;
   provider_api_key?: string | null;
   provider_base_url?: string | null;
   provider_model?: string | null;

--- a/apps/web/src/features/pipeline/hooks/usePipelineSubmit.test.tsx
+++ b/apps/web/src/features/pipeline/hooks/usePipelineSubmit.test.tsx
@@ -5,9 +5,12 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { server } from "../../../mocks/server";
 import { API_BASE_URL } from "../../../shared/config/constants";
-import { usePipelineSubmit } from "./usePipelineSubmit";
+import {
+  usePipelineSubmit,
+  type PipelineSubmitInput,
+} from "./usePipelineSubmit";
 
-function SubmitHarness() {
+function SubmitHarness({ input }: { input: PipelineSubmitInput }) {
   const { submit, runId, error } = usePipelineSubmit();
   const [caught, setCaught] = useState(false);
   const [resolvedRunId, setResolvedRunId] = useState<string | null>(null);
@@ -17,12 +20,7 @@ function SubmitHarness() {
       <button
         type="button"
         onClick={() =>
-          void submit({
-            prompt: "讲解二分查找",
-            domain: "algorithm",
-            sourceCode: "while left < right:\n    right -= 1",
-            language: "python",
-          })
+          void submit(input)
             .then((newRunId) => setResolvedRunId(newRunId))
             .catch(() => setCaught(true))
         }
@@ -42,24 +40,66 @@ describe("usePipelineSubmit", () => {
     cleanup();
   });
 
-  it("passes domain and source code hints to the pipeline API", async () => {
+  it.each([
+    "用动画解释导数的几何意义",
+    "演示平抛运动的速度变化",
+  ])("submits text with nullable routing evidence for %s", async (prompt) => {
     server.use(
       http.post(`${API_BASE_URL}/api/v1/pipeline`, async ({ request }) => {
         expect(await request.json()).toMatchObject({
-          prompt: "讲解二分查找",
-          domain: "algorithm",
-          source_code: "while left < right:\n    right -= 1",
-          language: "python",
+          prompt,
+          domain: null,
+          source_code: null,
+          language: null,
+          source_filename: null,
+          source_size_bytes: null,
         });
         return HttpResponse.json({
-          run_id: "run-code",
+          run_id: "run-text",
           status: "queued",
-          created_at: "2026-06-12T00:00:00Z",
+          created_at: "2026-07-13T00:00:00Z",
         });
       }),
     );
 
-    const { getByRole, getByText } = render(<SubmitHarness />);
+    const { getByRole, getByText } = render(
+      <SubmitHarness input={{ prompt }} />,
+    );
+    fireEvent.click(getByRole("button", { name: "submit" }));
+
+    await waitFor(() => expect(getByText("run-text")).toBeTruthy());
+  });
+
+  it("submits code metadata without injecting a frontend domain", async () => {
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/pipeline`, async ({ request }) => {
+        expect(await request.json()).toMatchObject({
+          prompt: "讲解 solution.py 中的代码。",
+          domain: null,
+          source_code: "while left < right:\n    right -= 1",
+          language: "python",
+          source_filename: "solution.py",
+          source_size_bytes: 39,
+        });
+        return HttpResponse.json({
+          run_id: "run-code",
+          status: "queued",
+          created_at: "2026-07-13T00:00:00Z",
+        });
+      }),
+    );
+
+    const { getByRole, getByText } = render(
+      <SubmitHarness
+        input={{
+          prompt: "讲解 solution.py 中的代码。",
+          sourceCode: "while left < right:\n    right -= 1",
+          language: "python",
+          sourceFilename: "solution.py",
+          sourceSizeBytes: 39,
+        }}
+      />,
+    );
 
     fireEvent.click(getByRole("button", { name: "submit" }));
 
@@ -74,7 +114,9 @@ describe("usePipelineSubmit", () => {
       ),
     );
 
-    const { getByRole, getByText } = render(<SubmitHarness />);
+    const { getByRole, getByText } = render(
+      <SubmitHarness input={{ prompt: "讲解二分查找" }} />,
+    );
 
     fireEvent.click(getByRole("button", { name: "submit" }));
 

--- a/apps/web/src/features/pipeline/hooks/usePipelineSubmit.ts
+++ b/apps/web/src/features/pipeline/hooks/usePipelineSubmit.ts
@@ -4,9 +4,10 @@ import type { ProviderSettings } from "../../providers/hooks/useProviderSettings
 
 export interface PipelineSubmitInput {
   prompt: string;
-  domain?: string | null;
-  sourceCode?: string;
-  language?: string;
+  sourceCode?: string | null;
+  language?: string | null;
+  sourceFilename?: string | null;
+  sourceSizeBytes?: number | null;
   provider?: ProviderSettings;
 }
 
@@ -27,12 +28,22 @@ export function usePipelineSubmit(): UsePipelineSubmitResult {
     setError(null);
     setRunId(null);
     try {
-      const { prompt, domain, sourceCode, language, provider } = input;
+      const {
+        prompt,
+        sourceCode,
+        language,
+        sourceFilename,
+        sourceSizeBytes,
+        provider,
+      } = input;
+      const hasSourceCode = sourceCode != null;
       const result = await submitPipeline({
         prompt,
-        domain: domain ?? null,
-        source_code: sourceCode ?? null,
-        language: language ?? "python",
+        domain: null,
+        source_code: hasSourceCode ? sourceCode : null,
+        language: hasSourceCode ? (language ?? null) : null,
+        source_filename: hasSourceCode ? (sourceFilename ?? null) : null,
+        source_size_bytes: hasSourceCode ? (sourceSizeBytes ?? null) : null,
         provider_api_key: provider?.apiKey || null,
         provider_base_url: provider?.baseUrl || null,
         provider_model: provider?.model || null,

--- a/apps/web/src/features/studio-editor/lib/codeFileLanguage.ts
+++ b/apps/web/src/features/studio-editor/lib/codeFileLanguage.ts
@@ -1,0 +1,41 @@
+const EXT_TO_LANGUAGE: Record<string, string> = {
+  ".py": "python",
+  ".js": "javascript",
+  ".ts": "typescript",
+  ".tsx": "typescript",
+  ".jsx": "javascript",
+  ".java": "java",
+  ".cpp": "cpp",
+  ".cc": "cpp",
+  ".cxx": "cpp",
+  ".c": "c",
+  ".h": "c",
+  ".hpp": "cpp",
+  ".cs": "csharp",
+  ".go": "go",
+  ".rs": "rust",
+  ".rb": "ruby",
+  ".swift": "swift",
+  ".kt": "kotlin",
+  ".kts": "kotlin",
+  ".php": "php",
+  ".r": "r",
+  ".m": "objc",
+  ".sh": "bash",
+  ".bash": "bash",
+  ".zsh": "bash",
+  ".sql": "sql",
+  ".html": "html",
+  ".css": "css",
+  ".json": "json",
+  ".yaml": "yaml",
+  ".yml": "yaml",
+};
+
+export const CODE_FILE_ACCEPT = Object.keys(EXT_TO_LANGUAGE).join(",");
+
+export function languageFromCodeFilename(name: string): string | null {
+  const dotIndex = name.lastIndexOf(".");
+  if (dotIndex < 0) return null;
+  return EXT_TO_LANGUAGE[name.slice(dotIndex).toLowerCase()] ?? null;
+}

--- a/apps/web/src/features/studio-editor/ui/IntakeScreen.test.tsx
+++ b/apps/web/src/features/studio-editor/ui/IntakeScreen.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { languageFromCodeFilename } from "../lib/codeFileLanguage";
 import { IntakeScreen } from "./IntakeScreen";
 
 const baseProps: React.ComponentProps<typeof IntakeScreen> = {
@@ -23,162 +24,254 @@ function renderIntake(
   };
 }
 
-describe("IntakeScreen launch home", () => {
+function fileInput(container: HTMLElement): HTMLInputElement {
+  return container.querySelector('input[type="file"]') as HTMLInputElement;
+}
+
+function pythonFile(name = "solution.py", source = "def solve():\n    return 42\n") {
+  return new File([source], name, { type: "text/x-python" });
+}
+
+describe("IntakeScreen smart-routed intake", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
-  it("renders only currently supported generation promises", () => {
-    const { getByText, queryByText, getByRole } = renderIntake();
+  it("renders one focused creation surface without internal routing copy", () => {
+    const { getAllByRole, getByText, queryByText } = renderIntake();
 
+    expect(getAllByRole("heading", { level: 1 })).toHaveLength(1);
     expect(getByText("新建可视化讲解")).toBeTruthy();
+    expect(getByText("输入一道题、一个知识点，或粘贴代码。")).toBeTruthy();
+    expect(queryByText(/NEW VISUAL LESSON/)).toBeNull();
+    expect(queryByText(/Generation Path/i)).toBeNull();
+    expect(queryByText(/Coverage/i)).toBeNull();
+    expect(queryByText(/LessonPlan/i)).toBeNull();
+    expect(queryByText(/Director/i)).toBeNull();
+    expect(queryByText("领域提示")).toBeNull();
+    expect(queryByText("等待输入")).toBeNull();
+    expect(queryByText("可播放")).toBeNull();
+    expect(queryByText("可追问")).toBeNull();
+    expect(queryByText("可导出")).toBeNull();
+  });
+
+  it("offers exactly three prompt-only examples and a stable cases link", () => {
+    const { container, getByRole, getAllByRole, props } = renderIntake();
+
+    const examples = getAllByRole("button").filter((button) =>
+      button.classList.contains("mv-intake-example"),
+    );
+    expect(examples).toHaveLength(3);
+    expect(getByRole("button", { name: "导数与切线" })).toBeTruthy();
+    expect(getByRole("button", { name: "二分查找" })).toBeTruthy();
+    expect(getByRole("button", { name: "抛体运动" })).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: "导数与切线" }));
+
+    expect(props.onSubmit).not.toHaveBeenCalled();
     expect(
-      getByText(
-        "输入一道题或一段代码，MetaView 会把它组织成可播放的分步画面。",
-      ),
-    ).toBeTruthy();
-    expect(getByText("从题意到可播放画面")).toBeTruthy();
-    expect(queryByText(/截图/)).toBeNull();
-    expect(queryByText(/翻译/)).toBeNull();
-    expect(queryByText("英语拆解")).toBeNull();
-    expect(queryByText("空白课件")).toBeNull();
-    expect(getByText("二分查找")).toBeTruthy();
-    expect(getByText("抛体运动")).toBeTruthy();
-    expect(getByText("配平方程")).toBeTruthy();
-    expect(getByText("孟德尔遗传")).toBeTruthy();
-    expect(
-      (getByRole("button", { name: "生成讲解" }) as HTMLButtonElement).disabled,
-    ).toBe(true);
+      (container.querySelector("textarea") as HTMLTextAreaElement).value,
+    ).toBe(
+      "用动画解释导数的几何意义：曲线 y=x² 在点 (1,1) 处切线的斜率为什么是 2。",
+    );
+    expect(getByRole("link", { name: "查看精选案例" }).getAttribute("href")).toBe(
+      "/cases",
+    );
   });
 
-  it("drops duplicate hero copy and composer hints for a calmer intake", () => {
-    const { queryByText } = renderIntake();
-
-    expect(queryByText(/THEORETICAL CANVAS/)).toBeNull();
-    expect(queryByText("支持代码片段和代码文件")).toBeNull();
-    expect(queryByText("数学题")).toBeNull();
-    expect(queryByText("化学计量")).toBeNull();
-  });
-
-  it("keeps code upload as a secondary composer action instead of a persistent tab", () => {
-    const { container, getByRole } = renderIntake();
-
-    expect(container.querySelector(".mv-intake-attachment-tab")).toBeNull();
-    const uploadButton = getByRole("button", { name: "上传代码文件" });
-    expect(uploadButton.closest(".mv-intake-actions")).toBeTruthy();
-    expect(uploadButton.classList.contains("mv-intake-action")).toBe(true);
-    expect(uploadButton.classList.contains("mv-intake-attach")).toBe(true);
-    expect(uploadButton.textContent).toContain("代码文件");
-  });
-
-  it("fills physics examples for review before the explicit generation action", async () => {
+  it.each([
+    "求函数 f(x)=x² 在 x=1 处的导数",
+    "解释速度为什么会随时间变化",
+    "逐行解释递归函数的返回过程",
+  ])("submits text without exposing a frontend domain for %s", async (prompt) => {
     const { getByRole, getByPlaceholderText, props } = renderIntake();
 
-    fireEvent.click(getByRole("button", { name: /抛体运动/ }));
-    expect(props.onSubmit).not.toHaveBeenCalled();
-    expect((getByPlaceholderText(/例如：解释导数/) as HTMLTextAreaElement).value).toContain(
-      "抛体运动",
-    );
-
-    fireEvent.click(getByRole("button", { name: "生成讲解" }));
-
-    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledTimes(1));
-    expect(props.onSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        domain: "physics",
-        template: "projectile-motion",
-        title: "抛体运动",
-      }),
-    );
-  });
-
-  it("preserves the supported biology hint after selecting an example", async () => {
-    const { getByRole, props } = renderIntake();
-
-    fireEvent.click(getByRole("button", { name: /孟德尔遗传/ }));
-    expect(props.onSubmit).not.toHaveBeenCalled();
-    fireEvent.click(getByRole("button", { name: "生成讲解" }));
-
-    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledTimes(1));
-    expect(props.onSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        domain: "biology",
-        template: "mendel-genetics",
-        title: "孟德尔遗传",
-      }),
-    );
-  });
-
-  it("rejects unsupported attachments without submitting them", () => {
-    const { container, getByText, queryByText } = renderIntake();
-    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const image = new File(["not image bytes"], "diagram.png", {
-      type: "image/png",
+    fireEvent.change(getByPlaceholderText(/例如：用动画解释导数/), {
+      target: { value: prompt },
     });
+    fireEvent.click(getByRole("button", { name: "生成讲解" }));
+
+    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledTimes(1));
+    expect(props.onSubmit).toHaveBeenCalledWith({ prompt });
+    expect(props.onSubmit.mock.calls[0][0]).not.toHaveProperty("domain");
+    expect(props.onSubmit.mock.calls[0][0]).not.toHaveProperty("language");
+  });
+
+  it("uses Ctrl/Cmd + Enter without submitting empty input", async () => {
+    const { getByPlaceholderText, props } = renderIntake();
+    const textarea = getByPlaceholderText(/例如：用动画解释导数/);
+
+    fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
+    expect(props.onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.change(textarea, { target: { value: "讲解抛体运动" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+
+    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledTimes(1));
+  });
+
+  it("seeds initialPrompt and caps textarea growth at 320px", () => {
+    const { getByDisplayValue } = renderIntake({ initialPrompt: "已有题目" });
+    const textarea = getByDisplayValue("已有题目") as HTMLTextAreaElement;
+    Object.defineProperty(textarea, "scrollHeight", {
+      configurable: true,
+      value: 480,
+    });
+
+    fireEvent.change(textarea, { target: { value: "已有题目，继续补充" } });
+
+    expect(textarea.style.height).toBe("320px");
+    expect(textarea.style.overflowY).toBe("auto");
+  });
+
+  it("keeps code upload single-file and replaces the previous selection", () => {
+    const { container, getByText, queryByText } = renderIntake();
+    const input = fileInput(container);
+
+    expect(input.multiple).toBe(false);
+    fireEvent.change(input, { target: { files: [pythonFile("first.py")] } });
+    expect(getByText("first.py")).toBeTruthy();
+
+    fireEvent.change(input, { target: { files: [pythonFile("second.py")] } });
+    expect(queryByText("first.py")).toBeNull();
+    expect(getByText("second.py")).toBeTruthy();
+  });
+
+  it("removes the selected code file", () => {
+    const { container, getByRole, getByText, queryByText } = renderIntake();
+    fireEvent.change(fileInput(container), {
+      target: { files: [pythonFile("remove-me.py")] },
+    });
+    expect(getByText("remove-me.py")).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: "删除 remove-me.py" }));
+
+    expect(queryByText("remove-me.py")).toBeNull();
+    expect((getByRole("button", { name: "生成讲解" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("rejects multiple dropped files without replacing the current file", () => {
+    const { container, getByText } = renderIntake();
+    const input = fileInput(container);
+    fireEvent.change(input, { target: { files: [pythonFile("kept.py")] } });
+
+    fireEvent.drop(container.querySelector(".mv-intake-composer") as HTMLElement, {
+      dataTransfer: {
+        files: [pythonFile("one.py"), pythonFile("two.py")],
+      },
+    });
+
+    expect(getByText("一次只能上传一个代码文件。")).toBeTruthy();
+    expect(getByText("kept.py")).toBeTruthy();
+  });
+
+  it("rejects unknown extensions and files larger than 256 KB", () => {
+    const { container, getByText, queryByText } = renderIntake();
+    const input = fileInput(container);
+    const image = new File(["not code"], "diagram.png", { type: "image/png" });
 
     fireEvent.change(input, { target: { files: [image] } });
-
-    expect(getByText("当前只支持上传代码文件。图片、PDF、课件暂未接入生成管线。")).toBeTruthy();
+    expect(getByText("不支持该文件类型，请选择代码文件。")).toBeTruthy();
     expect(queryByText("diagram.png")).toBeNull();
+
+    const oversized = new File([new Uint8Array(256 * 1024 + 1)], "large.py");
+    fireEvent.change(input, { target: { files: [oversized] } });
+    expect(getByText("代码文件不能超过 256 KB。")).toBeTruthy();
+    expect(queryByText("large.py")).toBeNull();
   });
 
-  it("reads code attachments into source code and language before submit", async () => {
-    const { container, getByRole, getByPlaceholderText, getByText, props } = renderIntake();
-    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const file = new File(["def solve():\n    return 42\n"], "solution.py", {
-      type: "text/x-python",
-    });
+  it("submits real code metadata while leaving domain ownership to the backend", async () => {
+    const { container, getByRole, getByText, props } = renderIntake();
+    const file = pythonFile();
 
-    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.change(fileInput(container), { target: { files: [file] } });
     expect(getByText("solution.py")).toBeTruthy();
-    fireEvent.change(getByPlaceholderText(/例如：解释导数/), {
-      target: { value: "讲解这段代码" },
-    });
     fireEvent.click(getByRole("button", { name: "生成讲解" }));
 
     await waitFor(() => expect(props.onSubmit).toHaveBeenCalledTimes(1));
-    expect(props.onSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        domain: "code",
-        sourceCode: "def solve():\n    return 42\n",
-        language: "python",
-      }),
-    );
+    expect(props.onSubmit).toHaveBeenCalledWith({
+      prompt: "讲解 solution.py 中的代码。",
+      sourceCode: "def solve():\n    return 42\n",
+      language: "python",
+      sourceFilename: "solution.py",
+      sourceSizeBytes: file.size,
+    });
+    expect(props.onSubmit.mock.calls[0][0]).not.toHaveProperty("domain");
   });
 
-  it("surfaces submit errors near the composer", () => {
-    const { getByText } = renderIntake({ submitError: "提交失败，请重试" });
+  it("surfaces file read failures and does not submit", async () => {
+    vi.spyOn(FileReader.prototype, "readAsText").mockImplementation(function (
+      this: FileReader,
+    ) {
+      queueMicrotask(() => this.onerror?.(new ProgressEvent("error")));
+    });
+    const { container, getByRole, getByText, props } = renderIntake();
 
+    fireEvent.change(fileInput(container), {
+      target: { files: [pythonFile()] },
+    });
+    fireEvent.click(getByRole("button", { name: "生成讲解" }));
+
+    await waitFor(() =>
+      expect(getByText("文件读取失败，请重新选择代码文件。")).toBeTruthy(),
+    );
+    expect(props.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit twice while an asynchronous submission is pending", async () => {
+    let resolveSubmit: (() => void) | undefined;
+    const onSubmit = vi.fn(
+      () => new Promise<void>((resolve) => (resolveSubmit = resolve)),
+    );
+    const { getByRole, getByPlaceholderText } = renderIntake({ onSubmit });
+    fireEvent.change(getByPlaceholderText(/例如：用动画解释导数/), {
+      target: { value: "讲解二分查找" },
+    });
+    const submitButton = getByRole("button", { name: "生成讲解" });
+
+    fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    resolveSubmit?.();
+  });
+
+  it("exposes pending and submit errors accessibly", () => {
+    const { getByRole, getByText, getByPlaceholderText } = renderIntake({
+      isSubmitting: true,
+      submitError: "提交失败，请重试",
+    });
+
+    expect(getByRole("status").textContent).toContain("正在提交");
     expect(getByText("提交失败，请重试")).toBeTruthy();
-  });
-
-  it("submits freeform prompts with a null domain when inference misses", async () => {
-    const { getByPlaceholderText, getByRole, queryByRole, props } = renderIntake();
-
-    fireEvent.change(getByPlaceholderText(/例如：解释导数/), {
-      target: { value: "孟德尔豌豆杂交实验的显隐性遗传规律" },
-    });
-    fireEvent.click(getByRole("button", { name: "生成讲解" }));
-
-    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledTimes(1));
-    expect(props.onSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({ domain: null, template: "freeform" }),
+    expect((getByRole("button", { name: "生成讲解" }) as HTMLButtonElement).disabled).toBe(
+      true,
     );
-    expect(queryByRole("alert")).toBeNull();
-  });
-
-  it("still forwards the inferred domain hint when keywords match", async () => {
-    const { getByPlaceholderText, getByRole, props } = renderIntake();
-
-    fireEvent.change(getByPlaceholderText(/例如：解释导数/), {
-      target: { value: "求函数 f(x)=x^2 在 x=1 处的导数" },
-    });
-    fireEvent.click(getByRole("button", { name: "生成讲解" }));
-
-    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledTimes(1));
-    expect(props.onSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({ domain: "math" }),
+    expect((getByPlaceholderText(/例如：用动画解释导数/) as HTMLTextAreaElement).disabled).toBe(
+      true,
     );
+    expect((getByRole("button", { name: "上传代码文件" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect((getByRole("button", { name: "导数与切线" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+});
+
+describe("languageFromCodeFilename", () => {
+  it.each([
+    ["lesson.PY", "python"],
+    ["demo.tsx", "typescript"],
+    ["Main.java", "java"],
+    ["query.sql", "sql"],
+    ["notes.txt", null],
+    ["README", null],
+  ])("maps %s to %s", (filename, expected) => {
+    expect(languageFromCodeFilename(filename)).toBe(expected);
   });
 });

--- a/apps/web/src/features/studio-editor/ui/IntakeScreen.tsx
+++ b/apps/web/src/features/studio-editor/ui/IntakeScreen.tsx
@@ -1,80 +1,37 @@
-import { useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
+import {
+  CODE_FILE_ACCEPT,
+  languageFromCodeFilename,
+} from "../lib/codeFileLanguage";
 
-type IntakeDomain =
-  | "algorithm"
-  | "math"
-  | "code"
-  | "physics"
-  | "chemistry"
-  | "biology"
-  | "geography";
+const MAX_CODE_FILE_BYTES = 256 * 1024;
+const TEXTAREA_MIN_HEIGHT = 168;
+const TEXTAREA_MAX_HEIGHT = 320;
 
-const UNSUPPORTED_FILE_WARNING =
-  "当前只支持上传代码文件。图片、PDF、课件暂未接入生成管线。";
-
-/** One-line example prompts under the composer; the full gallery lives on the 模板 page. */
-const EXAMPLE_PROMPTS: Array<{
-  id: string;
-  domain: IntakeDomain;
-  label: string;
-  meta: string;
-  prompt: string;
-}> = [
+const EXAMPLE_PROMPTS = [
   {
-    id: "binary-search",
-    domain: "algorithm",
+    label: "导数与切线",
+    prompt:
+      "用动画解释导数的几何意义：曲线 y=x² 在点 (1,1) 处切线的斜率为什么是 2。",
+  },
+  {
     label: "二分查找",
-    meta: "指针 · 区间 · 代码行",
-    prompt: "生成一个算法讲解：演示二分查找的指针移动和区间收缩过程。",
+    prompt:
+      "演示在有序数组 [1,3,5,7,9,11] 里二分查找 7 的过程，标出 low/mid/high。",
   },
   {
-    id: "projectile-motion",
-    domain: "physics",
     label: "抛体运动",
-    meta: "受力 · 速度 · 轨迹",
-    prompt: "生成一个物理题讲解：演示抛体运动的受力分析、速度分解和轨迹。",
+    prompt:
+      "演示平抛运动：水平速度不变、竖直加速，画出抛物线轨迹和分速度矢量。",
   },
-  {
-    id: "balance-equation",
-    domain: "chemistry",
-    label: "配平方程",
-    meta: "方程式 · 物质的量",
-    prompt: "生成一个化学讲解：演示化学方程式配平和物质的量换算。",
-  },
-  {
-    id: "mendel-genetics",
-    domain: "biology",
-    label: "孟德尔遗传",
-    meta: "性状 · 概率 · 遗传图",
-    prompt: "生成一个生物讲解：演示孟德尔豌豆杂交实验的显隐性遗传规律。",
-  },
-];
-
-const DOMAIN_LABELS: Record<IntakeDomain, string> = {
-  algorithm: "算法",
-  math: "数学",
-  code: "代码",
-  physics: "物理",
-  chemistry: "化学",
-  biology: "生物",
-  geography: "地理",
-};
-
-const GENERATION_PATH = [
-  { index: "01", label: "理解题意", contract: "COVERAGE" },
-  { index: "02", label: "规划讲解", contract: "LESSON PLAN" },
-  { index: "03", label: "构建画面", contract: "PLAYBOOK" },
-  { index: "04", label: "编排播放", contract: "DIRECTOR" },
 ] as const;
 
 export interface IntakeContext {
-  domain: IntakeDomain | null;
-  template: string;
-  title: string;
-  raw: string;
-  files: Array<{ name: string; size: number }>;
+  prompt: string;
   sourceCode?: string;
-  language?: string;
+  language?: string | null;
+  sourceFilename?: string;
+  sourceSizeBytes?: number;
 }
 
 interface IntakeScreenProps {
@@ -85,112 +42,34 @@ interface IntakeScreenProps {
   initialPrompt?: string;
 }
 
+type LocalSubmitStatus = "idle" | "reading-file" | "submitting";
+
 function readFileAsText(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = () => reject(reader.error);
+    reader.onload = () =>
+      resolve(typeof reader.result === "string" ? reader.result : "");
+    reader.onerror = () => reject(reader.error ?? new Error("file read failed"));
+    reader.onabort = () => reject(new Error("file read aborted"));
     reader.readAsText(file);
   });
 }
 
-const EXT_TO_LANGUAGE: Record<string, string> = {
-  ".py": "python",
-  ".js": "javascript",
-  ".ts": "typescript",
-  ".tsx": "typescript",
-  ".jsx": "javascript",
-  ".java": "java",
-  ".cpp": "cpp",
-  ".cc": "cpp",
-  ".cxx": "cpp",
-  ".c": "c",
-  ".h": "c",
-  ".hpp": "cpp",
-  ".cs": "csharp",
-  ".go": "go",
-  ".rs": "rust",
-  ".rb": "ruby",
-  ".swift": "swift",
-  ".kt": "kotlin",
-  ".kts": "kotlin",
-  ".php": "php",
-  ".r": "r",
-  ".m": "objc",
-  ".sh": "bash",
-  ".bash": "bash",
-  ".zsh": "bash",
-  ".sql": "sql",
-  ".html": "html",
-  ".css": "css",
-  ".json": "json",
-  ".yaml": "yaml",
-  ".yml": "yaml",
-};
-
-const CODE_ACCEPT = Object.keys(EXT_TO_LANGUAGE).join(",");
-
-function languageFromName(name: string): string | undefined {
-  const dotIndex = name.lastIndexOf(".");
-  if (dotIndex < 0) return undefined;
-  const ext = name.slice(dotIndex).toLowerCase();
-  return EXT_TO_LANGUAGE[ext];
+function resizeTextarea(element: HTMLTextAreaElement) {
+  element.style.height = `${TEXTAREA_MIN_HEIGHT}px`;
+  const contentHeight = element.scrollHeight;
+  const nextHeight = Math.min(
+    Math.max(contentHeight, TEXTAREA_MIN_HEIGHT),
+    TEXTAREA_MAX_HEIGHT,
+  );
+  element.style.height = `${nextHeight}px`;
+  element.style.overflowY =
+    contentHeight > TEXTAREA_MAX_HEIGHT ? "auto" : "hidden";
 }
 
-function inferDomain(raw: string, codeFile?: File): IntakeDomain | null {
-  // Hint-only heuristic: a null result never blocks submission — the
-  // backend topic router owns the final domain decision.
-  if (codeFile) return "code";
-
-  const text = raw.toLowerCase();
-  if (
-    text.includes("排序") ||
-    text.includes("算法") ||
-    text.includes("二分") ||
-    text.includes("递归") ||
-    text.includes("search") ||
-    text.includes("pointer") ||
-    text.includes("array") ||
-    text.includes("function ") ||
-    text.includes("def ") ||
-    text.includes("class ")
-  ) {
-    return "algorithm";
-  }
-  if (
-    raw.includes("微分") ||
-    raw.includes("积分") ||
-    raw.includes("极限") ||
-    raw.includes("函数") ||
-    raw.includes("导数") ||
-    raw.includes("方程") ||
-    raw.includes("傅里叶")
-  ) {
-    return "math";
-  }
-  if (
-    raw.includes("斜面") ||
-    raw.includes("物理") ||
-    raw.includes("受力") ||
-    raw.includes("速度") ||
-    raw.includes("加速度") ||
-    raw.includes("能量") ||
-    raw.includes("力")
-  ) {
-    return "physics";
-  }
-  if (
-    raw.includes("化学") ||
-    raw.includes("配平") ||
-    raw.includes("物质的量") ||
-    raw.includes("摩尔") ||
-    raw.includes("反应") ||
-    text.includes("stoichiometry") ||
-    text.includes("mole")
-  ) {
-    return "chemistry";
-  }
-  return null;
+function fileSizeLabel(size: number): string {
+  if (size < 1024) return `${size} B`;
+  return `${Math.ceil(size / 1024)} KB`;
 }
 
 export function IntakeScreen({
@@ -200,112 +79,112 @@ export function IntakeScreen({
   initialPrompt = "",
 }: IntakeScreenProps) {
   const [input, setInput] = useState(initialPrompt);
-  const [files, setFiles] = useState<Array<{ name: string; size: number }>>([]);
-  const [fileObjects, setFileObjects] = useState<File[]>([]);
-  const [fileWarning, setFileWarning] = useState<string | null>(null);
-  const [thinking, setThinking] = useState("");
-  const [selectedExample, setSelectedExample] = useState<
-    (typeof EXAMPLE_PROMPTS)[number] | null
-  >(null);
+  const [attachment, setAttachment] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [submitStatus, setSubmitStatus] =
+    useState<LocalSubmitStatus>("idle");
   const [dragActive, setDragActive] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
-  const pending = isSubmitting || Boolean(thinking);
-  const attachedCodeFile = fileObjects.find((file) => languageFromName(file.name));
-  const inferredDomain = attachedCodeFile
-    ? "code"
-    : selectedExample?.domain ?? inferDomain(input);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const busyRef = useRef(false);
+  const pending = isSubmitting || submitStatus !== "idle";
 
-  const handleFiles = (list: FileList | null) => {
-    if (!list) return;
-    const arr = Array.from(list);
-    const supported = arr.filter((file) => languageFromName(file.name));
-    const unsupportedCount = arr.length - supported.length;
+  useLayoutEffect(() => {
+    if (textareaRef.current) resizeTextarea(textareaRef.current);
+  }, []);
 
-    setFileWarning(unsupportedCount > 0 ? UNSUPPORTED_FILE_WARNING : null);
-    if (supported.length === 0) return;
+  const handleFiles = (list: FileList | File[] | null) => {
+    if (!list || list.length === 0 || pending) return;
+    const candidates = Array.from(list);
 
-    setSelectedExample(null);
-    setFileObjects((prev) => [...prev, ...supported]);
-    setFiles((prev) => [
-      ...prev,
-      ...supported.map((f) => ({ name: f.name, size: f.size })),
-    ]);
+    if (candidates.length !== 1) {
+      setFileError("一次只能上传一个代码文件。");
+      return;
+    }
+
+    const nextFile = candidates[0];
+    if (!languageFromCodeFilename(nextFile.name)) {
+      setFileError("不支持该文件类型，请选择代码文件。");
+      return;
+    }
+    if (nextFile.size > MAX_CODE_FILE_BYTES) {
+      setFileError("代码文件不能超过 256 KB。");
+      return;
+    }
+
+    setAttachment(nextFile);
+    setFileError(null);
   };
 
-  const removeFile = (index: number) => {
-    setFiles((prev) => prev.filter((_, i) => i !== index));
-    setFileObjects((prev) => prev.filter((_, i) => i !== index));
+  const removeFile = () => {
+    if (pending) return;
+    setAttachment(null);
+    setFileError(null);
+    if (fileRef.current) fileRef.current.value = "";
   };
 
   const submit = async () => {
-    if (!input.trim() && files.length === 0) return;
+    const prompt = input.trim();
+    if ((!prompt && !attachment) || pending || busyRef.current) return;
 
-    setThinking("正在理解题目…");
-    const codeFile = fileObjects.find((f) => languageFromName(f.name));
-    let sourceCode: string | undefined;
-    let language: string | undefined;
-
-    if (codeFile) {
-      try {
-        sourceCode = await readFileAsText(codeFile);
-        language = languageFromName(codeFile.name);
-      } catch {
-        sourceCode = undefined;
-        language = undefined;
-      }
-    }
-
-    const domain = codeFile
-      ? "code"
-      : selectedExample?.domain ?? inferDomain(input);
-    setThinking("提交中…");
+    busyRef.current = true;
+    setFileError(null);
 
     try {
+      if (!attachment) {
+        setSubmitStatus("submitting");
+        await onSubmit({ prompt });
+        return;
+      }
+
+      setSubmitStatus("reading-file");
+      let sourceCode: string;
+      try {
+        sourceCode = await readFileAsText(attachment);
+      } catch {
+        setFileError("文件读取失败，请重新选择代码文件。");
+        return;
+      }
+
+      setSubmitStatus("submitting");
       await onSubmit({
-        domain,
-        template: selectedExample?.id ?? "freeform",
-        title:
-          selectedExample?.label ||
-          input.trim().slice(0, 40) ||
-          codeFile?.name ||
-          "未命名",
-        raw: input,
-        files,
+        prompt: prompt || `讲解 ${attachment.name} 中的代码。`,
         sourceCode,
-        language,
+        language: languageFromCodeFilename(attachment.name),
+        sourceFilename: attachment.name,
+        sourceSizeBytes: attachment.size,
       });
     } catch {
-      // The shell exposes the submission error through submitError; stay on intake.
+      // The shell exposes request failures through submitError; stay on intake.
     } finally {
-      setThinking("");
+      busyRef.current = false;
+      setSubmitStatus("idle");
     }
   };
 
-  const pickExample = (example: (typeof EXAMPLE_PROMPTS)[number]) => {
+  const pickExample = (prompt: string) => {
     if (pending) return;
-    setInput(example.prompt);
-    setSelectedExample(example);
-    setFileWarning(null);
+    setInput(prompt);
+    setFileError(null);
+    queueMicrotask(() => {
+      if (textareaRef.current) resizeTextarea(textareaRef.current);
+    });
   };
+
+  const statusText = isSubmitting
+    ? "正在提交…"
+    : submitStatus === "reading-file"
+      ? "正在读取代码文件…"
+      : submitStatus === "submitting"
+        ? "正在提交…"
+        : null;
 
   return (
     <main className="mv-intake-body">
       <div className="mv-intake-shell">
-        <header className="mv-intake-hero" aria-label="MetaView intake">
-          <div>
-            <p className="mv-intake-kicker">
-              <span aria-hidden="true" /> NEW VISUAL LESSON / 01
-            </p>
-            <h1 className="mv-intake-title">新建可视化讲解</h1>
-            <p className="mv-intake-sub">
-              输入一道题或一段代码，MetaView 会把它组织成可播放的分步画面。
-            </p>
-          </div>
-          <div className="mv-intake-outcomes" aria-label="讲解输出能力">
-            <span>可播放</span>
-            <span>可追问</span>
-            <span>可导出</span>
-          </div>
+        <header className="mv-intake-hero" aria-label="MetaView 创建讲解">
+          <h1 className="mv-intake-title">新建可视化讲解</h1>
+          <p className="mv-intake-sub">输入一道题、一个知识点，或粘贴代码。</p>
         </header>
 
         <div className="mv-intake-layout">
@@ -314,67 +193,33 @@ export function IntakeScreen({
             aria-label="生成输入"
             onDragEnter={(event) => {
               event.preventDefault();
-              setDragActive(true);
+              if (!pending) setDragActive(true);
             }}
             onDragOver={(event) => {
               event.preventDefault();
-              setDragActive(true);
+              if (!pending) setDragActive(true);
             }}
-            onDragLeave={() => setDragActive(false)}
+            onDragLeave={(event) => {
+              if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+                setDragActive(false);
+              }
+            }}
             onDrop={(event) => {
               event.preventDefault();
               setDragActive(false);
               handleFiles(event.dataTransfer.files);
             }}
           >
-            <div className="mv-intake-composer__head">
-              <div>
-                <span>INPUT / 题目与代码</span>
-                <strong>从一道题或一段代码开始</strong>
-              </div>
-              <div
-                className={`mv-intake-domain-hint${inferredDomain ? " is-ready" : ""}`}
-                title="仅作输入提示，最终学科由生成管线判断"
-              >
-                <span>领域提示</span>
-                <strong>{inferredDomain ? DOMAIN_LABELS[inferredDomain] : "等待输入"}</strong>
-              </div>
-            </div>
-
-            {files.length > 0 && (
-              <div className="mv-intake-files">
-                {files.map((file, index) => (
-                  <div key={`${file.name}-${index}`} className="mv-intake-file">
-                    <span className="mv-file-name">{file.name}</span>
-                    <button type="button" onClick={() => removeFile(index)}>
-                      删除
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {(fileWarning || submitError) && (
-              <div
-                className={`mv-intake-warning${submitError ? " mv-intake-error" : ""}`}
-                role="alert"
-              >
-                {submitError ?? fileWarning}
-              </div>
-            )}
-
             <textarea
+              ref={textareaRef}
               className="mv-intake-input"
-              rows={7}
-              placeholder="例如：解释导数的几何意义，并演示切线如何随割线逼近……"
+              rows={6}
+              placeholder="例如：用动画解释导数的几何意义，并演示切线如何随割线逼近……"
               value={input}
-              aria-describedby="mv-intake-file-help"
+              disabled={pending}
               onChange={(event) => {
                 setInput(event.target.value);
-                setSelectedExample(null);
-                const element = event.target;
-                element.style.height = "auto";
-                element.style.height = `${element.scrollHeight}px`;
+                resizeTextarea(event.target);
               }}
               onKeyDown={(event) => {
                 if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
@@ -382,8 +227,40 @@ export function IntakeScreen({
                   void submit();
                 }
               }}
-              style={{ resize: "none", overflow: "hidden", minHeight: 228 }}
             />
+
+            {attachment && (
+              <div
+                className="mv-intake-file"
+                title={`${attachment.name} · ${fileSizeLabel(attachment.size)}`}
+              >
+                <span className="mv-file-name">{attachment.name}</span>
+                <small>{fileSizeLabel(attachment.size)}</small>
+                <button
+                  className="mv-intake-file__remove"
+                  type="button"
+                  aria-label={`删除 ${attachment.name}`}
+                  title="删除代码文件"
+                  disabled={pending}
+                  onClick={removeFile}
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path d="m7 7 10 10M17 7 7 17" />
+                  </svg>
+                </button>
+              </div>
+            )}
+
+            {(fileError || submitError) && (
+              <div className="mv-intake-warning" role="alert">
+                {fileError ?? submitError}
+              </div>
+            )}
 
             <div className="mv-intake-actions">
               <div className="mv-intake-toolrow">
@@ -391,26 +268,27 @@ export function IntakeScreen({
                   className="mv-intake-action mv-intake-attach"
                   type="button"
                   aria-label="上传代码文件"
-                  title="上传代码文件"
+                  title="上传一个代码文件，最大 256 KB"
+                  disabled={pending}
                   onClick={() => fileRef.current?.click()}
                 >
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  >
                     <path d="M6 4h9l3 3v13H6z" />
-                    <path d="M15 4v4h4" />
-                    <path d="M9 13h6" />
-                    <path d="M9 17h4" />
+                    <path d="M15 4v4h4M9 13h6M9 17h4" />
                   </svg>
-                  <span>添加代码文件</span>
+                  <span>{attachment ? "替换代码文件" : "添加代码文件"}</span>
                 </button>
-                <span className="mv-intake-file-help" id="mv-intake-file-help">
-                  或拖入 .py / .js / .java 等代码文件
-                </span>
                 <input
                   ref={fileRef}
                   type="file"
-                  multiple
-                  accept={CODE_ACCEPT}
-                  style={{ display: "none" }}
+                  accept={CODE_FILE_ACCEPT}
+                  disabled={pending}
+                  hidden
                   onChange={(event) => {
                     handleFiles(event.target.files);
                     event.target.value = "";
@@ -419,76 +297,59 @@ export function IntakeScreen({
               </div>
 
               <div className="mv-intake-submitrow">
-                {thinking ? (
-                  <span className="mv-intake-thinking" role="status" aria-live="polite">
-                    {thinking}
+                {statusText ? (
+                  <span
+                    className="mv-intake-thinking"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    {statusText}
                   </span>
                 ) : (
-                  <span className="mv-intake-count">{input.length} 字符 · ⌘ / Ctrl + Enter</span>
+                  <span className="mv-intake-shortcut">⌘ / Ctrl + Enter</span>
                 )}
                 <button
                   className="mv-send mv-intake-send"
                   type="button"
                   onClick={() => void submit()}
-                  disabled={pending || (!input.trim() && files.length === 0)}
+                  disabled={pending || (!input.trim() && !attachment)}
                 >
                   生成讲解
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
-                    <path d="M5 12h14" />
-                    <path d="m13 6 6 6-6 6" />
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path d="M5 12h14M13 6l6 6-6 6" />
                   </svg>
                 </button>
               </div>
             </div>
           </section>
 
-          <aside className="mv-intake-guide" aria-label="生成路径与示例">
-            <section className="mv-intake-path" aria-labelledby="mv-intake-path-title">
-              <div className="mv-intake-guide__head">
-                <span>GENERATION PATH</span>
-                <h2 id="mv-intake-path-title">从题意到可播放画面</h2>
-              </div>
-              <ol>
-                {GENERATION_PATH.map((step) => (
-                  <li key={step.contract}>
-                    <span>{step.index}</span>
-                    <div>
-                      <strong>{step.label}</strong>
-                      <small>{step.contract}</small>
-                    </div>
-                  </li>
-                ))}
-              </ol>
-            </section>
-
-            <section className="mv-intake-examples" aria-label="示例题目">
-              <div className="mv-intake-guide__head">
-                <span>EXAMPLE STARTS</span>
-                <h2>从一个可靠样例开始</h2>
-                <p>点击填入，可继续修改。</p>
-              </div>
-              <div className="mv-intake-example-list">
-                {EXAMPLE_PROMPTS.map((example, index) => (
-                  <button
-                    key={example.id}
-                    className={`mv-intake-example${selectedExample?.id === example.id ? " is-selected" : ""}`}
-                    type="button"
-                    disabled={pending}
-                    aria-pressed={selectedExample?.id === example.id}
-                    onClick={() => pickExample(example)}
-                  >
-                    <span>{String(index + 1).padStart(2, "0")} / {DOMAIN_LABELS[example.domain]}</span>
-                    <strong>{example.label}</strong>
-                    <small>{example.meta}</small>
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
-                      <path d="M5 12h14" />
-                      <path d="m13 6 6 6-6 6" />
-                    </svg>
-                  </button>
-                ))}
-              </div>
-            </section>
-          </aside>
+          <section className="mv-intake-examples" aria-labelledby="mv-intake-examples-title">
+            <div className="mv-intake-example-head">
+              <h2 id="mv-intake-examples-title">试试：</h2>
+            </div>
+            <div className="mv-intake-example-list">
+              {EXAMPLE_PROMPTS.map((example) => (
+                <button
+                  key={example.label}
+                  className="mv-intake-example"
+                  type="button"
+                  disabled={pending}
+                  onClick={() => pickExample(example.prompt)}
+                >
+                  {example.label}
+                </button>
+              ))}
+            </div>
+            <a className="mv-intake-cases-link" href="/cases">
+              查看精选案例
+              <span aria-hidden="true">→</span>
+            </a>
+          </section>
         </div>
       </div>
     </main>

--- a/apps/web/src/styles/mobileWebSmoke.test.tsx
+++ b/apps/web/src/styles/mobileWebSmoke.test.tsx
@@ -120,7 +120,7 @@ describe("mobile web smoke", () => {
       expect(container.querySelector(".mv-intake-hero")).toBeTruthy();
       expect(container.querySelector(".mv-intake-composer")).toBeTruthy();
       expect(container.querySelector(".mv-intake-send")).toBeTruthy();
-      expect(container.querySelectorAll(".mv-intake-example")).toHaveLength(4);
+      expect(container.querySelectorAll(".mv-intake-example")).toHaveLength(3);
       expect(
         container.querySelector<HTMLInputElement>('input[type="file"]')?.accept,
       ).toContain(".py");

--- a/apps/web/src/styles/pages/studio.css
+++ b/apps/web/src/styles/pages/studio.css
@@ -164,6 +164,8 @@
 .mv-intake-action:focus-visible,
 .mv-intake-send:focus-visible,
 .mv-intake-example:focus-visible,
+.mv-intake-file__remove:focus-visible,
+.mv-intake-cases-link:focus-visible,
 .mv-tpl-card:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent) 46%, transparent);
   outline-offset: 2px;
@@ -1747,6 +1749,7 @@
 /* ───── Intake / Landing ───── */
 /* ───── Launch-ready intake home ───── */
 .mv-intake-body {
+  --mv-intake-danger: color-mix(in srgb, var(--warn) 70%, var(--ink));
   flex: 1;
   min-height: calc(100vh - 58px);
   width: 100%;
@@ -1754,17 +1757,8 @@
   position: relative;
   overflow: auto;
   isolation: isolate;
-  padding: clamp(34px, 5.5vh, 58px) 24px 52px;
-  background:
-    radial-gradient(
-      circle at 24% 12%,
-      color-mix(in srgb, var(--accent) 7%, transparent),
-      transparent 30%
-    ),
-    linear-gradient(color-mix(in srgb, var(--line) 34%, transparent) 1px, transparent 1px),
-    linear-gradient(90deg, color-mix(in srgb, var(--line) 34%, transparent) 1px, transparent 1px),
-    var(--bg);
-  background-size: auto, 40px 40px, 40px 40px, auto;
+  padding: clamp(36px, 6vh, 64px) 24px 52px;
+  background: var(--bg);
 }
 
 .mv-intake-body::before {
@@ -1772,16 +1766,7 @@
 }
 
 .mv-dark .mv-intake-body {
-  background:
-    radial-gradient(
-      circle at 24% 12%,
-      color-mix(in srgb, var(--accent) 7%, transparent),
-      transparent 30%
-    ),
-    linear-gradient(color-mix(in srgb, var(--line) 32%, transparent) 1px, transparent 1px),
-    linear-gradient(90deg, color-mix(in srgb, var(--line) 32%, transparent) 1px, transparent 1px),
-    var(--bg);
-  background-size: auto, 40px 40px, 40px 40px, auto;
+  background: var(--bg);
 }
 
 .mv-dark .mv-intake-body::before {
@@ -1790,23 +1775,18 @@
 
 .mv-intake-hero,
 .mv-intake-composer,
-.mv-intake-guide {
+.mv-intake-examples {
   position: relative;
   z-index: 1;
 }
 
 .mv-intake-shell {
-  width: min(1120px, calc(100vw - 48px));
+  width: min(820px, calc(100vw - 48px));
   margin-inline: auto;
 }
 
 .mv-intake-hero {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 40px;
-  padding: 0 0 28px;
-  border-bottom: 1px solid var(--line);
+  padding: 0;
   text-align: left;
 }
 
@@ -2147,63 +2127,15 @@
   }
 }
 
-.mv-intake-kicker {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 0 0 12px;
-  color: var(--ink-3);
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.11em;
-}
-
-.mv-intake-kicker span {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
-}
-
-.mv-intake-outcomes {
-  display: flex;
-  align-items: center;
-  gap: 20px;
-  padding-bottom: 4px;
-  color: var(--ink-3);
-  font-size: 11px;
-}
-
-.mv-intake-outcomes span {
-  position: relative;
-}
-
-.mv-intake-outcomes span:not(:last-child)::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  right: -11px;
-  width: 2px;
-  height: 2px;
-  border-radius: 50%;
-  background: var(--ink-3);
-}
-
 .mv-intake-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1.55fr) minmax(280px, 0.65fr);
-  align-items: start;
-  gap: clamp(28px, 4vw, 52px);
-  padding-top: 30px;
+  padding-top: 24px;
 }
 
 .mv-intake-title {
   margin: 0;
   color: var(--ink);
   font-family: var(--font-headline, "Space Grotesk", sans-serif);
-  font-size: clamp(30px, 3.2vw, 42px);
+  font-size: clamp(30px, 4vw, 40px);
   font-weight: 620;
   letter-spacing: -0.035em;
   line-height: 1.12;
@@ -2211,8 +2143,7 @@
 }
 
 .mv-intake-sub {
-  max-width: 620px;
-  margin: 11px 0 0;
+  margin: 10px 0 0;
   color: var(--ink-2);
   font-size: 13.5px;
   line-height: 1.65;
@@ -2224,11 +2155,9 @@
   min-width: 0;
   overflow: hidden;
   border: 1px solid var(--line-2);
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--surface) 96%, transparent);
-  box-shadow:
-    0 22px 54px rgba(42, 39, 30, 0.09),
-    inset 0 1px 0 rgba(255, 255, 255, 0.48);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: 0 12px 32px color-mix(in srgb, var(--line-2) 34%, transparent);
   transition:
     border-color 180ms ease,
     box-shadow 180ms ease,
@@ -2236,100 +2165,43 @@
 }
 
 .mv-dark .mv-intake-composer {
-  background: color-mix(in srgb, var(--surface) 92%, #0f1512);
+  background: var(--surface);
   border-color: var(--line-2);
-  box-shadow:
-    0 22px 54px rgba(0, 0, 0, 0.28),
-    inset 0 1px 0 rgba(255, 255, 255, 0.045);
-}
-
-.mv-intake-composer__head {
-  min-height: 68px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 20px;
-  padding: 13px 18px;
-  border-bottom: 1px solid var(--line);
-  background: color-mix(in srgb, var(--surface-2) 72%, var(--surface));
-}
-
-.mv-intake-composer__head > div:first-child {
-  display: grid;
-  gap: 5px;
-}
-
-.mv-intake-composer__head > div:first-child span,
-.mv-intake-domain-hint span,
-.mv-intake-guide__head > span {
-  color: var(--ink-3);
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 8.5px;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-}
-
-.mv-intake-composer__head > div:first-child strong {
-  color: var(--ink);
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.mv-intake-domain-hint {
-  display: grid;
-  justify-items: end;
-  gap: 4px;
-}
-
-.mv-intake-domain-hint strong {
-  color: var(--ink-3);
-  font-size: 11.5px;
-  font-weight: 580;
-}
-
-.mv-intake-domain-hint.is-ready strong {
-  color: var(--accent);
+  box-shadow: 0 12px 32px color-mix(in srgb, var(--line-2) 38%, transparent);
 }
 
 .mv-intake-composer:focus-within {
   border-color: color-mix(in srgb, var(--accent) 32%, var(--line-2));
-  background: color-mix(in srgb, var(--surface) 96%, transparent);
+  background: var(--surface);
   box-shadow:
-    0 12px 32px rgba(42, 39, 30, 0.07),
+    0 12px 32px color-mix(in srgb, var(--line-2) 30%, transparent),
     0 0 0 2px color-mix(in srgb, var(--accent) 6%, transparent),
-    inset 0 1px 0 rgba(255, 255, 255, 0.54);
+    inset 0 1px 0 color-mix(in srgb, var(--line) 24%, transparent);
 }
 
 .mv-intake-composer.is-dragging {
   border-color: color-mix(in srgb, var(--accent) 64%, var(--line-2));
   background: color-mix(in srgb, var(--accent) 6%, var(--surface));
   box-shadow:
-    0 22px 54px rgba(42, 39, 30, 0.09),
+    0 12px 32px color-mix(in srgb, var(--line-2) 34%, transparent),
     0 0 0 3px var(--accent-soft);
 }
 
 .mv-dark .mv-intake-composer:focus-within {
-  background: color-mix(in srgb, var(--surface) 90%, #0f1512);
+  background: var(--surface);
   box-shadow:
-    0 12px 32px rgba(0, 0, 0, 0.24),
+    0 12px 32px color-mix(in srgb, var(--line-2) 34%, transparent),
     0 0 0 2px color-mix(in srgb, var(--accent) 7%, transparent),
-    inset 0 1px 0 rgba(255, 255, 255, 0.05);
-}
-
-.mv-intake-files {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 14px 20px 0;
+    inset 0 1px 0 color-mix(in srgb, var(--line) 24%, transparent);
 }
 
 .mv-intake-warning {
-  margin: 12px 18px 0;
+  margin: 0 18px 12px;
   padding: 9px 10px;
-  border: 1px solid color-mix(in srgb, #b7664b 26%, transparent);
-  border-radius: 7px;
-  background: color-mix(in srgb, #b7664b 9%, transparent);
-  color: #9b523b;
+  border: 1px solid color-mix(in srgb, var(--mv-intake-danger) 26%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--mv-intake-danger) 9%, transparent);
+  color: var(--mv-intake-danger);
   font-size: 12px;
   line-height: 1.45;
 }
@@ -2338,8 +2210,10 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  min-height: 28px;
-  padding: 0 10px;
+  max-width: calc(100% - 36px);
+  min-height: 32px;
+  margin: 0 18px 12px;
+  padding: 0 5px 0 11px;
   border: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);
   border-radius: 999px;
   background: var(--accent-soft);
@@ -2353,7 +2227,40 @@
   background: transparent;
   color: var(--ink-2);
   cursor: pointer;
-  font-size: 11px;
+}
+
+.mv-intake-file small {
+  flex: 0 0 auto;
+  color: var(--ink-3);
+  font-size: 10px;
+}
+
+.mv-intake-file .mv-file-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mv-intake-file .mv-intake-file__remove {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  padding: 0;
+  border-radius: 50%;
+}
+
+.mv-intake-file__remove:hover {
+  background: color-mix(in srgb, var(--ink) 6%, transparent);
+  color: var(--ink);
+}
+
+.mv-intake-file__remove svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 1.8;
 }
 
 .mv-intake-input {
@@ -2364,8 +2271,9 @@
   box-sizing: border-box;
   border: 0;
   outline: none;
-  min-height: 228px;
-  padding: 24px 22px 18px;
+  min-height: 168px;
+  max-height: 320px;
+  padding: 20px 20px 16px;
   background: transparent;
   color: var(--ink);
   font: inherit;
@@ -2382,8 +2290,8 @@
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  min-height: 64px;
-  padding: 10px 12px 10px 14px;
+  min-height: 62px;
+  padding: 9px 10px 9px 12px;
   border-top: 1px solid color-mix(in srgb, var(--ink) 7%, transparent);
   background: color-mix(in srgb, var(--surface-2) 46%, transparent);
 }
@@ -2397,7 +2305,7 @@
 }
 
 .mv-intake-action {
-  min-height: 36px;
+  min-height: 40px;
   display: inline-flex;
   align-items: center;
   gap: 7px;
@@ -2413,7 +2321,7 @@
 }
 
 .mv-intake-attach {
-  min-height: 36px;
+  min-height: 40px;
   gap: 6px;
   padding: 0 8px;
   border-color: var(--line);
@@ -2427,12 +2335,16 @@
   color: var(--ink);
 }
 
+.mv-intake-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .mv-intake-action span {
   display: inline;
 }
 
-.mv-intake-file-help,
-.mv-intake-count {
+.mv-intake-shortcut {
   color: var(--ink-3);
   font-size: 10px;
   line-height: 1.4;
@@ -2453,10 +2365,6 @@
   white-space: nowrap;
   color: var(--accent);
   font-size: 11px;
-}
-
-.mv-intake-error {
-  color: #b7664b;
 }
 
 .mv-intake-send {
@@ -2498,192 +2406,71 @@
 
 .mv-intake-examples {
   min-width: 0;
+  margin-top: 24px;
 }
 
-.mv-intake-guide {
-  min-width: 0;
-  display: grid;
-  gap: 30px;
+.mv-intake-example-head {
+  display: block;
 }
 
-.mv-intake-path {
-  padding-bottom: 28px;
-  border-bottom: 1px solid var(--line);
-}
-
-.mv-intake-guide__head {
-  display: grid;
-  gap: 6px;
-}
-
-.mv-intake-guide__head h2 {
+.mv-intake-example-head h2 {
   margin: 0;
-  color: var(--ink);
-  font-size: 16px;
-  font-weight: 610;
-  letter-spacing: -0.018em;
-  line-height: 1.35;
-}
-
-.mv-intake-guide__head p {
-  margin: 0;
-  color: var(--ink-3);
-  font-size: 11px;
-}
-
-.mv-intake-path ol {
-  display: grid;
-  gap: 0;
-  margin: 20px 0 0;
-  padding: 0;
-  list-style: none;
-}
-
-.mv-intake-path li {
-  position: relative;
-  min-height: 56px;
-  display: grid;
-  grid-template-columns: 34px 1fr;
-  align-items: start;
-  gap: 10px;
-}
-
-.mv-intake-path li::after {
-  content: "";
-  position: absolute;
-  top: 28px;
-  bottom: 0;
-  left: 13px;
-  width: 1px;
-  background: var(--line-2);
-}
-
-.mv-intake-path li:last-child {
-  min-height: 30px;
-}
-
-.mv-intake-path li:last-child::after {
-  display: none;
-}
-
-.mv-intake-path li > span {
-  position: relative;
-  z-index: 1;
-  width: 27px;
-  height: 27px;
-  display: grid;
-  place-items: center;
-  border: 1px solid var(--line-2);
-  border-radius: 7px;
-  background: var(--surface);
-  color: var(--ink-3);
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 8px;
-}
-
-.mv-intake-path li:first-child > span {
-  border-color: color-mix(in srgb, var(--accent) 44%, var(--line-2));
-  background: var(--accent-soft);
-  color: var(--accent);
-}
-
-.mv-intake-path li > div {
-  display: grid;
-  gap: 3px;
-  padding-top: 2px;
-}
-
-.mv-intake-path strong {
   color: var(--ink-2);
   font-size: 12px;
   font-weight: 580;
 }
 
-.mv-intake-path small {
+.mv-intake-cases-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 12px;
   color: var(--ink-3);
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 7.5px;
-  letter-spacing: 0.08em;
+  font-size: 11px;
+  text-decoration: none;
+}
+
+.mv-intake-cases-link:hover {
+  color: var(--accent);
 }
 
 .mv-intake-example-list {
-  margin-top: 14px;
-  border-top: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 10px;
 }
 
 .mv-intake-example {
   appearance: none;
   position: relative;
   width: 100%;
-  min-height: 76px;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 18px;
-  grid-template-rows: auto auto auto;
-  align-items: center;
-  gap: 4px 12px;
-  padding: 12px 8px 12px 0;
-  border: 0;
-  border-bottom: 1px solid var(--line);
-  background: transparent;
-  color: var(--ink);
-  text-align: left;
+  min-height: 42px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--surface) 68%, transparent);
+  color: var(--ink-2);
+  text-align: center;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 540;
   cursor: pointer;
   transition:
     background-color 150ms ease,
-    padding 150ms ease;
+    border-color 150ms ease,
+    color 150ms ease;
 }
 
-.mv-intake-example:hover,
-.mv-intake-example.is-selected {
-  padding-left: 10px;
-  background: color-mix(in srgb, var(--accent) 6%, transparent);
+.mv-intake-example:hover {
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--line-2));
+  background: color-mix(in srgb, var(--accent) 6%, var(--surface));
+  color: var(--ink);
 }
 
 .mv-intake-example:disabled {
   cursor: not-allowed;
   opacity: 0.52;
-}
-
-.mv-intake-example > span,
-.mv-intake-example > strong,
-.mv-intake-example > small {
-  grid-column: 1;
-}
-
-.mv-intake-example > span {
-  color: var(--ink-3);
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 7.5px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-}
-
-.mv-intake-example > strong {
-  font-size: 12.5px;
-  font-weight: 610;
-}
-
-.mv-intake-example > small {
-  color: var(--ink-3);
-  font-size: 9.5px;
-}
-
-.mv-intake-example > svg {
-  grid-column: 2;
-  grid-row: 1 / 4;
-  width: 15px;
-  height: 15px;
-  color: var(--ink-3);
-  stroke-width: 1.7;
-  transition:
-    color 150ms ease,
-    transform 150ms ease;
-}
-
-.mv-intake-example:hover > svg,
-.mv-intake-example.is-selected > svg {
-  color: var(--accent);
-  transform: translateX(2px);
 }
 
 .mv-tpl-card {
@@ -2740,23 +2527,7 @@
   }
 
   .mv-intake-shell {
-    width: min(760px, calc(100vw - 36px));
-  }
-
-  .mv-intake-layout {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 38px;
-  }
-
-  .mv-intake-guide {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 30px;
-  }
-
-  .mv-intake-path {
-    padding: 0 30px 0 0;
-    border-right: 1px solid var(--line);
-    border-bottom: 0;
+    width: min(820px, calc(100vw - 36px));
   }
 }
 
@@ -2808,10 +2579,7 @@
   }
 
   .mv-intake-hero {
-    align-items: start;
-    flex-direction: column;
-    gap: 18px;
-    padding-bottom: 22px;
+    padding: 0;
   }
 
   .mv-intake-title {
@@ -2830,26 +2598,12 @@
     overflow-wrap: anywhere;
   }
 
-  .mv-intake-outcomes {
-    padding-bottom: 0;
-  }
-
   .mv-intake-layout {
-    gap: 32px;
-    padding-top: 22px;
-  }
-
-  .mv-intake-composer__head {
-    min-height: 62px;
-    padding-inline: 14px;
-  }
-
-  .mv-intake-domain-hint span {
-    display: none;
+    padding-top: 20px;
   }
 
   .mv-intake-input {
-    min-height: 178px;
+    min-height: 168px;
     padding: 18px 16px 14px;
     font-size: 15px;
   }
@@ -2875,24 +2629,19 @@
     justify-content: flex-start;
   }
 
-  .mv-intake-file-help {
-    max-width: 180px;
-  }
-
   .mv-intake-send {
     min-width: 124px;
     min-height: 44px;
   }
 
-  .mv-intake-guide {
-    grid-template-columns: 1fr;
-    gap: 28px;
+  .mv-intake-example {
+    min-height: 44px;
   }
 
-  .mv-intake-path {
-    padding: 0 0 26px;
-    border-right: 0;
-    border-bottom: 1px solid var(--line);
+  .mv-intake-file .mv-intake-file__remove {
+    width: 44px;
+    height: 44px;
+    margin: -6px;
   }
 
   .mv-tpl-card {
@@ -2937,6 +2686,15 @@
 
   .mv-intake-input {
     min-height: 164px;
+  }
+
+  .mv-intake-example-list {
+    gap: 6px;
+  }
+
+  .mv-intake-example {
+    padding-inline: 6px;
+    font-size: 11px;
   }
 }
 

--- a/docs/coverage-and-fallback.md
+++ b/docs/coverage-and-fallback.md
@@ -18,6 +18,19 @@ Skill routing + topic evidence + registered manifests + runtime tool discovery
 `CoverageDecision` is a capability and safety boundary. It is not a rendering contract and
 must not be copied into `PlaybookScript`, `DirectorScript`, or the Remotion composition.
 
+## Intake evidence boundary
+
+The normal Web Intake always supplies `explicit_domain=None`. Text-only requests also carry
+`source_code=None` and `language=None`; code attachments carry the source and detected language
+but still do not claim a domain. Nullable language is preserved through `PipelineRequest`,
+`SkillRouteInput`, the topic router and this resolver. Missing language means unknown evidence,
+never Python.
+
+Domain selection therefore belongs to backend topic evidence, registered deterministic skill
+heuristics and coverage validation. The request DTO keeps an explicit domain for benchmarks and
+internal compatibility clients, but a Web-provided label cannot bypass the resolver's manifest,
+ProblemSpec, confidence or tool checks because the Web path does not provide one.
+
 ## Modes
 
 | Mode | Meaning | Fallback |

--- a/docs/frontend-shell.md
+++ b/docs/frontend-shell.md
@@ -49,6 +49,25 @@ settings              -> /settings
 
 未知应用路径回到公共首页 `/`。
 
+## 智能创建入口契约
+
+`/create` 只呈现一个单列输入面，不在前端显示或推断学科、Coverage、Skill、
+LessonPlan 或 Director。教师可以输入题目/知识点、粘贴代码，或附加一个代码文件；
+“导数与切线 / 二分查找 / 抛体运动”三个按钮只填入自然语言 prompt，不提交、
+不选择模板，也不写入 domain。`/cases` 是精选案例的稳定目标路径，由后续公共案例
+阶段实现。
+
+正常 Web 提交统一经过 `usePipelineSubmit`，始终发送 `domain: null`：
+
+- 纯文本发送 `source_code/language/source_filename/source_size_bytes: null`；
+- 代码附件发送源码、扩展名映射出的真实语言、原始文件名和字节数；
+- 附件只允许一个受支持的代码文件，第二次选择替换前一个，大小上限为 256 KB；
+- 空输入不提交，`Ctrl/Cmd + Enter` 与按钮共用同一异步防重入口。
+
+这意味着 Web Intake 只收集证据，最终 domain 和能力路径由后端 Router、
+CoverageResolver 与 Skill registry 决定。API 仍允许内部调用方显式提供 domain，
+但应用 Shell 不使用该兼容入口。
+
 ## GlobalTopbar
 
 `apps/web/src/shared/ui/GlobalTopbar.tsx` 是应用内五个 Stage 共享的顶部栏。**不要**在页面级别复制 Topbar JSX，也不要在公共 Landing Page 中强行复用它。

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -18,6 +18,13 @@ Router
   -> PlaybookScript
 ```
 
+正常 Web Intake 不预判 Router 结果。`usePipelineSubmit` 对所有应用内提交写入
+`domain: null`；纯文本同时写入 `source_code: null`、`language: null`、
+`source_filename: null` 与 `source_size_bytes: null`。因此一条普通数学或物理 prompt
+不会携带虚假的 Python 信号。`PipelineRequest.language` 是 nullable，null 会原样进入
+`SkillRouteInput`、CoverageResolver 和 Agent/legacy 上下文。API 仍保留显式 domain
+字段，供基准和内部兼容调用使用。
+
 LessonPlan 只记录教学目标、误区、结论、教学弧线和 SceneIntent，不包含 frame、坐标、
 asset、layer 或 renderer 私有字段。最终候选还会由后端检查已注册的 required facts、
 visual roles、preferred scene type 和精确结论；缺失证据会触发 repair 或阻断。
@@ -131,11 +138,17 @@ SceneIntent 展开为多个步骤，但必须保持教学目标、所需事实�
 
 当 `IntakeContext.sourceCode` 存在时：
 
-1. 前端从扩展名映射 `language`（见 `IntakeScreen.EXT_TO_LANGUAGE`）。
-2. `usePipelineSubmit` 把 `sourceCode + language` 传到后端。
+1. 前端从扩展名映射真实 `language`，并记录 `sourceFilename` 与
+   `sourceSizeBytes`；仅接受一个不超过 256 KB 的代码文件。
+2. `usePipelineSubmit` 把四项证据映射为 `source_code + language +
+   source_filename + source_size_bytes`，仍保持 `domain: null`。
 3. `build_cir_prompt` 在 system prompt 里以行号方式嵌入源码（`_number_source`，0-indexed）。
 4. LLM 在每个 checkpoint 的 `code_lines` 填入相关行号。
 5. `playbook_builder._build_code_highlight` 过滤越界行号，构造 `CodeHighlightOverlay`。
+
+后端拒绝没有 `source_code` 却携带语言/文件元数据的请求，也拒绝超过 256 KB 的
+源码或声明字节数。若非 Web 调用方提供源码但没有语言，Router prompt 与 CIR prompt
+使用 `unknown`，Playbook 的展示降级语言使用 `text`；任何路径都不得默认为 Python。
 
 `CodeHighlightOverlay` 是与视觉 snapshot 并行的工作台轨道。BFS 与递归的
 Agent 结果缺少该轨道时，后端会从 canonical 算法代码和结构化状态确定性补齐；

--- a/docs/worklogs/teacher-showcase-v1.md
+++ b/docs/worklogs/teacher-showcase-v1.md
@@ -1,0 +1,132 @@
+# Teacher Showcase V1 Worklog
+
+Status: PR 1 validated; Draft PR pending
+
+## Baseline
+
+- Base commit: `f62d88171a0dc6a90996aad46462e5bf6ed0851b` (`origin/main` on 2026-07-13).
+- Working branch: `codex/intake-smart-routing-contract`.
+- The primary checkout contained unrelated uncommitted changes and was four commits behind
+  `origin/main`. PR 1 therefore uses a separate clean worktree; none of those changes are
+  copied, modified, staged, or published.
+- PR #123 (`docs: rewrite README for product positioning`): open Draft, clean merge state.
+  Root `README.md` is out of scope until that PR lands.
+- PR #124 (`fix(web): preserve studio theme and isolate hidden landing panels`): open Draft,
+  clean merge state. PR 1 starts from `origin/main` because its Intake contract does not depend
+  on the Landing changes; later public-route/Landing phases must resolve that dependency.
+
+## Environment
+
+- macOS Darwin 25.5.0 arm64.
+- Node.js 22.18.0; npm 10.9.3.
+- Python 3.14.4 in the ignored worktree-local `.venv`.
+- Dependencies installed from `package-lock.json` and `apps/api/requirements-dev.txt`.
+- npm reported that two agent packages declare Node `>=22.19.0`; installation still completed.
+
+## Baseline commands
+
+### `make check`
+
+- Exit code: 2.
+- Ruff: passed.
+- API pytest: 946 passed, 0 failed.
+- Web Vitest: 956 passed, 10 failed across four files.
+- Failing files: `usePipelinePoller.test.tsx` (4), `App.edition.test.tsx` (3),
+  `routing.test.tsx` (2), and `OpsDashboardPage.test.tsx` (1).
+- Failure shape: full-suite timeouts plus later DOM leakage after timeouts. These failures were
+  observed before PR 1 edits and must be rechecked independently and again after implementation.
+- The target stopped at Web tests, so Agent/MCP tests and production builds did not run in this
+  baseline invocation.
+- Existing lint signal: two non-error Fast Refresh warnings in `AlgorithmParamPanel.tsx`.
+- Full ignored log: `eval/reports/teacher-showcase-pr1-baseline-check.log`.
+
+### `make visual-check`
+
+- Exit code: 0.
+- Asset audit passed.
+- Showcase smoke rendered and passed 15 fixtures.
+- Showcase baseline and review packet generation passed.
+- Full ignored log: `eval/reports/teacher-showcase-pr1-baseline-visual-check.log`.
+
+### `make eval-gold`
+
+- Exit code: 2.
+- Recorded Benchmark V2: 0/12 attempts passed.
+- This is the documented negative-migration baseline: all four recorded fixtures contain hard
+  failures. No threshold, Gold expectation, or fixture was changed.
+- No recorded output may be promoted or described as verified.
+- Full ignored log: `eval/reports/teacher-showcase-pr1-baseline-eval-gold.log`.
+
+## PR 1 scope and known blockers
+
+- In scope: a single-column `/create` Intake, backend-owned domain routing, nullable language,
+  a 256 KB single-code-file contract, request filename/size metadata, focused tests, and direct
+  contract documentation.
+- Out of scope: `/cases` implementation, public static playback, Benchmark auto-routing mode,
+  Promotion, verified case publication, Landing case cards, and Preview deployment.
+- Live provider verification is not required for PR 1 and has not been claimed.
+- The pre-existing full-Web-suite failures must either pass on rerun or remain explicitly
+  documented; PR 1 cannot be described as making `make check` green unless the command exits 0.
+
+## PR 1 implementation
+
+- Replaced the two-column routing-oriented Intake with one quiet 820 px single-column creation
+  surface. It contains only the prompt, optional single-file attachment, submit action, three
+  prompt-only examples and the stable `/cases` link.
+- Removed frontend domain inference and domain/template metadata from `IntakeContext`. Both app
+  editions now submit only prompt and optional source evidence.
+- Normal Web requests always serialize `domain: null`; text requests serialize nullable source
+  fields, while code requests include real language, filename and byte size.
+- Made API language nullable end-to-end and removed the implicit Python fallback from CIR and
+  Playbook source handling. Added DTO validation for orphan metadata and the 256 KB limit.
+- Added focused Web/API/router/coverage/CIR tests for text and code contracts, replacement,
+  drag/drop rejection, size/type/read errors, keyboard submission and async deduplication.
+
+Focused verification completed before the final gate:
+
+- Web: 4 files, 34 tests passed.
+- API: 4 files, 100 tests passed.
+
+## PR 1 final verification
+
+### `make check`
+
+- Exit code: 0.
+- Ruff, Agent lint/typecheck, MCP typecheck and all production builds passed.
+- API: 954 tests passed.
+- Web: 117 files, 979 tests passed.
+- Agent: 63 tests passed.
+- MCP server: 18 tests passed.
+- ESLint retained only the two pre-existing non-error Fast Refresh warnings in
+  `AlgorithmParamPanel.tsx`; PR 1 introduced no new lint warning.
+- Full ignored log: `eval/reports/teacher-showcase-pr1-final-check.log`.
+
+### `make visual-check`
+
+- Exit code: 0.
+- Asset audit passed; all 15 showcase fixtures passed smoke render, baseline and review packet
+  generation.
+- Full ignored log: `eval/reports/teacher-showcase-pr1-final-visual-check.log`.
+
+### Browser contract check
+
+- Playwright CLI opened the real Vite `/create` route in light and dark themes and with reduced
+  motion enabled.
+- Checked 1440x900, 1280x800, 768x1024, 390x844 and 375x812. Every viewport had
+  `documentElement.scrollWidth === clientWidth`; title, composer, actions, all three examples and
+  `/cases` remained in the first viewport.
+- At 390 px and 375 px, upload, submit and example controls measured 44 px high.
+- `Ctrl+Enter` on the derivative example produced a captured request with `domain`, `source_code`,
+  `language`, filename and size all null. Uploading the repository's `main.py` produced
+  `domain=null`, `language=python`, `source_filename=main.py`, and a byte count matching the
+  submitted source.
+- The local browser run intentionally had no API process, so submission ended in the accessible
+  error state after the request contract was captured. No provider or live-generation evidence
+  is claimed by PR 1.
+
+### Remaining phase boundary
+
+- The recorded `make eval-gold` baseline remains 0/12 because all four repository fixtures carry
+  documented hard failures. PR 1 does not alter Gold thresholds, fixtures or verified labels.
+- PR 2–PR 4 remain unstarted. In particular, `/cases` is only a stable link target in PR 1 and no
+  public case, promotion artifact, Landing card or Preview deployment exists yet.


### PR DESCRIPTION
## 本 PR 解决的问题

- 把 `/create` 从双栏、前端推断学科的架构说明页收敛为一个 820px 单列创建面。
- 让正常 Web 提交始终发送 `domain: null`，由后端 Router、CoverageResolver 和 Skill registry 拥有唯一的路由决策权。
- 修复纯文本请求被错误标记为 Python 的问题；`language=None` 现在会安全穿过 DTO、Router、Coverage 与生成上下文。
- 把附件统一为单个、可替换、最大 256 KB 的代码文件，并提交真实语言、文件名和字节数。

## 本 PR 不解决的问题

- 不实现 `/cases` 页面、公共静态播放器或 Landing 案例卡；当前只提供稳定链接。
- 不实现 Benchmark auto-route、Promotion、Poster 或 verified case 发布。
- 不部署 Preview，不提供 live provider 生成证据，不修改 Gold fixture/阈值。
- 不修改根 README，不触碰 PR #123；不吸收 PR #124 的 Landing 改动。

## Base 与依赖

- Base commit: `f62d88171a0dc6a90996aad46462e5bf6ed0851b`
- Base branch: `main`
- PR #123: open Draft；根 README 保持不变。
- PR #124: open Draft；PR1 不依赖它，后续 Landing 阶段需重新处理依赖。

## 修改文件

- Web Intake 与样式：`IntakeScreen.tsx`、`codeFileLanguage.ts`、`studio.css`
- Web 请求边界：两套 App Shell、`usePipelineSubmit.ts`、`pipelineApi.ts`
- API nullable 契约：`pipeline_dto.py`、`cir_prompt.py`、`playbook_builder.py`
- 聚焦测试：Intake、Pipeline API/Hook、Router、CoverageResolver、CIR、移动端 smoke
- 文档：`frontend-shell.md`、`pipeline.md`、`coverage-and-fallback.md`、工作日志

## 架构边界与路由行为

`IntakeContext` 不再包含 domain/template/title/files 等路由或展示推断。示例只填入自然语言 prompt；上传 `.py` 也不会在前端固定 `code`。API 的显式 domain 字段仅为 benchmark/内部兼容调用保留，正常应用 Shell 无法提供它。

## 数据契约

纯文本 Web 请求：

```json
{
  "domain": null,
  "source_code": null,
  "language": null,
  "source_filename": null,
  "source_size_bytes": null
}
```

代码附件 Web 请求：

```json
{
  "domain": null,
  "source_code": "...",
  "language": "python",
  "source_filename": "main.py",
  "source_size_bytes": 2860
}
```

后端拒绝无源码却携带语言/文件元数据的请求，也拒绝超过 256 KB 的源码或声明大小。未知源码语言使用 `unknown`/`text` 降级，不再回填 Python。

## 测试命令与结果

- 聚焦 Web：4 files / 34 tests passed。
- 聚焦 API：4 files / 100 tests passed。
- `make check`: passed。
  - API 954 passed
  - Web 117 files / 979 passed
  - Agent 63 passed
  - MCP server 18 passed
  - Ruff、typecheck、production builds passed
  - 仅保留 `AlgorithmParamPanel.tsx` 的 2 条既有非错误 Fast Refresh warning
- `make visual-check`: passed；asset audit 与 15 个 fixture 的 smoke/baseline/review packet 全部通过。
- `git diff --check`: passed。

## 视觉与移动端检查

Playwright CLI 在真实 Vite `/create` 上检查了：

- 1440x900
- 1280x800
- 768x1024
- 390x844
- 375x812

五个视口均无横向溢出，标题、Composer、操作区、三个示例和 `/cases` 均在首屏。390/375px 下上传、生成和示例按钮高度均为 44px。浅色、深色和 reduced-motion 状态均已检查。

浏览器捕获的 `Ctrl+Enter` 文本请求所有路由/源码字段均为 null；上传仓库 `main.py` 后捕获到 `domain=null`、真实 Python、文件名和匹配的源码字节数。

## 已知限制与未验证内容

- 浏览器验证时没有启动 API 进程，因此请求契约捕获后进入了可访问的 502 错误状态；未声称 live generation。
- 基线 `make eval-gold` 仍为 0/12，四个 recorded fixture 均有仓库已记录的 hard failure；本 PR 未更改任何 Gold 预期，也未发布 verified 内容。
- `/cases` 尚未实现；点击后仍由当前未知路由回到公共首页，等待 PR2。
- 没有 Preview URL，当前不能声称线上版本可直接发给指导老师。

## 回滚方式

按相反顺序 revert 本 PR 的四个提交即可恢复旧 Intake 和旧请求默认值；没有数据库迁移、公开资产或外部状态需要清理。

## 是否包含真实 live evidence

否。PR1 只锁定 Intake 与请求/路由契约；真实案例与 live verified evidence 属于 PR3/PR4。

## 下一阶段动作

PR1 经 review 并进入目标基线后，再从该基线开始 PR2：实现公共精选案例浏览与静态播放。不会自动 merge。
