### PR TITLE
feat: explain sandbox interactions explicitly

### DIFF
--- a/apps/api/app/application/dto/followup_dto.py
+++ b/apps/api/app/application/dto/followup_dto.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, model_validator
 
 from app.domain.models.director import DirectorScript
 from app.domain.models.playbook import PlaybookScript
@@ -13,13 +13,82 @@ class FollowUpChatMessage(BaseModel):
     content: str = Field(min_length=1, max_length=2000)
 
 
+class DerivativeInteractionEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    adapter_id: Literal["math.derivative-tangent"]
+    step_id: str = Field(min_length=1, max_length=120)
+    target_id: str = Field(min_length=1, max_length=180)
+    action: Literal["set-value"]
+    value: FiniteFloat
+    sequence: int = Field(ge=1, le=10_000)
+
+    @model_validator(mode="after")
+    def validate_semantic_target(self) -> "DerivativeInteractionEvent":
+        if self.target_id != f"step:{self.step_id}:marker-x":
+            raise ValueError("derivative interaction target must be the semantic marker-x id")
+        return self
+
+
+class BfsInteractionEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    adapter_id: Literal["algorithm.bfs"]
+    step_id: str = Field(min_length=1, max_length=120)
+    target_id: str = Field(min_length=1, max_length=180)
+    action: Literal["select"]
+    value: str = Field(min_length=1, max_length=120)
+    sequence: int = Field(ge=1, le=10_000)
+
+    @model_validator(mode="after")
+    def validate_semantic_target(self) -> "BfsInteractionEvent":
+        if self.target_id != f"step:{self.step_id}:start-node":
+            raise ValueError("BFS interaction target must be the semantic start-node id")
+        return self
+
+
+InteractionEvent = Annotated[
+    DerivativeInteractionEvent | BfsInteractionEvent,
+    Field(discriminator="adapter_id"),
+]
+
+
+class InteractionFollowUpContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    manifest_version: Literal["1"]
+    events: list[InteractionEvent] = Field(min_length=1, max_length=20)
+
+    @model_validator(mode="after")
+    def validate_event_order(self) -> "InteractionFollowUpContext":
+        sequences = [event.sequence for event in self.events]
+        if any(
+            current != previous + 1
+            for previous, current in zip(sequences, sequences[1:], strict=False)
+        ):
+            raise ValueError("interaction event sequences must be contiguous and increasing")
+        return self
+
+
 class FollowUpRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     message: str = Field(min_length=1, max_length=2000)
     messages: list[FollowUpChatMessage] = Field(default_factory=list, max_length=12)
+    intent: Literal["conversation", "explain_interaction"] = "conversation"
+    interaction_context: InteractionFollowUpContext | None = None
     base_version_id: str | None = Field(default=None, max_length=80)
     provider_api_key: str | None = Field(default=None, max_length=4096)
     provider_base_url: str | None = Field(default=None, max_length=512)
     provider_model: str | None = Field(default=None, max_length=128)
+
+    @model_validator(mode="after")
+    def validate_interaction_intent(self) -> "FollowUpRequest":
+        if self.intent == "explain_interaction" and self.interaction_context is None:
+            raise ValueError("explain_interaction requires interaction_context")
+        if self.intent == "conversation" and self.interaction_context is not None:
+            raise ValueError("interaction_context is only accepted for explicit explanation")
+        return self
 
 
 class FollowUpResponse(BaseModel):

--- a/apps/api/app/application/use_cases/follow_up.py
+++ b/apps/api/app/application/use_cases/follow_up.py
@@ -7,7 +7,11 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from app.application.dto.followup_dto import FollowUpChatMessage, FollowUpRequest
+from app.application.dto.followup_dto import (
+    FollowUpChatMessage,
+    FollowUpRequest,
+    InteractionFollowUpContext,
+)
 from app.application.ports.llm_provider import ILLMProvider
 from app.domain.models.playbook import PlaybookScript
 
@@ -42,18 +46,28 @@ class FollowUpPatchUseCase:
     async def execute(
         self, playbook: PlaybookScript, request: FollowUpRequest
     ) -> FollowUpPatchResult:
-        system = _build_system_prompt()
-        user = _build_user_prompt(playbook, request.message, request.messages)
+        allow_patch = request.intent == "conversation"
+        system = _build_system_prompt(request.intent)
+        user = _build_user_prompt(
+            playbook,
+            request.message,
+            request.messages,
+            request.interaction_context,
+        )
         first_raw = await self._llm.complete(system, user)
         try:
