### PR TITLE
fix: harden optional RDKit and automate visual checks

### DIFF
--- a/.github/workflows/visual-check.yml
+++ b/.github/workflows/visual-check.yml
@@ -1,0 +1,58 @@
+name: Visual Check
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "apps/web/public/assets/**"
+      - "apps/web/scripts/**"
+      - "apps/web/src/features/playbook/engine/assets/**"
+      - "apps/web/src/features/playbook/engine/composition/**"
+      - "apps/web/src/features/playbook/engine/renderers/**"
+      - "apps/web/src/remotion/**"
+      - "eval/**"
+      - "Makefile"
+      - "package.json"
+      - "package-lock.json"
+      - "apps/web/package.json"
+      - ".github/workflows/visual-check.yml"
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  visual-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Ensure Remotion browser
+        run: npx remotion browser ensure
+
+      - name: Run visual regression gate
+        run: make visual-check
+
+      - name: Upload visual review evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-check-${{ github.run_id }}
+          path: |
+            eval/reports/
+            eval/shots/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/apps/api/app/domain/services/rdkit_molecule_compiler.py
+++ b/apps/api/app/domain/services/rdkit_molecule_compiler.py
@@ -1,29 +1,43 @@
 from __future__ import annotations
 
 import re
-
-from rdkit import Chem, RDLogger
-from rdkit.Chem import rdDepictor, rdMolDescriptors
-from rdkit.Chem.rdchem import BondType
+from functools import lru_cache
+from typing import Any
 
 from app.domain.models.playbook import Molecule2DAtom, Molecule2DBond, Molecule2DSceneSnapshot
 
-RDLogger.DisableLog("rdApp.error")
+
+@lru_cache
+def _load_rdkit() -> tuple[Any, Any, Any, Any]:
+    try:
+        from rdkit import Chem, RDLogger
+        from rdkit.Chem import rdDepictor, rdMolDescriptors
+        from rdkit.Chem.rdchem import BondType
+    except ModuleNotFoundError as exc:
+        if exc.name == "rdkit" or (exc.name and exc.name.startswith("rdkit.")):
+            raise RuntimeError(
+                "RDKit is required only for SMILES molecule scenes. "
+                "Install apps/api/requirements-subjects.txt to enable them."
+            ) from exc
+        raise
+
+    RDLogger.DisableLog("rdApp.error")
+    return Chem, rdDepictor, rdMolDescriptors, BondType
 
 
 def _formula_to_latex(formula: str) -> str:
     return re.sub(r"(\d+)", r"_\1", formula)
 
 
-def _bond_order(bond_type: BondType) -> int:
-    if bond_type == BondType.DOUBLE:
+def _bond_order(bond_type: Any, bond_type_enum: Any) -> int:
+    if bond_type == bond_type_enum.DOUBLE:
         return 2
-    if bond_type == BondType.TRIPLE:
+    if bond_type == bond_type_enum.TRIPLE:
         return 3
     return 1
 
 
-def _scaled_positions(mol: Chem.Mol) -> list[tuple[float, float]]:
+def _scaled_positions(mol: Any) -> list[tuple[float, float]]:
     conformer = mol.GetConformer()
     raw_points = [
         (float(conformer.GetAtomPosition(index).x), float(conformer.GetAtomPosition(index).y))
@@ -54,6 +68,8 @@ def compile_molecule_snapshot_from_smiles(
     bond_asset_id: str | None = None,
     caption: str | None = None,
 ) -> Molecule2DSceneSnapshot:
+    Chem, rdDepictor, rdMolDescriptors, BondType = _load_rdkit()
+
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
         raise ValueError(f"Invalid SMILES for molecule {molecule_id!r}: {smiles!r}")
@@ -77,7 +93,7 @@ def compile_molecule_snapshot_from_smiles(
             id=f"b{index + 1}",
             **{"from": f"a{bond.GetBeginAtomIdx() + 1}"},
             to=f"a{bond.GetEndAtomIdx() + 1}",
-            order=_bond_order(bond.GetBondType()),
+            order=_bond_order(bond.GetBondType(), BondType),
             asset_id=bond_asset_id,
         )
         for index, bond in enumerate(mol.GetBonds())

--- a/apps/api/tests/test_rdkit_molecule_compiler.py
+++ b/apps/api/tests/test_rdkit_molecule_compiler.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import builtins
 import json
 from pathlib import Path
 
 import pytest
 
+from app.domain.services import rdkit_molecule_compiler
 from app.domain.services.rdkit_molecule_compiler import compile_molecule_snapshot_from_smiles
 
 GLUCOSE_SMILES = "OC[C@H]1O[C@@H](O)[C@H](O)[C@H](O)[C@@H]1O"
@@ -65,4 +67,25 @@ def test_compile_molecule_snapshot_from_smiles_rejects_invalid_smiles() -> None:
             pack_id="chemistry-basic",
             molecule_id="broken",
             smiles="not-a-smiles",
+        )
+
+
+def test_missing_rdkit_fails_only_when_a_smiles_scene_is_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rdkit_molecule_compiler._load_rdkit.cache_clear()
+    real_import = builtins.__import__
+
+    def import_without_rdkit(name: str, *args, **kwargs):
+        if name == "rdkit" or name.startswith("rdkit."):
+            raise ModuleNotFoundError("No module named 'rdkit'", name="rdkit")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_rdkit)
+
+    with pytest.raises(RuntimeError, match="required only for SMILES molecule scenes"):
+        compile_molecule_snapshot_from_smiles(
+            pack_id="chemistry-basic",
+            molecule_id="glucose",
+            smiles=GLUCOSE_SMILES,
         )


### PR DESCRIPTION
## What changed

- load RDKit lazily only when a SMILES molecule scene is requested
- preserve the full Docker deployment path, which still installs `requirements-subjects.txt`
- return a focused installation error when a lightweight deployment requests an RDKit-backed scene
- add regression coverage for the missing-RDKit path
- add a separate `Visual Check` workflow for renderer, Remotion, asset, eval, and showcase changes
- run the visual gate weekly and allow manual dispatch
- upload visual reports and shots as workflow artifacts

## Why

A minimal API install should not fail during startup only because optional molecule tooling is unavailable. Heavy visual rendering should also remain separate from the fast `Check` workflow while still receiving automated regression coverage.

## Validation

- branch is based on the current `main`
- diff is limited to the RDKit loader/test and the new visual workflow
- GitHub Actions will provide the authoritative CI result for this draft

Closes #113
Closes #114

This PR is intentionally a draft and must not be merged automatically.