### PR TITLE
feat: add deterministic interaction engine pilots

### DIFF
--- a/apps/web/src/features/playbook/interaction/engine.test.ts
+++ b/apps/web/src/features/playbook/interaction/engine.test.ts
@@ -91,7 +91,10 @@ describe("interaction manifest", () => {
       [step("graph", graph)],
       { domain: "algorithm", algorithm_id: "bfs" },
     ));
-    expect(bfs.adapters[0].bindings[0].options.map((item) => item.id))
+    const bfsBinding = bfs.adapters[0].bindings.find(
+      (binding) => binding.target_role === "start-node",
+    );
+    expect(bfsBinding?.options.map((item) => item.id))
       .toEqual(["A", "B", "C", "D"]);
   });
 

--- a/apps/web/src/features/playbook/interaction/engine.test.ts
+++ b/apps/web/src/features/playbook/interaction/engine.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { compileExpr } from "../../../shared/lib/mathExpr";
+import type {
+  GraphSceneSnapshot,
+  MathPlotSnapshot,
+  MetaStep,
+  PlaybookScript,
+} from "../engine/types";
+import { applyInteraction, deriveInteractionManifest } from "./engine";
+import { InteractionEngineError } from "./types";
+
+function step(
+  stepId: string,
+  snapshot: MathPlotSnapshot | GraphSceneSnapshot,
+  endFrame = 30,
+): MetaStep {
+  return {
+    step_id: stepId,
+    end_frame: endFrame,
+    title: stepId,
+    voiceover_text: "",
+    snapshot,
+    tokens: [],
+  };
+}
+
+function script(
+  steps: MetaStep[],
+  extra: Partial<PlaybookScript> = {},
+): PlaybookScript {
+  return {
+    fps: 30,
+    total_frames: Math.max(...steps.map((item) => item.end_frame)),
+    domain: "math",
+    title: "Interaction fixture",
+    summary: "",
+    steps,
+    parameter_controls: [],
+    ...extra,
+  };
+}
+
+const plot: MathPlotSnapshot = {
+  kind: "math_plot",
+  curves: [{ expression: "x^2", label: "f(x)", semantic_role: "curve" }],
+  x_min: -5,
+  x_max: 5,
+  y_min: -1,
+  y_max: 25,
+  marker_x: 1,
+  x_label: "x",
+  y_label: "y",
+};
+
+const graph: GraphSceneSnapshot = {
+  kind: "graph_scene",
+  nodes: [
+    { id: "A", label: "A" },
+    { id: "B", label: "B" },
+    { id: "C", label: "C" },
+    { id: "D", label: "D" },
+  ],
+  edges: [
+    { source: "A", target: "B" },
+    { source: "A", target: "C" },
+    { source: "B", target: "D" },
+  ],
+  directed: false,
+};
+
+describe("interaction manifest", () => {
+  it("declares only allowlisted bindings supported by the script", () => {
+    const math = deriveInteractionManifest(script([step("plot", plot)]));
+    expect(math.adapters).toEqual([
+      expect.objectContaining({
+        adapter_id: "math.derivative-tangent",
+        experimental: true,
+      }),
+    ]);
+    expect(math.adapters[0].bindings[0]).toMatchObject({
+      id: "step:plot:marker-x",
+      min: -5,
+      max: 5,
+      value: 1,
+    });
+
+    const bfs = deriveInteractionManifest(script(
+      [step("graph", graph)],
+      { domain: "algorithm", algorithm_id: "bfs" },
+    ));
+    expect(bfs.adapters[0].bindings[0].options?.map((item) => item.id))
+      .toEqual(["A", "B", "C", "D"]);
+  });
+
+  it("fails closed for a graph lesson that is not identified as BFS", () => {
+    const manifest = deriveInteractionManifest(script(
+      [step("graph", graph)],
+      { domain: "algorithm", algorithm_id: "dfs" },
+    ));
+    expect(manifest.adapters).toEqual([]);
+  });
+});
+
+describe("derivative interaction", () => {
+  it("moves the marker and deterministically recomputes the tangent", () => {
+    const base = script([step("plot", plot)]);
+    const result = applyInteraction(base, {
+      adapter_id: "math.derivative-tangent",
+      step_id: "plot",
+      target_id: "step:plot:marker-x",
+      action: "set-value",
+      value: 3,
+    }, 7);
+
+    const snapshot = result.script.steps[0].snapshot as MathPlotSnapshot;
+    expect(snapshot.marker_x).toBe(3);
+    expect(base.steps[0].snapshot).toBe(plot);
+    const tangent = snapshot.curves.find((curve) => curve.semantic_role === "tangent");
+    expect(tangent).toBeDefined();
+    const tangentFn = compileExpr(tangent!.expression);
+    expect(tangentFn({ x: 3 })).toBeCloseTo(9, 8);
+    expect(tangentFn({ x: 4 }) - tangentFn({ x: 3 })).toBeCloseTo(6, 4);
+    expect(result.event.sequence).toBe(7);
+  });
+
+  it("rejects values outside the manifest bounds", () => {
+    expect(() => applyInteraction(script([step("plot", plot)]), {
+      adapter_id: "math.derivative-tangent",
+      step_id: "plot",
+      target_id: "step:plot:marker-x",
+      action: "set-value",
+      value: 8,
+    })).toThrow(InteractionEngineError);
+  });
+});
+
+describe("BFS interaction", () => {
+  it("replays graph snapshots from the selected stable node id", () => {
+    const base = script(
+      [step("g1", graph, 30), step("g2", graph, 60), step("g3", graph, 90)],
+      { domain: "algorithm", algorithm_id: "bfs" },
+    );
+    const result = applyInteraction(base, {
+      adapter_id: "algorithm.bfs",
+      step_id: "g1",
+      target_id: "step:g1:start-node",
+      action: "select",
+      value: "C",
+    });
+
+    const snapshots = result.script.steps.map((item) => item.snapshot as GraphSceneSnapshot);
+    expect(snapshots.map((item) => item.current_node_id)).toEqual(["C", "A", "B"]);
+    expect(snapshots[0].visited_node_ids).toEqual(["C"]);
+    expect(snapshots[0].queue_node_ids).toEqual(["A"]);
+    expect(snapshots[1].queue_node_ids).toEqual(["B"]);
+    expect(result.summary).toContain("C → A → B → D");
+    expect((base.steps[0].snapshot as GraphSceneSnapshot).current_node_id).toBeUndefined();
+  });
+
+  it("rejects commands that bypass the manifest", () => {
+    expect(() => applyInteraction(
+      script([step("graph", graph)], { domain: "algorithm", algorithm_id: "bfs" }),
+      {
+        adapter_id: "algorithm.bfs",
+        step_id: "graph",
+        target_id: "raw-dom-selector",
+        action: "select",
+        value: "A",
+      },
+    )).toThrow("not declared by the manifest");
+  });
+});