-            return self._parse_and_apply(playbook, first_raw)
+            return self._parse_and_apply(playbook, first_raw, allow_patch=allow_patch)
         except FollowUpPatchError as first_error:
             repair_user = _build_repair_prompt(playbook, request.message, first_raw, first_error)
             repair_raw = await self._llm.complete(system, repair_user)
-            return self._parse_and_apply(playbook, repair_raw)
+            return self._parse_and_apply(playbook, repair_raw, allow_patch=allow_patch)
 
     def _parse_and_apply(
-        self, playbook: PlaybookScript, raw: str
+        self,
+        playbook: PlaybookScript,
+        raw: str,
+        *,
+        allow_patch: bool = True,
     ) -> FollowUpPatchResult:
         payload = _parse_llm_payload(raw)
         reply = str(payload.get("reply") or "").strip()
@@ -65,6 +79,13 @@ class FollowUpPatchUseCase:
             raise FollowUpPatchError("change_summary must be a non-empty string")
         if not isinstance(patch, list):
             raise FollowUpPatchError("patch must be a JSON array")
+        if not allow_patch:
+            return FollowUpPatchResult(
+                reply=reply,
+                change_summary="explain: interaction context",
+                patch=[],
+                playbook=None,
+            )
         if len(patch) == 0:
             return FollowUpPatchResult(
                 reply=reply,
@@ -88,7 +109,13 @@ class FollowUpPatchUseCase:
         )
 
 