--- a/apps/web/src/features/playbook/interaction/engine.test.ts
+++ b/apps/web/src/features/playbook/interaction/engine.test.ts
@@ -7,7 +7,7 @@ import type {
   PlaybookScript,
 } from "../engine/types";
 import { applyInteraction, deriveInteractionManifest } from "./engine";
-import { InteractionEngineError } from "./types";
+import { InteractionEngineError, type InteractionCommand } from "./types";
 
 function step(
   stepId: string,
@@ -42,7 +42,10 @@ function script(
 
 const plot: MathPlotSnapshot = {
   kind: "math_plot",
-  curves: [{ expression: "x^2", label: "f(x)", semantic_role: "curve" }],
+  curves: [
+    { expression: "x^2", label: "f(x)", semantic_role: "curve" },
+    { expression: "2*x - 1", label: "tangent", semantic_role: "tangent", emphasis: "accent" },
+  ],
   x_min: -5,
   x_max: 5,
   y_min: -1,
@@ -61,15 +64,15 @@ const graph: GraphSceneSnapshot = {
     { id: "D", label: "D" },
   ],
   edges: [
-    { source: "A", target: "B" },
-    { source: "A", target: "C" },
-    { source: "B", target: "D" },
+    { id: "AB", source: "A", target: "B" },
+    { id: "AC", source: "A", target: "C" },
+    { id: "BD", source: "B", target: "D" },
   ],
   directed: false,
 };
 
 describe("interaction manifest", () => {
-  it("declares only allowlisted bindings supported by the script", () => {
+  it("declares only validated, allowlisted bindings supported by the script", () => {
     const math = deriveInteractionManifest(script([step("plot", plot)]));
     expect(math.adapters).toEqual([
       expect.objectContaining({
@@ -88,16 +91,51 @@ describe("interaction manifest", () => {
       [step("graph", graph)],
       { domain: "algorithm", algorithm_id: "bfs" },
     ));
-    expect(bfs.adapters[0].bindings[0].options?.map((item) => item.id))
+    expect(bfs.adapters[0].bindings[0].options.map((item) => item.id))
       .toEqual(["A", "B", "C", "D"]);
   });
 
-  it("fails closed for a graph lesson that is not identified as BFS", () => {
-    const manifest = deriveInteractionManifest(script(
+  it("fails closed for non-BFS lessons, malformed graphs, and undeclared tangents", () => {
+    const dfs = deriveInteractionManifest(script(
       [step("graph", graph)],
       { domain: "algorithm", algorithm_id: "dfs" },
     ));
-    expect(manifest.adapters).toEqual([]);
+    expect(dfs.adapters).toEqual([]);
+
+    const malformed: GraphSceneSnapshot = {
+      ...graph,
+      edges: [...graph.edges, { source: "A", target: "missing" }],
+    };
+    const invalidBfs = deriveInteractionManifest(script(
+      [step("graph", malformed)],
+      { domain: "algorithm", algorithm_id: "bfs" },
+    ));
+    expect(invalidBfs.adapters).toEqual([]);
+
+    const noTangent: MathPlotSnapshot = { ...plot, curves: [plot.curves[0]] };
+    expect(deriveInteractionManifest(script([step("plot", noTangent)])).adapters).toEqual([]);
+  });
+
+  it("does not expose known non-differentiable or boundary points", () => {
+    const cusp: MathPlotSnapshot = {
+      ...plot,
+      curves: [
+        { expression: "abs(x)", semantic_role: "curve" },
+        { expression: "0", semantic_role: "tangent" },
+      ],
+      marker_x: 0,
+    };
+    const boundary: MathPlotSnapshot = {
+      ...plot,
+      curves: [
+        { expression: "sqrt(x)", semantic_role: "curve" },
+        { expression: "0", semantic_role: "tangent" },
+      ],
+      x_min: 0,
+      marker_x: 0,
+    };
+    expect(deriveInteractionManifest(script([step("cusp", cusp)])).adapters).toEqual([]);
+    expect(deriveInteractionManifest(script([step("boundary", boundary)])).adapters).toEqual([]);
   });
 });
 
@@ -120,10 +158,10 @@ describe("derivative interaction", () => {
     const tangentFn = compileExpr(tangent!.expression);
     expect(tangentFn({ x: 3 })).toBeCloseTo(9, 8);
     expect(tangentFn({ x: 4 }) - tangentFn({ x: 3 })).toBeCloseTo(6, 4);
-    expect(result.event.sequence).toBe(7);
+    expect(result.event).toMatchObject({ value: 3, sequence: 7 });
   });
 
-  it("rejects values outside the manifest bounds", () => {
+  it("rejects values outside bounds and invalid event sequences", () => {
     expect(() => applyInteraction(script([step("plot", plot)]), {
       adapter_id: "math.derivative-tangent",
       step_id: "plot",
@@ -131,33 +169,82 @@ describe("derivative interaction", () => {
       action: "set-value",
       value: 8,
     })).toThrow(InteractionEngineError);
+
+    expect(() => applyInteraction(script([step("plot", plot)]), {
+      adapter_id: "math.derivative-tangent",
+      step_id: "plot",
+      target_id: "step:plot:marker-x",
+      action: "set-value",
+      value: 2,
+    }, 0)).toThrow("positive integer");
   });
 });
 
 describe("BFS interaction", () => {
-  it("replays graph snapshots from the selected stable node id", () => {
+  it("builds a complete replay without contaminating unrelated graph scenes", () => {
+    const unrelated: GraphSceneSnapshot = {
+      kind: "graph_scene",
+      nodes: [{ id: "X" }, { id: "Y" }],
+      edges: [{ source: "X", target: "Y" }],
+    };
+    const staleGraph: GraphSceneSnapshot = {
+      ...graph,
+      nodes: graph.nodes.map((node) => ({ ...node, emphasis: "accent", asset_id: "stale" })),
+      edges: graph.edges.map((edge) => ({ ...edge, emphasis: "accent", asset_id: "stale" })),
+    };
     const base = script(
-      [step("g1", graph, 30), step("g2", graph, 60), step("g3", graph, 90)],
+      [
+        step("other-before", unrelated, 30),
+        step("graph", staleGraph, 60),
+        step("other-after", unrelated, 90),
+      ],
       { domain: "algorithm", algorithm_id: "bfs" },
     );
     const result = applyInteraction(base, {
       adapter_id: "algorithm.bfs",
-      step_id: "g1",
-      target_id: "step:g1:start-node",
+      step_id: "graph",
+      target_id: "step:graph:start-node",
       action: "select",
       value: "C",
     });
 
-    const snapshots = result.script.steps.map((item) => item.snapshot as GraphSceneSnapshot);
-    expect(snapshots.map((item) => item.current_node_id)).toEqual(["C", "A", "B"]);
-    expect(snapshots[0].visited_node_ids).toEqual(["C"]);
-    expect(snapshots[0].queue_node_ids).toEqual(["A"]);
-    expect(snapshots[1].queue_node_ids).toEqual(["B"]);
-    expect(result.summary).toContain("C → A → B → D");
-    expect((base.steps[0].snapshot as GraphSceneSnapshot).current_node_id).toBeUndefined();
+    expect(result.replay?.visit_order).toEqual(["C", "A", "B", "D"]);
+    expect(result.replay?.frames.map((frame) => frame.current_node_id))
+      .toEqual(["C", "A", "B", "D"]);
+    expect(result.replay?.frames.at(-1)?.visited_node_ids).toEqual(["C", "A", "B", "D"]);
+    expect((result.script.steps[0].snapshot as GraphSceneSnapshot).current_node_id).toBeUndefined();
+    expect((result.script.steps[1].snapshot as GraphSceneSnapshot).current_node_id).toBe("C");
+    expect((result.script.steps[2].snapshot as GraphSceneSnapshot).current_node_id).toBeUndefined();
+    expect(result.replay?.frames[0].snapshot.nodes[0].asset_id).toBeUndefined();
+    expect(result.summary).toContain("Prepared BFS replay");
+    expect((base.steps[1].snapshot as GraphSceneSnapshot).current_node_id).toBeUndefined();
   });
 
-  it("rejects commands that bypass the manifest", () => {
+  it("handles directed, disconnected, self-loop, and duplicate edges deterministically", () => {
+    const edgeCases: GraphSceneSnapshot = {
+      kind: "graph_scene",
+      nodes: [{ id: "A" }, { id: "B" }, { id: "C" }],
+      edges: [
+        { source: "A", target: "A" },
+        { source: "A", target: "B" },
+        { source: "A", target: "B" },
+      ],
+      directed: true,
+    };
+    const result = applyInteraction(
+      script([step("graph", edgeCases)], { domain: "algorithm", algorithm_id: "bfs" }),
+      {
+        adapter_id: "algorithm.bfs",
+        step_id: "graph",
+        target_id: "step:graph:start-node",
+        action: "select",
+        value: "A",
+      },
+    );
+    expect(result.replay?.visit_order).toEqual(["A", "B"]);
+  });
+
+  it("rejects commands that bypass or contradict the manifest", () => {
     expect(() => applyInteraction(
       script([step("graph", graph)], { domain: "algorithm", algorithm_id: "bfs" }),
       {
@@ -167,6 +254,18 @@ describe("BFS interaction", () => {
         action: "select",
         value: "A",
       },
+    )).toThrow("not declared by the manifest");
+
+    const contradictory = {
+      adapter_id: "algorithm.bfs",
+      step_id: "graph",
+      target_id: "step:graph:start-node",
+      action: "set-value",
+      value: "A",
+    } as unknown as InteractionCommand;
+    expect(() => applyInteraction(
+      script([step("graph", graph)], { domain: "algorithm", algorithm_id: "bfs" }),
+      contradictory,
     )).toThrow("not declared by the manifest");
   });
 });

--- a/apps/web/src/features/playbook/interaction/engine.ts
+++ b/apps/web/src/features/playbook/interaction/engine.ts
@@ -1,0 +1,274 @@
+import { compileExpr } from "../../../shared/lib/mathExpr";
+import type {
+  GraphSceneSnapshot,
+  MathPlotSnapshot,
+  MetaStep,
+  PlaybookScript,
+} from "../engine/types";
+import {
+  InteractionEngineError,
+  type InteractionAdapterManifest,
+  type InteractionBinding,
+  type InteractionCommand,
+  type InteractionManifest,
+  type InteractionResult,
+} from "./types";
+
+const DERIVATIVE_ADAPTER = "math.derivative-tangent" as const;
+const BFS_ADAPTER = "algorithm.bfs" as const;
+
+function bindingId(stepId: string, role: InteractionBinding["target_role"]): string {
+  return `step:${stepId}:${role}`;
+}
+
+function mathBindings(script: PlaybookScript): InteractionBinding[] {
+  return script.steps.flatMap((step) => {
+    const snapshot = step.snapshot;
+    if (
+      snapshot.kind !== "math_plot" ||
+      snapshot.marker_x == null ||
+      snapshot.curves.length === 0 ||
+      !Number.isFinite(snapshot.x_min) ||
+      !Number.isFinite(snapshot.x_max) ||
+      snapshot.x_min >= snapshot.x_max
+    ) return [];
+    return [{
+      id: bindingId(step.step_id, "marker-x"),
+      adapter_id: DERIVATIVE_ADAPTER,
+      step_id: step.step_id,
+      target_role: "marker-x",
+      action: "set-value",
+      label: "切点 x",
+      min: snapshot.x_min,
+      max: snapshot.x_max,
+      value: snapshot.marker_x,
+    }];
+  });
+}
+
+function bfsBindings(script: PlaybookScript): InteractionBinding[] {
+  if (script.algorithm_id?.toLowerCase() !== "bfs") return [];
+  return script.steps.flatMap((step) => {
+    const snapshot = step.snapshot;
+    if (snapshot.kind !== "graph_scene" || snapshot.nodes.length === 0) return [];
+    const ids = new Set(snapshot.nodes.map((node) => node.id));
+    if (ids.size !== snapshot.nodes.length || [...ids].some((id) => !id)) return [];
+    return [{
+      id: bindingId(step.step_id, "start-node"),
+      adapter_id: BFS_ADAPTER,
+      step_id: step.step_id,
+      target_role: "start-node",
+      action: "select",
+      label: "BFS 起点",
+      value: snapshot.current_node_id ?? snapshot.nodes[0].id,
+      options: snapshot.nodes.map((node) => ({ id: node.id, label: node.label ?? node.id })),
+    }];
+  });
+}
+
+export function deriveInteractionManifest(script: PlaybookScript): InteractionManifest {
+  const adapters: InteractionAdapterManifest[] = [];
+  const derivative = mathBindings(script);
+  const bfs = bfsBindings(script);
+  if (derivative.length) {
+    adapters.push({ adapter_id: DERIVATIVE_ADAPTER, experimental: true, bindings: derivative });
+  }
+  if (bfs.length) {
+    adapters.push({ adapter_id: BFS_ADAPTER, experimental: true, bindings: bfs });
+  }
+  return { version: "1", adapters };
+}
+
+function requireBinding(script: PlaybookScript, command: InteractionCommand): InteractionBinding {
+  const binding = deriveInteractionManifest(script).adapters
+    .find((adapter) => adapter.adapter_id === command.adapter_id)
+    ?.bindings.find((candidate) =>
+      candidate.id === command.target_id &&
+      candidate.step_id === command.step_id &&
+      candidate.action === command.action
+    );
+  if (!binding) {
+    throw new InteractionEngineError("Interaction target is not declared by the manifest");
+  }
+  return binding;
+}
+
+function finiteNumber(value: number | string, label: string): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new InteractionEngineError(`${label} must be a finite number`);
+  }
+  return parsed;
+}
+
+function concise(value: number): string {
+  return Number(value.toPrecision(12)).toString();
+}
+
+function updateMathSnapshot(snapshot: MathPlotSnapshot, markerX: number): MathPlotSnapshot {
+  if (markerX < snapshot.x_min || markerX > snapshot.x_max) {
+    throw new InteractionEngineError("Marker x is outside the declared plot bounds");
+  }
+  const lead = snapshot.curves.find((curve) =>
+    curve.semantic_role !== "tangent" && curve.semantic_role !== "normal"
+  );
+  if (!lead) throw new InteractionEngineError("Derivative interaction requires a source curve");
+
+  let fn: ReturnType<typeof compileExpr>;
+  try {
+    fn = compileExpr(lead.expression);
+  } catch {
+    throw new InteractionEngineError("Derivative interaction requires a valid source expression");
+  }
+
+  const scope = snapshot.params ?? {};
+  const h = Math.max(Math.abs(snapshot.x_max - snapshot.x_min) * 1e-5, 1e-6);
+  const left = Math.max(snapshot.x_min, markerX - h);
+  const right = Math.min(snapshot.x_max, markerX + h);
+  if (right <= left) throw new InteractionEngineError("Derivative cannot be sampled at this point");
+
+  let y: number;
+  let slope: number;
+  try {
+    y = fn({ ...scope, x: markerX });
+    slope = (fn({ ...scope, x: right }) - fn({ ...scope, x: left })) / (right - left);
+  } catch {
+    throw new InteractionEngineError("Derivative cannot be evaluated at this point");
+  }
+  if (!Number.isFinite(y) || !Number.isFinite(slope)) {
+    throw new InteractionEngineError("Derivative is not finite at this point");
+  }
+
+  const tangent = {
+    expression: `(${concise(slope)}) * (x - (${concise(markerX)})) + (${concise(y)})`,
+    label: `tangent @ x=${concise(markerX)}`,
+    emphasis: "accent",
+    semantic_role: "tangent",
+  };
+  const tangentIndex = snapshot.curves.findIndex((curve) => curve.semantic_role === "tangent");
+  const curves = [...snapshot.curves];
+  if (tangentIndex >= 0) curves[tangentIndex] = tangent;
+  else curves.push(tangent);
+  return { ...snapshot, marker_x: markerX, curves };
+}
+
+interface BfsState {
+  current: string;
+  visited: string[];
+  queue: string[];
+}
+
+function bfsTrace(graph: GraphSceneSnapshot, startId: string): BfsState[] {
+  const nodeIds = graph.nodes.map((node) => node.id);
+  if (!nodeIds.includes(startId)) {
+    throw new InteractionEngineError("Selected BFS start node does not exist");
+  }
+  const order = new Map(nodeIds.map((id, index) => [id, index]));
+  const adjacency = new Map(nodeIds.map((id) => [id, [] as string[]]));
+  for (const edge of graph.edges) {
+    if (!adjacency.has(edge.source) || !adjacency.has(edge.target)) {
+      throw new InteractionEngineError("BFS graph contains an edge with an unknown node");
+    }
+    adjacency.get(edge.source)?.push(edge.target);
+    if (!graph.directed) adjacency.get(edge.target)?.push(edge.source);
+  }
+  for (const neighbors of adjacency.values()) {
+    neighbors.sort((a, b) => (order.get(a) ?? 0) - (order.get(b) ?? 0));
+  }
+
+  const queue = [startId];
+  const queued = new Set(queue);
+  const visited: string[] = [];
+  const seen = new Set<string>();
+  const trace: BfsState[] = [];
+  while (queue.length) {
+    const current = queue.shift() as string;
+    queued.delete(current);
+    if (seen.has(current)) continue;
+    seen.add(current);
+    visited.push(current);
+    for (const neighbor of adjacency.get(current) ?? []) {
+      if (!seen.has(neighbor) && !queued.has(neighbor)) {
+        queue.push(neighbor);
+        queued.add(neighbor);
+      }
+    }
+    trace.push({ current, visited: [...visited], queue: [...queue] });
+  }
+  return trace;
+}
+
+function withSnapshot(step: MetaStep, snapshot: MathPlotSnapshot | GraphSceneSnapshot): MetaStep {
+  const layers = step.layers?.map((layer, index) =>
+    index === 0 && layer.body.kind === snapshot.kind ? { ...layer, body: snapshot } : layer
+  );
+  return { ...step, snapshot, ...(layers ? { layers } : {}) };
+}
+
+function applyDerivative(
+  script: PlaybookScript,
+  command: InteractionCommand,
+  binding: InteractionBinding,
+): { script: PlaybookScript; summary: string } {
+  const markerX = finiteNumber(command.value, "Marker x");
+  if (binding.min == null || binding.max == null || markerX < binding.min || markerX > binding.max) {
+    throw new InteractionEngineError("Marker x is outside the manifest bounds");
+  }
+  let updated = false;
+  const steps = script.steps.map((step) => {
+    if (step.step_id !== command.step_id || step.snapshot.kind !== "math_plot") return step;
+    updated = true;
+    return withSnapshot(step, updateMathSnapshot(step.snapshot, markerX));
+  });
+  if (!updated) throw new InteractionEngineError("Derivative step no longer exists");
+  return {
+    script: { ...script, steps },
+    summary: `Moved the tangent point to x=${concise(markerX)} and recomputed the local slope.`,
+  };
+}
+
+function applyBfs(
+  script: PlaybookScript,
+  command: InteractionCommand,
+): { script: PlaybookScript; summary: string } {
+  if (typeof command.value !== "string" || !command.value) {
+    throw new InteractionEngineError("BFS start node must be a stable node id");
+  }
+  const anchor = script.steps.find((step) => step.step_id === command.step_id);
+  if (!anchor || anchor.snapshot.kind !== "graph_scene") {
+    throw new InteractionEngineError("BFS graph step no longer exists");
+  }
+  const trace = bfsTrace(anchor.snapshot, command.value);
+  let graphIndex = 0;
+  const steps = script.steps.map((step) => {
+    if (step.snapshot.kind !== "graph_scene") return step;
+    const state = trace[Math.min(graphIndex, trace.length - 1)];
+    graphIndex += 1;
+    const snapshot: GraphSceneSnapshot = {
+      ...step.snapshot,
+      current_node_id: state.current,
+      active_node_ids: [state.current],
+      visited_node_ids: state.visited,
+      queue_node_ids: state.queue,
+      frontier_node_ids: state.queue,
+    };
+    return withSnapshot(step, snapshot);
+  });
+  return {
+    script: { ...script, steps },
+    summary: `Replayed BFS from node ${command.value}; visit order: ${trace
+      .map((state) => state.current).join(" → ")}.`,
+  };
+}
+
+export function applyInteraction(
+  script: PlaybookScript,
+  command: InteractionCommand,
+  sequence = 1,
+): InteractionResult {
+  const binding = requireBinding(script, command);
+  const applied = command.adapter_id === DERIVATIVE_ADAPTER
+    ? applyDerivative(script, command, binding)
+    : applyBfs(script, command);
+  return { ...applied, event: { ...command, sequence } };
+}

--- a/apps/web/src/features/playbook/interaction/engine.ts
+++ b/apps/web/src/features/playbook/interaction/engine.ts
@@ -7,6 +7,11 @@ import type {
 } from "../engine/types";
 import {
   InteractionEngineError,
+  type BfsInteractionBinding,
+  type BfsInteractionCommand,
+  type BfsInteractionReplay,
+  type DerivativeInteractionBinding,
+  type DerivativeInteractionCommand,
   type InteractionAdapterManifest,
   type InteractionBinding,
   type InteractionCommand,
@@ -21,17 +26,40 @@ function bindingId(stepId: string, role: InteractionBinding["target_role"]): str
   return `step:${stepId}:${role}`;
 }
 
-function mathBindings(script: PlaybookScript): InteractionBinding[] {
+function sourceCurve(snapshot: MathPlotSnapshot) {
+  return snapshot.curves.find((curve) =>
+    curve.semantic_role !== "tangent" && curve.semantic_role !== "normal"
+  );
+}
+
+function hasFiniteParams(snapshot: MathPlotSnapshot): boolean {
+  return Object.values(snapshot.params ?? {}).every(Number.isFinite);
+}
+
+function mathBindings(script: PlaybookScript): DerivativeInteractionBinding[] {
+  if (script.domain !== "math") return [];
   return script.steps.flatMap((step) => {
     const snapshot = step.snapshot;
     if (
       snapshot.kind !== "math_plot" ||
       snapshot.marker_x == null ||
-      snapshot.curves.length === 0 ||
+      !Number.isFinite(snapshot.marker_x) ||
       !Number.isFinite(snapshot.x_min) ||
       !Number.isFinite(snapshot.x_max) ||
-      snapshot.x_min >= snapshot.x_max
+      snapshot.x_min >= snapshot.x_max ||
+      snapshot.marker_x < snapshot.x_min ||
+      snapshot.marker_x > snapshot.x_max ||
+      !sourceCurve(snapshot) ||
+      !snapshot.curves.some((curve) => curve.semantic_role === "tangent") ||
+      !hasFiniteParams(snapshot)
     ) return [];
+
+    try {
+      estimateDerivative(snapshot, snapshot.marker_x);
+    } catch {
+      return [];
+    }
+
     return [{
       id: bindingId(step.step_id, "marker-x"),
       adapter_id: DERIVATIVE_ADAPTER,
@@ -46,13 +74,22 @@ function mathBindings(script: PlaybookScript): InteractionBinding[] {
   });
 }
 
-function bfsBindings(script: PlaybookScript): InteractionBinding[] {
+function validGraph(snapshot: GraphSceneSnapshot): boolean {
+  if (snapshot.nodes.length === 0) return false;
+  const ids = new Set(snapshot.nodes.map((node) => node.id));
+  if (ids.size !== snapshot.nodes.length || [...ids].some((id) => !id)) return false;
+  return snapshot.edges.every((edge) => ids.has(edge.source) && ids.has(edge.target));
+}
+
+function bfsBindings(script: PlaybookScript): BfsInteractionBinding[] {
   if (script.algorithm_id?.toLowerCase() !== "bfs") return [];
   return script.steps.flatMap((step) => {
     const snapshot = step.snapshot;
-    if (snapshot.kind !== "graph_scene" || snapshot.nodes.length === 0) return [];
-    const ids = new Set(snapshot.nodes.map((node) => node.id));
-    if (ids.size !== snapshot.nodes.length || [...ids].some((id) => !id)) return [];
+    if (snapshot.kind !== "graph_scene" || !validGraph(snapshot)) return [];
+    const selected = snapshot.current_node_id &&
+      snapshot.nodes.some((node) => node.id === snapshot.current_node_id)
+      ? snapshot.current_node_id
+      : snapshot.nodes[0].id;
     return [{
       id: bindingId(step.step_id, "start-node"),
       adapter_id: BFS_ADAPTER,
@@ -60,7 +97,7 @@ function bfsBindings(script: PlaybookScript): InteractionBinding[] {
       target_role: "start-node",
       action: "select",
       label: "BFS 起点",
-      value: snapshot.current_node_id ?? snapshot.nodes[0].id,
+      value: selected,
       options: snapshot.nodes.map((node) => ({ id: node.id, label: node.label ?? node.id })),
     }];
   });
@@ -85,6 +122,7 @@ function requireBinding(script: PlaybookScript, command: InteractionCommand): In
     ?.bindings.find((candidate) =>
       candidate.id === command.target_id &&
       candidate.step_id === command.step_id &&
+      candidate.adapter_id === command.adapter_id &&
       candidate.action === command.action
     );
   if (!binding) {
@@ -93,25 +131,20 @@ function requireBinding(script: PlaybookScript, command: InteractionCommand): In
   return binding;
 }
 
-function finiteNumber(value: number | string, label: string): number {
-  const parsed = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(parsed)) {
-    throw new InteractionEngineError(`${label} must be a finite number`);
-  }
-  return parsed;
-}
-
 function concise(value: number): string {
   return Number(value.toPrecision(12)).toString();
 }
 
-function updateMathSnapshot(snapshot: MathPlotSnapshot, markerX: number): MathPlotSnapshot {
-  if (markerX < snapshot.x_min || markerX > snapshot.x_max) {
-    throw new InteractionEngineError("Marker x is outside the declared plot bounds");
-  }
-  const lead = snapshot.curves.find((curve) =>
-    curve.semantic_role !== "tangent" && curve.semantic_role !== "normal"
-  );
+interface DerivativeEstimate {
+  y: number;
+  slope: number;
+}
+
+function estimateDerivative(
+  snapshot: MathPlotSnapshot,
+  markerX: number,
+): DerivativeEstimate {
+  const lead = sourceCurve(snapshot);
   if (!lead) throw new InteractionEngineError("Derivative interaction requires a source curve");
 
   let fn: ReturnType<typeof compileExpr>;
@@ -121,24 +154,54 @@ function updateMathSnapshot(snapshot: MathPlotSnapshot, markerX: number): MathPl
     throw new InteractionEngineError("Derivative interaction requires a valid source expression");
   }
 
+  const span = snapshot.x_max - snapshot.x_min;
+  const scale = Math.max(1, Math.abs(markerX));
+  const h = Math.max(1e-6, Math.min(Math.abs(span) * 1e-4, scale * 1e-3));
+  if (markerX - h < snapshot.x_min || markerX + h > snapshot.x_max) {
+    throw new InteractionEngineError("Derivative pilot requires a two-sided interior point");
+  }
+
   const scope = snapshot.params ?? {};
-  const h = Math.max(Math.abs(snapshot.x_max - snapshot.x_min) * 1e-5, 1e-6);
-  const left = Math.max(snapshot.x_min, markerX - h);
-  const right = Math.min(snapshot.x_max, markerX + h);
-  if (right <= left) throw new InteractionEngineError("Derivative cannot be sampled at this point");
+  const evaluate = (x: number): number => {
+    const value = fn({ ...scope, x });
+    if (!Number.isFinite(value)) {
+      throw new InteractionEngineError("Derivative is not finite at this point");
+    }
+    return value;
+  };
 
-  let y: number;
-  let slope: number;
-  try {
-    y = fn({ ...scope, x: markerX });
-    slope = (fn({ ...scope, x: right }) - fn({ ...scope, x: left })) / (right - left);
-  } catch {
-    throw new InteractionEngineError("Derivative cannot be evaluated at this point");
+  const y = evaluate(markerX);
+  const estimates = [h, h / 2, h / 4, h / 8].map((delta) => {
+    const left = (y - evaluate(markerX - delta)) / delta;
+    const right = (evaluate(markerX + delta) - y) / delta;
+    const central = (left + right) / 2;
+    if (![left, right, central].every(Number.isFinite)) {
+      throw new InteractionEngineError("Derivative is not finite at this point");
+    }
+    return { left, right, central };
+  });
+
+  const finest = estimates[estimates.length - 1];
+  const previous = estimates[estimates.length - 2];
+  const sideTolerance =
+    1e-5 + 5e-3 * Math.max(1, Math.abs(finest.left), Math.abs(finest.right));
+  if (Math.abs(finest.left - finest.right) > sideTolerance) {
+    throw new InteractionEngineError("The selected point is not differentiable");
   }
-  if (!Number.isFinite(y) || !Number.isFinite(slope)) {
-    throw new InteractionEngineError("Derivative is not finite at this point");
+  const convergenceTolerance =
+    1e-6 + 2e-3 * Math.max(1, Math.abs(finest.central), Math.abs(previous.central));
+  if (Math.abs(finest.central - previous.central) > convergenceTolerance) {
+    throw new InteractionEngineError("The derivative estimate does not converge");
   }
 
+  return { y, slope: finest.central };
+}
+
+function updateMathSnapshot(snapshot: MathPlotSnapshot, markerX: number): MathPlotSnapshot {
+  if (!Number.isFinite(markerX) || markerX < snapshot.x_min || markerX > snapshot.x_max) {
+    throw new InteractionEngineError("Marker x is outside the declared plot bounds");
+  }
+  const { y, slope } = estimateDerivative(snapshot, markerX);
   const tangent = {
     expression: `(${concise(slope)}) * (x - (${concise(markerX)})) + (${concise(y)})`,
     label: `tangent @ x=${concise(markerX)}`,
@@ -146,9 +209,11 @@ function updateMathSnapshot(snapshot: MathPlotSnapshot, markerX: number): MathPl
     semantic_role: "tangent",
   };
   const tangentIndex = snapshot.curves.findIndex((curve) => curve.semantic_role === "tangent");
+  if (tangentIndex < 0) {
+    throw new InteractionEngineError("Derivative interaction requires a declared tangent curve");
+  }
   const curves = [...snapshot.curves];
-  if (tangentIndex >= 0) curves[tangentIndex] = tangent;
-  else curves.push(tangent);
+  curves[tangentIndex] = tangent;
   return { ...snapshot, marker_x: markerX, curves };
 }
 
@@ -156,6 +221,12 @@ interface BfsState {
   current: string;
   visited: string[];
   queue: string[];
+  activeEdgeIds: string[];
+}
+
+interface BfsNeighbor {
+  nodeId: string;
+  edgeId: string | null;
 }
 
 function bfsTrace(graph: GraphSceneSnapshot, startId: string): BfsState[] {
@@ -163,39 +234,78 @@ function bfsTrace(graph: GraphSceneSnapshot, startId: string): BfsState[] {
   if (!nodeIds.includes(startId)) {
     throw new InteractionEngineError("Selected BFS start node does not exist");
   }
-  const order = new Map(nodeIds.map((id, index) => [id, index]));
-  const adjacency = new Map(nodeIds.map((id) => [id, [] as string[]]));
-  for (const edge of graph.edges) {
-    if (!adjacency.has(edge.source) || !adjacency.has(edge.target)) {
-      throw new InteractionEngineError("BFS graph contains an edge with an unknown node");
-    }
-    adjacency.get(edge.source)?.push(edge.target);
-    if (!graph.directed) adjacency.get(edge.target)?.push(edge.source);
-  }
-  for (const neighbors of adjacency.values()) {
-    neighbors.sort((a, b) => (order.get(a) ?? 0) - (order.get(b) ?? 0));
+  if (!validGraph(graph)) {
+    throw new InteractionEngineError("BFS graph is not valid");
   }
 
-  const queue = [startId];
-  const queued = new Set(queue);
+  const order = new Map(nodeIds.map((id, index) => [id, index]));
+  const adjacency = new Map(nodeIds.map((id) => [id, [] as BfsNeighbor[]]));
+  graph.edges.forEach((edge) => {
+    adjacency.get(edge.source)?.push({ nodeId: edge.target, edgeId: edge.id ?? null });
+    if (!graph.directed) {
+      adjacency.get(edge.target)?.push({ nodeId: edge.source, edgeId: edge.id ?? null });
+    }
+  });
+  for (const neighbors of adjacency.values()) {
+    neighbors.sort((a, b) => (order.get(a.nodeId) ?? 0) - (order.get(b.nodeId) ?? 0));
+  }
+
+  const queue: Array<{ nodeId: string; viaEdgeId: string | null }> = [{
+    nodeId: startId,
+    viaEdgeId: null,
+  }];
+  const queued = new Set([startId]);
   const visited: string[] = [];
   const seen = new Set<string>();
   const trace: BfsState[] = [];
+
   while (queue.length) {
-    const current = queue.shift() as string;
-    queued.delete(current);
-    if (seen.has(current)) continue;
-    seen.add(current);
-    visited.push(current);
-    for (const neighbor of adjacency.get(current) ?? []) {
-      if (!seen.has(neighbor) && !queued.has(neighbor)) {
-        queue.push(neighbor);
-        queued.add(neighbor);
+    const entry = queue.shift();
+    if (!entry) break;
+    queued.delete(entry.nodeId);
+    if (seen.has(entry.nodeId)) continue;
+    seen.add(entry.nodeId);
+    visited.push(entry.nodeId);
+
+    for (const neighbor of adjacency.get(entry.nodeId) ?? []) {
+      if (!seen.has(neighbor.nodeId) && !queued.has(neighbor.nodeId)) {
+        queue.push({ nodeId: neighbor.nodeId, viaEdgeId: neighbor.edgeId });
+        queued.add(neighbor.nodeId);
       }
     }
-    trace.push({ current, visited: [...visited], queue: [...queue] });
+    trace.push({
+      current: entry.nodeId,
+      visited: [...visited],
+      queue: queue.map((item) => item.nodeId),
+      activeEdgeIds: entry.viaEdgeId ? [entry.viaEdgeId] : [],
+    });
   }
   return trace;
+}
+
+function replaySnapshot(
+  graph: GraphSceneSnapshot,
+  state: BfsState,
+): GraphSceneSnapshot {
+  return {
+    ...graph,
+    nodes: graph.nodes.map((node) => ({
+      ...node,
+      emphasis: undefined,
+      asset_id: undefined,
+    })),
+    edges: graph.edges.map((edge) => ({
+      ...edge,
+      emphasis: undefined,
+      asset_id: undefined,
+    })),
+    current_node_id: state.current,
+    active_node_ids: [state.current],
+    active_edge_ids: state.activeEdgeIds,
+    visited_node_ids: state.visited,
+    queue_node_ids: state.queue,
+    frontier_node_ids: state.queue,
+  };
 }
 
 function withSnapshot(step: MetaStep, snapshot: MathPlotSnapshot | GraphSceneSnapshot): MetaStep {
@@ -207,57 +317,65 @@ function withSnapshot(step: MetaStep, snapshot: MathPlotSnapshot | GraphSceneSna
 
 function applyDerivative(
   script: PlaybookScript,
-  command: InteractionCommand,
-  binding: InteractionBinding,
+  command: DerivativeInteractionCommand,
+  binding: DerivativeInteractionBinding,
 ): { script: PlaybookScript; summary: string } {
-  const markerX = finiteNumber(command.value, "Marker x");
-  if (binding.min == null || binding.max == null || markerX < binding.min || markerX > binding.max) {
+  if (
+    !Number.isFinite(command.value) ||
+    command.value < binding.min ||
+    command.value > binding.max
+  ) {
     throw new InteractionEngineError("Marker x is outside the manifest bounds");
   }
+
   let updated = false;
   const steps = script.steps.map((step) => {
     if (step.step_id !== command.step_id || step.snapshot.kind !== "math_plot") return step;
     updated = true;
-    return withSnapshot(step, updateMathSnapshot(step.snapshot, markerX));
+    return withSnapshot(step, updateMathSnapshot(step.snapshot, command.value));
   });
   if (!updated) throw new InteractionEngineError("Derivative step no longer exists");
   return {
     script: { ...script, steps },
-    summary: `Moved the tangent point to x=${concise(markerX)} and recomputed the local slope.`,
+    summary: `Moved the tangent point to x=${concise(command.value)} and recomputed the local slope.`,
   };
 }
 
 function applyBfs(
   script: PlaybookScript,
-  command: InteractionCommand,
-): { script: PlaybookScript; summary: string } {
-  if (typeof command.value !== "string" || !command.value) {
+  command: BfsInteractionCommand,
+): { script: PlaybookScript; summary: string; replay: BfsInteractionReplay } {
+  if (!command.value) {
     throw new InteractionEngineError("BFS start node must be a stable node id");
   }
-  const anchor = script.steps.find((step) => step.step_id === command.step_id);
+  const anchorIndex = script.steps.findIndex((step) => step.step_id === command.step_id);
+  const anchor = script.steps[anchorIndex];
   if (!anchor || anchor.snapshot.kind !== "graph_scene") {
     throw new InteractionEngineError("BFS graph step no longer exists");
   }
+
   const trace = bfsTrace(anchor.snapshot, command.value);
-  let graphIndex = 0;
-  const steps = script.steps.map((step) => {
-    if (step.snapshot.kind !== "graph_scene") return step;
-    const state = trace[Math.min(graphIndex, trace.length - 1)];
-    graphIndex += 1;
-    const snapshot: GraphSceneSnapshot = {
-      ...step.snapshot,
-      current_node_id: state.current,
-      active_node_ids: [state.current],
-      visited_node_ids: state.visited,
-      queue_node_ids: state.queue,
-      frontier_node_ids: state.queue,
-    };
-    return withSnapshot(step, snapshot);
-  });
+  const frames = trace.map((state, index) => ({
+    index,
+    current_node_id: state.current,
+    visited_node_ids: state.visited,
+    queue_node_ids: state.queue,
+    snapshot: replaySnapshot(anchor.snapshot as GraphSceneSnapshot, state),
+  }));
+  const steps = [...script.steps];
+  steps[anchorIndex] = withSnapshot(anchor, frames[0].snapshot);
+  const visitOrder = trace.map((state) => state.current);
+
   return {
     script: { ...script, steps },
-    summary: `Replayed BFS from node ${command.value}; visit order: ${trace
-      .map((state) => state.current).join(" → ")}.`,
+    replay: {
+      adapter_id: BFS_ADAPTER,
+      step_id: command.step_id,
+      start_node_id: command.value,
+      visit_order: visitOrder,
+      frames,
+    },
+    summary: `Prepared BFS replay from node ${command.value}; visit order: ${visitOrder.join(" → ")}.`,
   };
 }
 
@@ -266,9 +384,20 @@ export function applyInteraction(
   command: InteractionCommand,
   sequence = 1,
 ): InteractionResult {
+  if (!Number.isInteger(sequence) || sequence < 1) {
+    throw new InteractionEngineError("Interaction event sequence must be a positive integer");
+  }
   const binding = requireBinding(script, command);
-  const applied = command.adapter_id === DERIVATIVE_ADAPTER
-    ? applyDerivative(script, command, binding)
-    : applyBfs(script, command);
+  if (command.adapter_id === DERIVATIVE_ADAPTER) {
+    if (binding.adapter_id !== DERIVATIVE_ADAPTER) {
+      throw new InteractionEngineError("Interaction binding type does not match the command");
+    }
+    const applied = applyDerivative(script, command, binding);
+    return { ...applied, event: { ...command, sequence } };
+  }
+  if (binding.adapter_id !== BFS_ADAPTER) {
+    throw new InteractionEngineError("Interaction binding type does not match the command");
+  }
+  const applied = applyBfs(script, command);
   return { ...applied, event: { ...command, sequence } };
 }

--- a/apps/web/src/features/playbook/interaction/types.ts
+++ b/apps/web/src/features/playbook/interaction/types.ts
@@ -1,23 +1,35 @@
-import type { PlaybookScript } from "../engine/types";
+import type { GraphSceneSnapshot, PlaybookScript } from "../engine/types";
 
 export type InteractionAdapterId =
   | "math.derivative-tangent"
   | "algorithm.bfs";
 
-export type InteractionAction = "set-value" | "select";
-
-export interface InteractionBinding {
+export interface DerivativeInteractionBinding {
   id: string;
-  adapter_id: InteractionAdapterId;
+  adapter_id: "math.derivative-tangent";
   step_id: string;
-  target_role: "marker-x" | "start-node";
-  action: InteractionAction;
+  target_role: "marker-x";
+  action: "set-value";
   label: string;
-  min?: number;
-  max?: number;
-  value?: number | string;
-  options?: Array<{ id: string; label: string }>;
+  min: number;
+  max: number;
+  value: number;
 }
+
+export interface BfsInteractionBinding {
+  id: string;
+  adapter_id: "algorithm.bfs";
+  step_id: string;
+  target_role: "start-node";
+  action: "select";
+  label: string;
+  value: string;
+  options: Array<{ id: string; label: string }>;
+}
+
+export type InteractionBinding =
+  | DerivativeInteractionBinding
+  | BfsInteractionBinding;
 
 export interface InteractionAdapterManifest {
   adapter_id: InteractionAdapterId;
@@ -30,22 +42,51 @@ export interface InteractionManifest {
   adapters: InteractionAdapterManifest[];
 }
 
-export interface InteractionCommand {
-  adapter_id: InteractionAdapterId;
+export interface DerivativeInteractionCommand {
+  adapter_id: "math.derivative-tangent";
   step_id: string;
   target_id: string;
-  action: InteractionAction;
-  value: number | string;
+  action: "set-value";
+  value: number;
 }
 
-export interface InteractionEvent extends InteractionCommand {
+export interface BfsInteractionCommand {
+  adapter_id: "algorithm.bfs";
+  step_id: string;
+  target_id: string;
+  action: "select";
+  value: string;
+}
+
+export type InteractionCommand =
+  | DerivativeInteractionCommand
+  | BfsInteractionCommand;
+
+export type InteractionEvent = InteractionCommand & {
   sequence: number;
+};
+
+export interface BfsInteractionReplayFrame {
+  index: number;
+  current_node_id: string;
+  visited_node_ids: string[];
+  queue_node_ids: string[];
+  snapshot: GraphSceneSnapshot;
+}
+
+export interface BfsInteractionReplay {
+  adapter_id: "algorithm.bfs";
+  step_id: string;
+  start_node_id: string;
+  visit_order: string[];
+  frames: BfsInteractionReplayFrame[];
 }
 
 export interface InteractionResult {
   script: PlaybookScript;
   event: InteractionEvent;
   summary: string;
+  replay?: BfsInteractionReplay;
 }
 
 export class InteractionEngineError extends Error {

--- a/apps/web/src/features/playbook/interaction/types.ts
+++ b/apps/web/src/features/playbook/interaction/types.ts
@@ -1,0 +1,56 @@
+import type { PlaybookScript } from "../engine/types";
+
+export type InteractionAdapterId =
+  | "math.derivative-tangent"
+  | "algorithm.bfs";
+
+export type InteractionAction = "set-value" | "select";
+
+export interface InteractionBinding {
+  id: string;
+  adapter_id: InteractionAdapterId;
+  step_id: string;
+  target_role: "marker-x" | "start-node";
+  action: InteractionAction;
+  label: string;
+  min?: number;
+  max?: number;
+  value?: number | string;
+  options?: Array<{ id: string; label: string }>;
+}
+
+export interface InteractionAdapterManifest {
+  adapter_id: InteractionAdapterId;
+  experimental: true;
+  bindings: InteractionBinding[];
+}
+
+export interface InteractionManifest {
+  version: "1";
+  adapters: InteractionAdapterManifest[];
+}
+
+export interface InteractionCommand {
+  adapter_id: InteractionAdapterId;
+  step_id: string;
+  target_id: string;
+  action: InteractionAction;
+  value: number | string;
+}
+
+export interface InteractionEvent extends InteractionCommand {
+  sequence: number;
+}
+
+export interface InteractionResult {
+  script: PlaybookScript;
+  event: InteractionEvent;
+  summary: string;
+}
+
+export class InteractionEngineError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InteractionEngineError";
+  }
+}


### PR DESCRIPTION
## Summary

Introduces the first deterministic foundation for the interaction engine discussed in #108.

- adds a versioned `InteractionManifest` plus discriminated, normalized commands and events
- derives only validated, allowlisted semantic bindings from `PlaybookScript`
- adds a derivative/tangent pilot with adaptive two-sided convergence checks
- rejects undeclared tangents, boundary points, non-finite parameters, cusps, and non-convergent derivative estimates
- adds a BFS pilot that selects a stable node id and produces a complete, separate replay bundle
- updates only the selected anchor graph preview; unrelated graph scenes are never rewritten
- clears stale node/edge visual state in generated BFS replay frames
- rejects malformed graph edges, undeclared targets, invalid values, and invalid event sequences
- keeps the source `PlaybookScript` immutable and marks both adapters experimental

## Product boundaries

- sandbox-only; no persistence or lesson-version mutation
- no raw DOM selectors, pointer streams, arbitrary JSON Patch, or automatic AI calls
- BFS replay frames are data only in this PR; playback UI is a follow-up
- direct canvas drag, mobile controls, explicit follow-up handoff, and apply-to-new-version remain follow-ups
- this PR is intentionally Draft and must not be merged yet

## Validation

The GitHub Actions `Check` workflow runs lint, tests, build, and coverage. Focused tests include:

- manifest validation and fail-closed behavior
- tangent recomputation, bounds, non-differentiable points, and event sequencing
- complete BFS visit order
- directed/disconnected/self-loop/duplicate-edge behavior
- malformed-edge rejection
- isolation from unrelated graph scenes
- source-script immutability

Related: #108