-def _build_system_prompt() -> str:
+def _build_system_prompt(intent: str = "conversation") -> str:
+    explicit_interaction_rule = (
+        "\n当前请求是用户显式点击“解释我的操作”后发起的。"
+        "只解释 interaction_context 中的语义事件，不得修改 Playbook；patch 必须为 []。\n"
+        if intent == "explain_interaction"
+        else ""
+    )
     return """你是 MetaView 的 Playbook 局部修改助手。
 你会收到当前 PlaybookScript JSON、用户追问和最近对话。
 如果用户只是追问概念、步骤原因或文字解释，可以只回答问题；如果用户要求调整讲解、
@@ -113,11 +140,14 @@ patch 使用 RFC 6902 子集，只能使用 add/remove/replace。
 允许修改的路径根：/title, /summary, /steps, /parameter_controls, /algorithm_id, /initial_data。
 可以一次修改多个 step，也可以修改任意合法 renderer 的 snapshot/layers。
 parameter_controls.*.value 和 initial_data.*[] 必须是字符串，即使表示数字也写成 "2"。
-不要修改 fps、total_frames、end_frame；服务端会重新规范化时间线。"""
+不要修改 fps、total_frames、end_frame；服务端会重新规范化时间线。""" + explicit_interaction_rule
 
 
 def _build_user_prompt(
-    playbook: PlaybookScript, message: str, messages: list[FollowUpChatMessage]
+    playbook: PlaybookScript,
+    message: str,
+    messages: list[FollowUpChatMessage],
+    interaction_context: InteractionFollowUpContext | None = None,
 ) -> str:
     history = [
         {"role": item.role, "content": item.content}
@@ -128,6 +158,11 @@ def _build_user_prompt(
             "current_playbook": playbook.model_dump(mode="json"),
             "conversation": history,
             "user_request": message,
+            "interaction_context": (
+                interaction_context.model_dump(mode="json")
+                if interaction_context is not None
+                else None
+            ),
         },
         ensure_ascii=False,
     )

--- a/apps/api/tests/test_follow_up_prompt.py
+++ b/apps/api/tests/test_follow_up_prompt.py
@@ -18,9 +18,11 @@ class SequenceLLM:
     def __init__(self, responses: list[str]) -> None:
         self.responses = list(responses)
         self.calls = 0
+        self.requests: list[tuple[str, str]] = []
 
-    async def complete(self, system: str, user: str) -> str:  # noqa: ARG002
+    async def complete(self, system: str, user: str) -> str:
         self.calls += 1
+        self.requests.append((system, user))
         if len(self.responses) == 1:
             return self.responses[0]
         return self.responses.pop(0)
@@ -33,6 +35,85 @@ def test_followup_prompt_guides_students_without_direct_homework_answers() -> No
     assert "不要直接给出作业答案" in prompt
     assert "一次只问一个问题" in prompt
     assert "patch 必须是空数组 []" in prompt
+
+
+@pytest.mark.asyncio
+async def test_explicit_interaction_explanation_injects_semantic_context_without_patch() -> None:
+    llm = SequenceLLM([
+        _payload([{"op": "replace", "path": "/title", "value": "不应写入"}]),
+    ])
+    use_case = FollowUpPatchUseCase(llm, default_step_frames=60)
+    request = FollowUpRequest.model_validate(
+        {
+            "message": "请解释我刚才的操作",
+            "intent": "explain_interaction",
+            "interaction_context": {
+                "manifest_version": "1",
+                "events": [
+                    {
+                        "adapter_id": "math.derivative-tangent",
+                        "step_id": "step_01",
+                        "target_id": "step:step_01:marker-x",
+                        "action": "set-value",
+                        "value": 3,
+                        "sequence": 1,
+                    }
+                ],
+            },
+        }
+    )
+
+    result = await use_case.execute(_playbook(), request)
+
+    assert result.playbook is None
+    assert result.patch == []
+    assert result.change_summary == "explain: interaction context"
+    system, user = llm.requests[0]
+    assert "解释我的操作" in system
+    payload = json.loads(user)
+    assert payload["interaction_context"]["events"][0]["value"] == 3.0
+
+
+def test_interaction_context_rejects_raw_targets_and_implicit_attachment() -> None:
+    event = {
+        "adapter_id": "algorithm.bfs",
+        "step_id": "graph",
+        "target_id": "#graph > circle:first-child",
+        "action": "select",
+        "value": "A",
+        "sequence": 1,
+    }
+
+    with pytest.raises(ValueError, match="semantic start-node"):
+        FollowUpRequest.model_validate(
+            {
+                "message": "解释",
+                "intent": "explain_interaction",
+                "interaction_context": {"manifest_version": "1", "events": [event]},
+            }
+        )
+
+    event["target_id"] = "step:graph:start-node"
+    with pytest.raises(ValueError, match="only accepted for explicit explanation"):
+        FollowUpRequest.model_validate(
+            {
+                "message": "普通追问",
+                "interaction_context": {"manifest_version": "1", "events": [event]},
+            }
+        )
+
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        FollowUpRequest.model_validate(
+            {
+                "message": "解释",
+                "intent": "explain_interaction",
+                "interaction_context": {
+                    "manifest_version": "1",
+                    "events": [event],
+                },
+                "patch": [{"op": "replace", "path": "/title", "value": "bad"}],
+            }
+        )
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_router_followups.py
+++ b/apps/api/tests/test_router_followups.py
@@ -223,6 +223,46 @@ def test_followup_can_reply_without_creating_version(monkeypatch, tmp_path) -> N
     assert history["versions"] == []
 
 
+def test_explicit_interaction_explanation_cannot_create_a_version(followup_client) -> None:
+    client, repo, _director_repo, llm = followup_client
+    run_id = _seed_run(repo)
+    original = _run(repo.get(run_id))
+    assert original is not None
+
+    response = client.post(
+        f"/api/v1/runs/{run_id}/follow-up",
+        json={
+            "message": "请解释我刚才的操作",
+            "intent": "explain_interaction",
+            "interaction_context": {
+                "manifest_version": "1",
+                "events": [
+                    {
+                        "adapter_id": "algorithm.bfs",
+                        "step_id": "step_01",
+                        "target_id": "step:step_01:start-node",
+                        "action": "select",
+                        "value": "A",
+                        "sequence": 1,
+                    }
+                ],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["kind"] == "reply"
+    assert response.json()["version_id"] is None
+    assert llm.calls == 1
+    stored = _run(repo.get(run_id))
+    assert stored is not None
+    assert stored.playbook == original.playbook
+    history = client.get(f"/api/v1/runs/{run_id}/follow-ups").json()
+    assert history["followups"][0]["patch_json"] == "[]"
+    assert history["followups"][0]["change_summary"] == "explain: interaction context"
+    assert history["versions"] == []
+
+
 def test_followup_repairs_invalid_patch_once(monkeypatch, tmp_path) -> None:
     get_settings.cache_clear()
     monkeypatch.setenv("METAVIEW_OPENAI_API_KEY", "sk-server")

--- a/apps/web/src/features/followups/api/followupApi.test.ts
+++ b/apps/web/src/features/followups/api/followupApi.test.ts
@@ -60,6 +60,50 @@ describe("followupApi", () => {
     expect(result.version_id).toBeNull();
   });
 
+  it("sends semantic interaction context only for an explicit explanation", async () => {
+    let requestBody: unknown = null;
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/runs/run-1/follow-up`, async ({ request }) => {
+        requestBody = await request.json();
+        return HttpResponse.json({
+          kind: "reply",
+          reply: "切点右移后，局部斜率变大。",
+          change_summary: "explain: interaction context",
+          version_id: null,
+          playbook: null,
+        });
+      }),
+    );
+
+    await submitRunFollowUp(
+      "run-1",
+      "请解释我刚才的操作",
+      [],
+      undefined,
+      undefined,
+      {
+        manifest_version: "1",
+        events: [{
+          adapter_id: "math.derivative-tangent",
+          step_id: "plot",
+          target_id: "step:plot:marker-x",
+          action: "set-value",
+          value: 3,
+          sequence: 1,
+        }],
+      },
+    );
+
+    expect(requestBody).toMatchObject({
+      message: "请解释我刚才的操作",
+      intent: "explain_interaction",
+      interaction_context: {
+        manifest_version: "1",
+        events: [{ target_id: "step:plot:marker-x", value: 3 }],
+      },
+    });
+  });
+
   it("loads follow-up history and restores versions", async () => {
     server.use(
       http.post(`${API_BASE_URL}/api/v1/runs/run-1/versions/v0/restore`, ({ request }) => {

--- a/apps/web/src/features/followups/api/followupApi.ts
+++ b/apps/web/src/features/followups/api/followupApi.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL, readErrorMessage } from "../../../shared/api/httpClient";
 import type { DirectorScript, PlaybookScript } from "../../playbook/engine/types";
+import type { InteractionFollowUpContext } from "../../playbook/interaction/types";
 import type { ProviderSettings } from "../../providers/hooks/useProviderSettings";
 
 export interface FollowUpChatMessage {
@@ -51,6 +52,7 @@ export async function submitRunFollowUp(
   messages: FollowUpChatMessage[],
   provider?: ProviderSettings,
   signal?: AbortSignal,
+  interactionContext?: InteractionFollowUpContext,
 ): Promise<FollowUpResponse> {
   const response = await fetch(`${API_BASE_URL}/api/v1/runs/${runId}/follow-up`, {
     method: "POST",
@@ -59,6 +61,8 @@ export async function submitRunFollowUp(
     body: JSON.stringify({
       message,
       messages,
+      intent: interactionContext ? "explain_interaction" : "conversation",
+      interaction_context: interactionContext ?? null,
       provider_api_key: provider?.apiKey || null,
       provider_base_url: provider?.baseUrl || null,
       provider_model: provider?.model || null,

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.test.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.test.tsx
@@ -937,8 +937,8 @@ describe("PlaybookPlayer", () => {
       manifest_version: "1",
       events: [expect.objectContaining({
         adapter_id: "math.derivative-tangent",
-        step_id: "s1",
-        target_id: "step:s1:marker-x",
+        step_id: "plot",
+        target_id: "step:plot:marker-x",
         action: "set-value",
         value: 2,
         sequence: 1,

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.test.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.test.tsx
@@ -913,6 +913,39 @@ describe("PlaybookPlayer", () => {
       .toBe("2");
   });
 
+  it("hands semantic sandbox events to AI only through the explicit explain button", async () => {
+    const onExplainInteraction = vi.fn().mockResolvedValue(undefined);
+    const view = render(
+      <PlaybookPlayer
+        script={derivativeScript()}
+        theme="light"
+        enableInteractionSandbox
+        onExplainInteraction={onExplainInteraction}
+      />,
+    );
+
+    expect(onExplainInteraction).not.toHaveBeenCalled();
+    const slider = view.getByRole("slider", { name: "切点 x" });
+    fireEvent.change(slider, { target: { value: "2" } });
+    fireEvent.pointerUp(slider);
+    expect(onExplainInteraction).not.toHaveBeenCalled();
+
+    fireEvent.click(view.getByRole("button", { name: "解释我的操作" }));
+
+    await waitFor(() => expect(onExplainInteraction).toHaveBeenCalledTimes(1));
+    expect(onExplainInteraction).toHaveBeenCalledWith({
+      manifest_version: "1",
+      events: [expect.objectContaining({
+        adapter_id: "math.derivative-tangent",
+        step_id: "s1",
+        target_id: "step:s1:marker-x",
+        action: "set-value",
+        value: 2,
+        sequence: 1,
+      })],
+    });
+  });
+
   it("keeps recovery controls after navigating away from the bound plot", async () => {
     const view = render(
       <PlaybookPlayer

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
@@ -29,6 +29,7 @@ import { SPEED_STEPS } from "./playbackRates";
 import type { RendererInteractionEvent } from "../renderers/types";
 import { InteractionSandboxPanel } from "../../interaction/InteractionSandboxPanel";
 import { useInteractionSandbox } from "../../interaction/useInteractionSandbox";
+import type { InteractionFollowUpContext } from "../../interaction/types";
 
 export type PlaybookLayoutMode = "desktop" | "portrait";
 
@@ -76,6 +77,8 @@ interface PlaybookPlayerProps {
   showLearningConsole?: boolean;
   /** Opt-in browser-only sandbox controls. Read-only player surfaces leave this disabled. */
   enableInteractionSandbox?: boolean;
+  /** Explicit user-triggered handoff of normalized semantic events to follow-up AI. */
+  onExplainInteraction?: (context: InteractionFollowUpContext) => Promise<void>;
   topbarCollapsed?: boolean;
   onToggleTopbar?: () => void;
   layoutMode?: PlaybookLayoutMode;
@@ -91,6 +94,7 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
   relatedSlot,
   showLearningConsole = true,
   enableInteractionSandbox = false,
+  onExplainInteraction,
   topbarCollapsed = false,
   onToggleTopbar,
   layoutMode,
@@ -335,6 +339,7 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
       onApply={interactionSandbox.apply}
       onUndo={interactionSandbox.undo}
       onReset={interactionSandbox.reset}
+      onExplainInteraction={onExplainInteraction}
     />
   ) : undefined;
   const isDark = theme === "dark";

--- a/apps/web/src/features/playbook/interaction/InteractionSandboxPanel.test.tsx
+++ b/apps/web/src/features/playbook/interaction/InteractionSandboxPanel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { InteractionSandboxPanel } from "./InteractionSandboxPanel";
@@ -295,5 +295,46 @@ describe("InteractionSandboxPanel", () => {
     expect(reset.disabled).toBe(false);
     fireEvent.click(reset);
     expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows semantic event summaries and explains them only after an explicit click", async () => {
+    const onExplainInteraction = vi.fn().mockResolvedValue(undefined);
+    const event = {
+      adapter_id: "math.derivative-tangent" as const,
+      step_id: "plot",
+      target_id: "step:plot:marker-x",
+      action: "set-value" as const,
+      value: 3,
+      sequence: 1,
+    };
+    const view = render(
+      <InteractionSandboxPanel
+        manifest={derivativeManifest}
+        currentStepId="plot"
+        events={[event]}
+        dirty
+        canUndo
+        lastError={null}
+        latestReplay={null}
+        onShowReplayFrame={vi.fn()}
+        onApply={vi.fn()}
+        onUndo={vi.fn()}
+        onReset={vi.fn()}
+        onExplainInteraction={onExplainInteraction}
+      />,
+    );
+
+    expect(view.getByText("把切点 x 调到 3")).toBeTruthy();
+    expect(onExplainInteraction).not.toHaveBeenCalled();
+
+    fireEvent.click(view.getByRole("button", { name: "解释我的操作" }));
+
+    expect(onExplainInteraction).toHaveBeenCalledWith({
+      manifest_version: "1",
+      events: [event],
+    });
+    await waitFor(() => {
+      expect(view.getByRole("button", { name: "解释我的操作" })).toBeTruthy();
+    });
   });
 });

--- a/apps/web/src/features/playbook/interaction/InteractionSandboxPanel.tsx
+++ b/apps/web/src/features/playbook/interaction/InteractionSandboxPanel.tsx
@@ -1,11 +1,16 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
+import {
+  buildInteractionFollowUpContext,
+  describeInteractionEvent,
+} from "./followUpContext";
 import type {
   BfsInteractionBinding,
   BfsInteractionReplay,
   DerivativeInteractionBinding,
   InteractionCommand,
   InteractionEvent,
+  InteractionFollowUpContext,
   InteractionManifest,
 } from "./types";
 
@@ -21,6 +26,7 @@ interface InteractionSandboxPanelProps {
   onApply: (command: InteractionCommand) => void;
   onUndo: () => void;
   onReset: () => void;
+  onExplainInteraction?: (context: InteractionFollowUpContext) => Promise<void>;
 }
 
 function RangeBinding({
@@ -213,13 +219,35 @@ export function InteractionSandboxPanel({
   onApply,
   onUndo,
   onReset,
+  onExplainInteraction,
 }: InteractionSandboxPanelProps) {
+  const [explainPending, setExplainPending] = useState(false);
   const binding = useMemo(
     () => manifest.adapters
       .flatMap((adapter) => adapter.bindings)
       .find((candidate) => candidate.step_id === currentStepId) ?? null,
     [currentStepId, manifest],
   );
+  const explanationContext = useMemo(
+    () => buildInteractionFollowUpContext(events),
+    [events],
+  );
+  const recentEventSummaries = useMemo(
+    () => events.slice(-4).map(describeInteractionEvent),
+    [events],
+  );
+
+  const explainInteraction = async () => {
+    if (!onExplainInteraction || !explanationContext || explainPending) return;
+    setExplainPending(true);
+    try {
+      await onExplainInteraction(explanationContext);
+    } catch {
+      // The owning follow-up surface renders request failures in its message stream.
+    } finally {
+      setExplainPending(false);
+    }
+  };
 
   if (!binding && !dirty && !lastError) return null;
 
@@ -229,6 +257,22 @@ export function InteractionSandboxPanel({
         <span>沙盒预览</span>
         <small>{dirty ? `${events.length} 个未保存操作` : "不会修改原课程"}</small>
       </div>
+
+      {recentEventSummaries.length > 0 && (
+        <div className="playbook-interaction__summary" aria-label="未保存操作摘要">
+          <span>最近操作</span>
+          <ol>
+            {recentEventSummaries.map((summary, index) => (
+              <li key={`${events.length - recentEventSummaries.length + index}:${summary}`}>
+                {summary}
+              </li>
+            ))}
+          </ol>
+          {events.length > recentEventSummaries.length && (
+            <small>另有 {events.length - recentEventSummaries.length} 个更早操作</small>
+          )}
+        </div>
+      )}
 
       {binding?.target_role === "marker-x" ? (
         <RangeBinding
@@ -268,6 +312,17 @@ export function InteractionSandboxPanel({
       )}
 
       <div className="playbook-interaction__actions">
+        {onExplainInteraction && (
+          <button
+            type="button"
+            className="playbook-interaction__explain"
+            onClick={explainInteraction}
+            disabled={!explanationContext || explainPending}
+            aria-busy={explainPending}
+          >
+            {explainPending ? "解释中…" : "解释我的操作"}
+          </button>
+        )}
         <button type="button" onClick={onUndo} disabled={!canUndo}>
           撤销
         </button>

--- a/apps/web/src/features/playbook/interaction/followUpContext.test.ts
+++ b/apps/web/src/features/playbook/interaction/followUpContext.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import type { InteractionEvent } from "./types";
+import {
+  buildInteractionFollowUpContext,
+  describeInteractionEvent,
+} from "./followUpContext";
+
+function event(sequence: number): InteractionEvent {
+  return {
+    adapter_id: "math.derivative-tangent",
+    step_id: "plot",
+    target_id: "step:plot:marker-x",
+    action: "set-value",
+    value: sequence / 10,
+    sequence,
+  };
+}
+
+describe("interaction follow-up context", () => {
+  it("returns null until the learner commits an interaction", () => {
+    expect(buildInteractionFollowUpContext([])).toBeNull();
+  });
+
+  it("copies only the latest twenty normalized events", () => {
+    const events = Array.from({ length: 25 }, (_, index) => event(index + 1));
+    const context = buildInteractionFollowUpContext(events);
+
+    expect(context?.manifest_version).toBe("1");
+    expect(context?.events).toHaveLength(20);
+    expect(context?.events[0].sequence).toBe(6);
+    expect(context?.events.at(-1)?.sequence).toBe(25);
+    expect(context?.events[0]).not.toBe(events[5]);
+  });
+
+  it("describes allowlisted derivative and BFS events for the visible summary", () => {
+    expect(describeInteractionEvent(event(20))).toBe("把切点 x 调到 2");
+    expect(describeInteractionEvent({
+      adapter_id: "algorithm.bfs",
+      step_id: "graph",
+      target_id: "step:graph:start-node",
+      action: "select",
+      value: "C",
+      sequence: 1,
+    })).toBe("把 BFS 起点选为 C");
+  });
+});

--- a/apps/web/src/features/playbook/interaction/followUpContext.ts
+++ b/apps/web/src/features/playbook/interaction/followUpContext.ts
@@ -1,0 +1,23 @@
+import type {
+  InteractionEvent,
+  InteractionFollowUpContext,
+} from "./types";
+
+const MAX_FOLLOW_UP_EVENTS = 20;
+
+export function buildInteractionFollowUpContext(
+  events: InteractionEvent[],
+): InteractionFollowUpContext | null {
+  if (events.length === 0) return null;
+  return {
+    manifest_version: "1",
+    events: events.slice(-MAX_FOLLOW_UP_EVENTS).map((event) => ({ ...event })),
+  };
+}
+
+export function describeInteractionEvent(event: InteractionEvent): string {
+  if (event.adapter_id === "math.derivative-tangent") {
+    return `把切点 x 调到 ${Number(event.value.toPrecision(12))}`;
+  }
+  return `把 BFS 起点选为 ${event.value}`;
+}

--- a/apps/web/src/features/playbook/interaction/types.ts
+++ b/apps/web/src/features/playbook/interaction/types.ts
@@ -66,6 +66,11 @@ export type InteractionEvent = InteractionCommand & {
   sequence: number;
 };
 
+export interface InteractionFollowUpContext {
+  manifest_version: "1";
+  events: InteractionEvent[];
+}
+
 export interface BfsInteractionReplayFrame {
   index: number;
   current_node_id: string;

--- a/apps/web/src/pages/Studio/StudioPage.test.tsx
+++ b/apps/web/src/pages/Studio/StudioPage.test.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 
 import { TWEAK_DEFAULTS } from "../../features/studio-editor/hooks/useTweaks";
 import type { PlaybookScript } from "../../features/playbook/engine/types";
+import type { InteractionFollowUpContext } from "../../features/playbook/interaction/types";
 import { server } from "../../mocks/server";
 import { API_BASE_URL } from "../../shared/config/constants";
 import { StudioPage } from "./StudioPage";
@@ -36,6 +37,7 @@ vi.mock("../../features/playbook/engine/player/PlaybookPlayer", async () => {
       topbarCollapsed = false,
       onToggleTopbar,
       onOpenExport,
+      onExplainInteraction,
       enableInteractionSandbox = false,
     }: {
       script: PlaybookScript;
@@ -44,6 +46,7 @@ vi.mock("../../features/playbook/engine/player/PlaybookPlayer", async () => {
       topbarCollapsed?: boolean;
       onToggleTopbar?: () => void;
       onOpenExport?: () => void;
+      onExplainInteraction?: (context: InteractionFollowUpContext) => Promise<void>;
       enableInteractionSandbox?: boolean;
     }) =>
       ReactModule.createElement(
@@ -68,6 +71,26 @@ vi.mock("../../features/playbook/engine/player/PlaybookPlayer", async () => {
               "button",
               { type: "button", onClick: onOpenExport },
               "导出",
+            )
+          : null,
+        onExplainInteraction
+          ? ReactModule.createElement(
+              "button",
+              {
+                type: "button",
+                onClick: () => void onExplainInteraction({
+                  manifest_version: "1",
+                  events: [{
+                    adapter_id: "math.derivative-tangent",
+                    step_id: "step_01",
+                    target_id: "step:step_01:marker-x",
+                    action: "set-value",
+                    value: 3,
+                    sequence: 1,
+                  }],
+                }),
+              },
+              "模拟解释我的操作",
             )
           : null,
         ReactModule.createElement("strong", null, script.title),
@@ -192,6 +215,72 @@ describe("StudioPage", () => {
     });
     expect(getByText("Original lesson")).toBeTruthy();
     expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("sends semantic interaction context only after the explicit explain action", async () => {
+    mockUsePipelinePoller.mockReturnValue({
+      playbook: playbook("Explicit lesson"),
+      director: null,
+      error: null,
+      isLoading: false,
+      status: "succeeded",
+    });
+    let listCalls = 0;
+    let postCalls = 0;
+    let submittedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/runs/run-1/follow-ups`, () => {
+        listCalls += 1;
+        return HttpResponse.json({ followups: [], versions: [] });
+      }),
+      http.post(`${API_BASE_URL}/api/v1/runs/run-1/follow-up`, async ({ request }) => {
+        postCalls += 1;
+        submittedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          kind: "reply",
+          reply: "你把切点移到了 x=3，因此切线斜率会随局部导数变化。",
+          change_summary: "explain: interaction context",
+          version_id: null,
+          playbook: null,
+          director: null,
+        });
+      }),
+    );
+
+    const view = render(
+      <StudioPage
+        runId="run-1"
+        t={TWEAK_DEFAULTS}
+        onNavigate={vi.fn()}
+        isProviderConfigured
+      />,
+    );
+
+    await waitFor(() => expect(listCalls).toBe(1));
+    expect(postCalls).toBe(0);
+
+    fireEvent.click(view.getByRole("button", { name: "模拟解释我的操作" }));
+
+    await waitFor(() => {
+      expect(view.getByText(/你把切点移到了 x=3/)).toBeTruthy();
+    });
+    expect(postCalls).toBe(1);
+    expect(submittedBody).toMatchObject({
+      message: "请解释我刚才的操作",
+      intent: "explain_interaction",
+      interaction_context: {
+        manifest_version: "1",
+        events: [{
+          adapter_id: "math.derivative-tangent",
+          step_id: "step_01",
+          target_id: "step:step_01:marker-x",
+          action: "set-value",
+          value: 3,
+          sequence: 1,
+        }],
+      },
+    });
+    expect(view.getByText("Explicit lesson")).toBeTruthy();
   });
 
   it("uses guided follow-up suggestions for study sessions", async () => {

--- a/apps/web/src/pages/Studio/StudioPage.tsx
+++ b/apps/web/src/pages/Studio/StudioPage.tsx
@@ -19,6 +19,7 @@ import {
   type RunVersionRecord,
 } from "../../features/followups/api/followupApi";
 import { FollowupCommitLog } from "../../features/followups/ui/FollowupCommitLog";
+import type { InteractionFollowUpContext } from "../../features/playbook/interaction/types";
 
 // ── Domain mapping ────────────────────────────────────────────────────────
 
@@ -59,6 +60,7 @@ interface ChatPanelProps {
   children: (slots: {
     followupSlot: React.ReactNode;
     relatedSlot: React.ReactNode;
+    onExplainInteraction?: (context: InteractionFollowUpContext) => Promise<void>;
   }) => React.ReactNode;
 }
 
@@ -125,7 +127,10 @@ function ChatPanel({
   const suggestions = DOMAIN_SUGGESTIONS[domain] ?? FALLBACK_SUGGESTIONS;
   const canModify = !!runId && !!playbook;
 
-  const send = async (text?: string) => {
+  const send = async (
+    text?: string,
+    interactionContext?: InteractionFollowUpContext,
+  ) => {
     const userText = (text ?? input).trim();
     if (!userText || pending || !canModify) return;
 
@@ -157,6 +162,7 @@ function ChatPanel({
         history,
         provider,
         abortRef.current.signal,
+        interactionContext,
       );
       if (result.kind === "patch" && result.playbook) {
         onPlaybookPatched(result.playbook, result.director);
@@ -341,7 +347,11 @@ function ChatPanel({
       />
     ) : null;
 
-  return <>{children({ followupSlot, relatedSlot })}</>;
+  const onExplainInteraction = canModify
+    ? (context: InteractionFollowUpContext) => send("请解释我刚才的操作", context)
+    : undefined;
+
+  return <>{children({ followupSlot, relatedSlot, onExplainInteraction })}</>;
 }
 
 // ── StudioPage ────────────────────────────────────────────────────────────
@@ -460,12 +470,13 @@ export function StudioPage({
                 }
               }}
             >
-              {({ followupSlot, relatedSlot }) => (
+              {({ followupSlot, relatedSlot, onExplainInteraction }) => (
                 <PlaybookPlayer
                   script={activePlaybook}
                   director={activeDirector}
                   theme={isDark ? "dark" : "light"}
                   enableInteractionSandbox
+                  onExplainInteraction={onExplainInteraction}
                   swapDurationFrames={t.swapFrames}
                   onOpenExport={canExport ? () => setExportOpen(true) : undefined}
                   topbarCollapsed={topbarCollapsed}

--- a/apps/web/src/styles/pages/playbook.css
+++ b/apps/web/src/styles/pages/playbook.css
@@ -799,6 +799,35 @@
   gap: 8px;
 }
 
+.playbook-interaction__summary {
+  display: grid;
+  gap: 5px;
+  padding: 8px 9px;
+  border: 1px solid var(--player-line-soft);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--player-paper-soft) 72%, transparent);
+  color: var(--player-ink-3);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.playbook-interaction__summary > span {
+  color: var(--player-ink-2);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.playbook-interaction__summary ol {
+  display: grid;
+  gap: 3px;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.playbook-interaction__summary small {
+  font-size: 10px;
+}
+
 .playbook-interaction__range input {
   width: 100%;
   accent-color: var(--player-accent);
@@ -847,7 +876,12 @@
   justify-content: flex-end;
 }
 
-.playbook-interaction__choice button:disabled,
+.playbook-interaction__actions .playbook-interaction__explain {
+  margin-right: auto;
+  border-color: color-mix(in srgb, var(--player-accent) 42%, var(--player-line));
+  color: var(--player-accent);
+}
+
 .playbook-interaction__actions button:disabled,
 .playbook-interaction__choice button:disabled,
 .playbook-interaction__replay-actions button:disabled {


### PR DESCRIPTION
## Summary
- add a visible semantic summary of unsaved sandbox operations
- expose “解释我的操作” only as an explicit user action in Studio
- send at most the last 20 normalized interaction events; never raw DOM targets, canvas data, or arbitrary patches
- force explanation requests to return an empty patch server-side, even if the model attempts a mutation
- keep History/Showcase/read-only players unchanged

## Safety boundaries
- no automatic AI call on drag, node selection, replay, undo, or reset
- `interaction_context` is accepted only with `intent=explain_interaction`
- semantic target IDs and contiguous event ordering are validated; unknown fields are rejected
- explanation calls cannot create a Playbook version or mutate the active lesson
- this PR remains Draft and must not be merged independently of the interaction stack

## Validation
- API: 957 tests passed
- Web: 123 files / 1042 tests passed
- focused interaction/follow-up tests: 53 passed
- ESLint: 0 errors (2 pre-existing Fast Refresh warnings)
- TypeScript + production build passed
- Ruff passed

## Stack / merge order
Logically stacked after Draft PR #131. The PR targets `main` temporarily so GitHub Actions validates the full tree. Recommended order remains #129 → #130 → #131 → #132.