### PR TITLE
feat: apply interaction sandbox as an atomic new version

### DIFF
--- a/apps/api/app/application/dto/followup_dto.py
+++ b/apps/api/app/application/dto/followup_dto.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from app.application.dto.interaction_dto import InteractionFollowUpContext
 from app.domain.models.director import DirectorScript
 from app.domain.models.playbook import PlaybookScript
 
@@ -11,63 +12,6 @@ from app.domain.models.playbook import PlaybookScript
 class FollowUpChatMessage(BaseModel):
     role: Literal["user", "assistant"]
     content: str = Field(min_length=1, max_length=2000)
-
-
-class DerivativeInteractionEvent(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    adapter_id: Literal["math.derivative-tangent"]
-    step_id: str = Field(min_length=1, max_length=120)
-    target_id: str = Field(min_length=1, max_length=180)
-    action: Literal["set-value"]
-    value: FiniteFloat
-    sequence: int = Field(ge=1, le=10_000)
-
-    @model_validator(mode="after")
-    def validate_semantic_target(self) -> "DerivativeInteractionEvent":
-        if self.target_id != f"step:{self.step_id}:marker-x":
-            raise ValueError("derivative interaction target must be the semantic marker-x id")
-        return self
-
-
-class BfsInteractionEvent(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    adapter_id: Literal["algorithm.bfs"]
-    step_id: str = Field(min_length=1, max_length=120)
-    target_id: str = Field(min_length=1, max_length=180)
-    action: Literal["select"]
-    value: str = Field(min_length=1, max_length=120)
-    sequence: int = Field(ge=1, le=10_000)
-
-    @model_validator(mode="after")
-    def validate_semantic_target(self) -> "BfsInteractionEvent":
-        if self.target_id != f"step:{self.step_id}:start-node":
-            raise ValueError("BFS interaction target must be the semantic start-node id")
-        return self
-
-
-InteractionEvent = Annotated[
-    DerivativeInteractionEvent | BfsInteractionEvent,
-    Field(discriminator="adapter_id"),
-]
-
-
-class InteractionFollowUpContext(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    manifest_version: Literal["1"]
-    events: list[InteractionEvent] = Field(min_length=1, max_length=20)
-
-    @model_validator(mode="after")
-    def validate_event_order(self) -> "InteractionFollowUpContext":
-        sequences = [event.sequence for event in self.events]
-        if any(
-            current != previous + 1
-            for previous, current in zip(sequences, sequences[1:], strict=False)
-        ):
-            raise ValueError("interaction event sequences must be contiguous and increasing")
-        return self
 
 
 class FollowUpRequest(BaseModel):

--- a/apps/api/app/application/dto/interaction_dto.py
+++ b/apps/api/app/application/dto/interaction_dto.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, model_validator
+
+from app.domain.models.director import DirectorScript
+from app.domain.models.playbook import PlaybookScript
+
+
+class StrictInteractionModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class DerivativeInteractionEvent(StrictInteractionModel):
+    adapter_id: Literal["math.derivative-tangent"]
+    step_id: str = Field(min_length=1, max_length=120)
+    target_id: str = Field(min_length=1, max_length=180)
+    action: Literal["set-value"]
+    value: FiniteFloat
+    sequence: int = Field(ge=1, le=10_000)
+
+    @model_validator(mode="after")
+    def validate_semantic_target(self) -> "DerivativeInteractionEvent":
+        if self.target_id != f"step:{self.step_id}:marker-x":
+            raise ValueError("derivative interaction target must be the semantic marker-x id")
+        return self
+
+
+class BfsInteractionEvent(StrictInteractionModel):
+    adapter_id: Literal["algorithm.bfs"]
+    step_id: str = Field(min_length=1, max_length=120)
+    target_id: str = Field(min_length=1, max_length=180)
+    action: Literal["select"]
+    value: str = Field(min_length=1, max_length=120)
+    sequence: int = Field(ge=1, le=10_000)
+
+    @model_validator(mode="after")
+    def validate_semantic_target(self) -> "BfsInteractionEvent":
+        if self.target_id != f"step:{self.step_id}:start-node":
+            raise ValueError("BFS interaction target must be the semantic start-node id")
+        return self
+
+
+InteractionEvent = Annotated[
+    DerivativeInteractionEvent | BfsInteractionEvent,
+    Field(discriminator="adapter_id"),
+]
+
+
+def _validate_event_order(
+    events: list[InteractionEvent],
+    *,
+    require_start_at_one: bool,
+) -> None:
+    sequences = [event.sequence for event in events]
+    if require_start_at_one and sequences and sequences[0] != 1:
+        raise ValueError("interaction event sequences must start at 1")
+    if any(
+        current != previous + 1
+        for previous, current in zip(sequences, sequences[1:], strict=False)
+    ):
+        raise ValueError("interaction event sequences must be contiguous and increasing")
+
+
+class InteractionFollowUpContext(StrictInteractionModel):
+    manifest_version: Literal["1"]
+    events: list[InteractionEvent] = Field(min_length=1, max_length=20)
+
+    @model_validator(mode="after")
+    def validate_event_order(self) -> "InteractionFollowUpContext":
+        _validate_event_order(self.events, require_start_at_one=False)
+        return self
+
+
+class ApplyInteractionVersionRequest(StrictInteractionModel):
+    manifest_version: Literal["1"]
+    events: list[InteractionEvent] = Field(min_length=1, max_length=100)
+    base_version_id: str | None = Field(default=None, max_length=80)
+
+    @model_validator(mode="after")
+    def validate_event_order(self) -> "ApplyInteractionVersionRequest":
+        _validate_event_order(self.events, require_start_at_one=True)
+        return self
+
+
+class ApplyInteractionVersionResponse(BaseModel):
+    version_id: str
+    summary: str
+    playbook: PlaybookScript
+    director: DirectorScript

--- a/apps/api/app/application/ports/run_repository.py
+++ b/apps/api/app/application/ports/run_repository.py
@@ -4,7 +4,12 @@ from typing import Protocol
 
 from app.application.dto.followup_dto import RunFollowUpRecord, RunVersionRecord
 from app.application.dto.pipeline_dto import PipelineRunResponse
+from app.domain.models.director import DirectorScript
 from app.domain.models.pipeline_run import PipelineRunStatus
+
+
+class InteractionVersionConflictError(RuntimeError):
+    """The interaction sandbox was based on a version that is no longer active."""
 
 
 class IRunRepository(Protocol):
@@ -85,6 +90,20 @@ class IRunRepository(Protocol):
         created_at: str,
         director_json: str | None = None,
     ) -> int: ...
+
+    async def commit_interaction_version(
+        self,
+        run_id: str,
+        *,
+        expected_base_version_id: str | None,
+        version_id: str,
+        initial_playbook_json: str,
+        playbook_json: str,
+        quality_report_json: str,
+        director: DirectorScript,
+        summary: str,
+        created_at: str,
+    ) -> None: ...
 
     async def attach_followup_version(self, followup_id: str, version_id: str) -> None: ...
 

--- a/apps/api/app/application/use_cases/follow_up.py
+++ b/apps/api/app/application/use_cases/follow_up.py
@@ -11,8 +11,8 @@ from pydantic import ValidationError
 from app.application.dto.followup_dto import (
     FollowUpChatMessage,
     FollowUpRequest,
-    InteractionFollowUpContext,
 )
+from app.application.dto.interaction_dto import InteractionFollowUpContext
 from app.application.ports.llm_provider import ILLMProvider
 from app.domain.models.director import DirectorScript
 from app.domain.models.playbook import PlaybookScript
@@ -157,7 +157,8 @@ class FollowUpPatchUseCase:
 def _build_system_prompt(intent: str = "conversation") -> str:
     explicit_interaction_rule = (
         "\n当前请求是用户显式点击“解释我的操作”后发起的。"
-        "只解释 interaction_context 中的语义事件，不得修改 Playbook；patch 必须为 []。\n"
+        "只解释 interaction_context 中的语义事件，不得修改 Playbook；"
+        "patch 必须为 []。\n"
         if intent == "explain_interaction"
         else ""
     )

--- a/apps/api/app/domain/services/interaction_apply.py
+++ b/apps/api/app/domain/services/interaction_apply.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import math
+from collections import deque
+from dataclasses import dataclass
+from typing import TypeVar
+
+from app.application.dto.interaction_dto import (
+    BfsInteractionEvent,
+    DerivativeInteractionEvent,
+    InteractionEvent,
+)
+from app.domain.models.playbook import (
+    GraphSceneSnapshot,
+    MathPlotCurve,
+    MathPlotSnapshot,
+    MetaStep,
+    PlaybookScript,
+)
+from app.domain.services.safe_math_expr import (
+    SafeMathExpressionError,
+    compile_safe_math_expression,
+)
+
+
+class InteractionApplyError(ValueError):
+    """Raised when normalized interaction events cannot be replayed safely."""
+
+
+_MAX_GRAPH_NODES = 500
+_MAX_GRAPH_EDGES = 2_000
+_SnapshotT = TypeVar("_SnapshotT", MathPlotSnapshot, GraphSceneSnapshot)
+
+
+@dataclass(frozen=True)
+class InteractionApplyResult:
+    playbook: PlaybookScript
+    summaries: list[str]
+
+    @property
+    def summary(self) -> str:
+        if len(self.summaries) == 1:
+            return self.summaries[0]
+        return f"Applied {len(self.summaries)} learner interactions."
+
+
+def apply_interaction_events(
+    playbook: PlaybookScript,
+    events: list[InteractionEvent],
+) -> InteractionApplyResult:
+    if not events:
+        raise InteractionApplyError("At least one interaction event is required")
+    current = playbook.model_copy(deep=True)
+    summaries: list[str] = []
+    for event in events:
+        if isinstance(event, DerivativeInteractionEvent):
+            summaries.append(_apply_derivative(current, event))
+        elif isinstance(event, BfsInteractionEvent):
+            summaries.append(_apply_bfs(current, event))
+        else:  # pragma: no cover - the DTO discriminator rejects this first
+            raise InteractionApplyError("Unsupported interaction adapter")
+    return InteractionApplyResult(playbook=current, summaries=summaries)
+
+
+def _single_step(playbook: PlaybookScript, step_id: str) -> MetaStep:
+    matches = [step for step in playbook.steps if step.step_id == step_id]
+    if len(matches) != 1:
+        raise InteractionApplyError("Interaction step must resolve to exactly one scene")
+    return matches[0]
+
+
+def _interaction_snapshot(
+    step: MetaStep,
+    snapshot_type: type[_SnapshotT],
+    kind: str,
+) -> _SnapshotT | None:
+    if not step.layers:
+        return step.snapshot if isinstance(step.snapshot, snapshot_type) else None
+    matching = [layer.body for layer in step.layers if layer.body.kind == kind]
+    if len(matching) != 1:
+        raise InteractionApplyError(
+            f"Interaction target must resolve to exactly one {kind} layer"
+        )
+    snapshot = matching[0]
+    return snapshot if isinstance(snapshot, snapshot_type) else None
+
+
+def _replace_snapshot(
+    step: MetaStep,
+    snapshot: MathPlotSnapshot | GraphSceneSnapshot,
+) -> None:
+    step.snapshot = snapshot
+    if not step.layers:
+        return
+    matching = [
+        index for index, layer in enumerate(step.layers) if layer.body.kind == snapshot.kind
+    ]
+    if len(matching) != 1:
+        raise InteractionApplyError(
+            f"Interaction target must resolve to exactly one {snapshot.kind} layer"
+        )
+    step.layers[matching[0]].body = snapshot.model_copy(deep=True)
+
+
+def _topic_value(playbook: PlaybookScript) -> str:
+    return getattr(playbook.domain, "value", str(playbook.domain))
+
+
+def _apply_derivative(
+    playbook: PlaybookScript,
+    event: DerivativeInteractionEvent,
+) -> str:
+    if _topic_value(playbook) != "math":
+        raise InteractionApplyError("Derivative interaction requires a math playbook")
+    step = _single_step(playbook, event.step_id)
+    snapshot = _interaction_snapshot(step, MathPlotSnapshot, "math_plot")
+    if snapshot is None:
+        raise InteractionApplyError("Derivative interaction requires a math plot scene")
+    if (
+        snapshot.marker_x is None
+        or not math.isfinite(snapshot.marker_x)
+        or not math.isfinite(snapshot.x_min)
+        or not math.isfinite(snapshot.x_max)
+        or snapshot.x_min >= snapshot.x_max
+        or not snapshot.x_min <= snapshot.marker_x <= snapshot.x_max
+        or any(not math.isfinite(value) for value in snapshot.params.values())
+    ):
+        raise InteractionApplyError("Derivative interaction manifest is not valid")
+
+    source = next(
+        (
+            curve
+            for curve in snapshot.curves
+            if curve.semantic_role not in {"tangent", "normal"}
+        ),
+        None,
+    )
+    tangent_index = next(
+        (
+            index
+            for index, curve in enumerate(snapshot.curves)
+            if curve.semantic_role == "tangent"
+        ),
+        None,
+    )
+    if source is None or tangent_index is None:
+        raise InteractionApplyError("Derivative interaction requires source and tangent curves")
+
+    # Validate the original manifest point before accepting the normalized event.
+    _estimate_derivative(snapshot, source.expression, snapshot.marker_x)
+    marker_x = float(event.value)
+    if marker_x < snapshot.x_min or marker_x > snapshot.x_max:
+        raise InteractionApplyError("Marker x is outside the declared plot bounds")
+    y, slope = _estimate_derivative(snapshot, source.expression, marker_x)
+
+    next_snapshot = snapshot.model_copy(deep=True)
+    next_snapshot.marker_x = marker_x
+    next_snapshot.curves[tangent_index] = MathPlotCurve(
+        expression=(
+            f"({_concise(slope)}) * (x - ({_concise(marker_x)})) + ({_concise(y)})"
+        ),
+        label=f"tangent @ x={_concise(marker_x)}",
+        emphasis="accent",
+        semantic_role="tangent",
+    )
+    _replace_snapshot(step, next_snapshot)
+    return (
+        f"Moved the tangent point to x={_concise(marker_x)} "
+        "and recomputed the local slope."
+    )
+
+
+def _estimate_derivative(
+    snapshot: MathPlotSnapshot,
+    expression: str,
+    marker_x: float,
+) -> tuple[float, float]:
+    try:
+        fn = compile_safe_math_expression(expression)
+    except SafeMathExpressionError as exc:
+        raise InteractionApplyError("Derivative source expression is not valid") from exc
+
+    span = snapshot.x_max - snapshot.x_min
+    scale = max(1.0, abs(marker_x))
+    h = max(1e-6, min(abs(span) * 1e-4, scale * 1e-3))
+    if marker_x - h < snapshot.x_min or marker_x + h > snapshot.x_max:
+        raise InteractionApplyError("Derivative pilot requires a two-sided interior point")
+
+    def evaluate(value: float) -> float:
+        scope = {name: float(param) for name, param in snapshot.params.items()}
+        # Match the frontend's `{...params, x}` semantics: the plotted coordinate
+        # always wins over a stored parameter with the reserved name `x`.
+        scope["x"] = value
+        try:
+            result = fn(scope)
+        except SafeMathExpressionError as exc:
+            raise InteractionApplyError("Derivative is not finite at this point") from exc
+        if not math.isfinite(result):
+            raise InteractionApplyError("Derivative is not finite at this point")
+        return result
+
+    y = evaluate(marker_x)
+    estimates: list[tuple[float, float, float]] = []
+    for delta in (h, h / 2, h / 4, h / 8):
+        left = (y - evaluate(marker_x - delta)) / delta
+        right = (evaluate(marker_x + delta) - y) / delta
+        central = (left + right) / 2
+        if not all(math.isfinite(value) for value in (left, right, central)):
+            raise InteractionApplyError("Derivative is not finite at this point")
+        estimates.append((left, right, central))
+
+    finest = estimates[-1]
+    previous = estimates[-2]
+    side_tolerance = 1e-5 + 5e-3 * max(1.0, abs(finest[0]), abs(finest[1]))
+    if abs(finest[0] - finest[1]) > side_tolerance:
+        raise InteractionApplyError("The selected point is not differentiable")
+    convergence_tolerance = 1e-6 + 2e-3 * max(
+        1.0,
+        abs(finest[2]),
+        abs(previous[2]),
+    )
+    if abs(finest[2] - previous[2]) > convergence_tolerance:
+        raise InteractionApplyError("The derivative estimate does not converge")
+    return y, finest[2]
+
+
+def _apply_bfs(playbook: PlaybookScript, event: BfsInteractionEvent) -> str:
+    if (playbook.algorithm_id or "").lower() != "bfs":
+        raise InteractionApplyError("BFS interaction requires a BFS playbook")
+    step = _single_step(playbook, event.step_id)
+    graph = _interaction_snapshot(step, GraphSceneSnapshot, "graph_scene")
+    if graph is None:
+        raise InteractionApplyError("BFS interaction requires a graph scene")
+    node_ids = [node.id for node in graph.nodes]
+    node_set = set(node_ids)
+    if (
+        not node_ids
+        or len(node_set) != len(node_ids)
+        or any(not node_id for node_id in node_ids)
+    ):
+        raise InteractionApplyError("BFS graph node ids are not valid")
+    if any(edge.source not in node_set or edge.target not in node_set for edge in graph.edges):
+        raise InteractionApplyError("BFS graph edges must reference declared nodes")
+    if len(node_ids) > _MAX_GRAPH_NODES or len(graph.edges) > _MAX_GRAPH_EDGES:
+        raise InteractionApplyError("BFS graph exceeds the interaction pilot limits")
+    if event.value not in node_set:
+        raise InteractionApplyError("Selected BFS start node does not exist")
+
+    order = {node_id: index for index, node_id in enumerate(node_ids)}
+    adjacency: dict[str, list[tuple[str, str | None]]] = {
+        node_id: [] for node_id in node_ids
+    }
+    for edge in graph.edges:
+        adjacency[edge.source].append((edge.target, edge.id))
+        if not graph.directed:
+            adjacency[edge.target].append((edge.source, edge.id))
+    for neighbors in adjacency.values():
+        neighbors.sort(key=lambda item: order[item[0]])
+
+    queue: deque[tuple[str, str | None]] = deque([(event.value, None)])
+    queued = {event.value}
+    seen: set[str] = set()
+    visited: list[str] = []
+    first_state: tuple[str, list[str], list[str], list[str]] | None = None
+    visit_order: list[str] = []
+    while queue:
+        current, via_edge_id = queue.popleft()
+        queued.discard(current)
+        if current in seen:
+            continue
+        seen.add(current)
+        visited.append(current)
+        visit_order.append(current)
+        for neighbor, edge_id in adjacency[current]:
+            if neighbor not in seen and neighbor not in queued:
+                queue.append((neighbor, edge_id))
+                queued.add(neighbor)
+        if first_state is None:
+            first_state = (
+                current,
+                list(visited),
+                [node_id for node_id, _ in queue],
+                [via_edge_id] if via_edge_id else [],
+            )
+
+    assert first_state is not None
+    current, first_visited, first_queue, active_edges = first_state
+    next_graph = graph.model_copy(deep=True)
+    next_graph.nodes = [
+        node.model_copy(update={"emphasis": "secondary", "asset_id": None})
+        for node in graph.nodes
+    ]
+    next_graph.edges = [
+        edge.model_copy(update={"emphasis": "secondary", "asset_id": None})
+        for edge in graph.edges
+    ]
+    next_graph.current_node_id = current
+    next_graph.active_node_ids = [current]
+    next_graph.active_edge_ids = active_edges
+    next_graph.visited_node_ids = first_visited
+    next_graph.queue_node_ids = first_queue
+    next_graph.frontier_node_ids = first_queue
+    _replace_snapshot(step, next_graph)
+    if step.code_highlight is not None:
+        variables = dict(step.code_highlight.variables)
+        variables.update(
+            {
+                "current": current,
+                "queue": f"[{', '.join(first_queue)}]",
+                "visited": f"{{{', '.join(first_visited)}}}",
+            }
+        )
+        step.code_highlight = step.code_highlight.model_copy(
+            update={"variables": variables}
+        )
+    return (
+        f"Prepared BFS replay from node {event.value}; "
+        f"visit order: {' → '.join(visit_order)}."
+    )
+
+
+def _concise(value: float) -> str:
+    if value == 0:
+        return "0"
+    return format(value, ".12g")

--- a/apps/api/app/domain/services/safe_math_expr.py
+++ b/apps/api/app/domain/services/safe_math_expr.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from functools import lru_cache
+
+
+class SafeMathExpressionError(ValueError):
+    """Raised when a plot expression is outside the sandboxed grammar."""
+
+
+Scope = Mapping[str, float]
+CompiledExpression = Callable[[Scope], float]
+
+_MAX_SOURCE_LENGTH = 512
+_MAX_TOKENS = 256
+_MAX_NESTING = 32
+_MAX_FUNCTION_ARGUMENTS = 16
+_OPERATOR_CHARS = frozenset("+-*/%^")
+_CONSTANTS = {
+    "pi": math.pi,
+    "tau": math.tau,
+    "e": math.e,
+}
+
+
+def _js_round(value: float) -> float:
+    return float(math.floor(value + 0.5))
+
+
+def _sign(value: float) -> float:
+    if value > 0:
+        return 1.0
+    if value < 0:
+        return -1.0
+    return 0.0
+
+
+def _minimum(*values: float) -> float:
+    return min(values) if values else math.inf
+
+
+def _maximum(*values: float) -> float:
+    return max(values) if values else -math.inf
+
+
+_FUNCTIONS: dict[str, Callable[..., float]] = {
+    "sin": math.sin,
+    "cos": math.cos,
+    "tan": math.tan,
+    "asin": math.asin,
+    "acos": math.acos,
+    "atan": math.atan,
+    "atan2": math.atan2,
+    "sinh": math.sinh,
+    "cosh": math.cosh,
+    "tanh": math.tanh,
+    "exp": math.exp,
+    "log": math.log,
+    "ln": math.log,
+    "log2": math.log2,
+    "log10": math.log10,
+    "sqrt": math.sqrt,
+    "cbrt": math.cbrt,
+    "abs": abs,
+    "floor": lambda value: float(math.floor(value)),
+    "ceil": lambda value: float(math.ceil(value)),
+    "round": _js_round,
+    "sign": _sign,
+    "min": _minimum,
+    "max": _maximum,
+    "pow": math.pow,
+    "hypot": math.hypot,
+}
+
+
+def _binary_expression(
+    operator: str,
+    left: CompiledExpression,
+    right: CompiledExpression,
+) -> CompiledExpression:
+    if operator == "+":
+        return lambda scope: left(scope) + right(scope)
+    if operator == "-":
+        return lambda scope: left(scope) - right(scope)
+    if operator == "*":
+        return lambda scope: left(scope) * right(scope)
+    if operator == "/":
+        return lambda scope: left(scope) / right(scope)
+    if operator == "%":
+        return lambda scope: math.fmod(left(scope), right(scope))
+    raise SafeMathExpressionError(f"Unsupported operator {operator!r}")
+
+
+@dataclass(frozen=True)
+class _Token:
+    kind: str
+    value: str | float | None = None
+
+
+def _tokenize(source: str) -> list[_Token]:
+    tokens: list[_Token] = []
+    index = 0
+    while index < len(source):
+        char = source[index]
+        if char.isspace():
+            index += 1
+            continue
+        if char == "(":
+            tokens.append(_Token("lparen"))
+            index += 1
+        elif char == ")":
+            tokens.append(_Token("rparen"))
+            index += 1
+        elif char == ",":
+            tokens.append(_Token("comma"))
+            index += 1
+        elif char in _OPERATOR_CHARS:
+            tokens.append(_Token("op", char))
+            index += 1
+        elif char.isascii() and (char.isdigit() or char == "."):
+            end = index
+            while end < len(source) and (
+                source[end].isascii()
+                and (source[end].isdigit() or source[end] == ".")
+            ):
+                end += 1
+            if end < len(source) and source[end] in {"e", "E"}:
+                exponent_end = end + 1
+                if exponent_end < len(source) and source[exponent_end] in {"+", "-"}:
+                    exponent_end += 1
+                if (
+                    exponent_end < len(source)
+                    and source[exponent_end].isascii()
+                    and source[exponent_end].isdigit()
+                ):
+                    exponent_end += 1
+                    while (
+                        exponent_end < len(source)
+                        and source[exponent_end].isascii()
+                        and source[exponent_end].isdigit()
+                    ):
+                        exponent_end += 1
+                    end = exponent_end
+            raw_number = source[index:end]
+            try:
+                value = float(raw_number)
+            except ValueError as exc:
+                raise SafeMathExpressionError(f"Invalid number: {raw_number!r}") from exc
+            if not math.isfinite(value):
+                raise SafeMathExpressionError(f"Invalid number: {raw_number!r}")
+            tokens.append(_Token("number", value))
+            index = end
+        elif char.isascii() and (char.isalpha() or char == "_"):
+            end = index + 1
+            while end < len(source):
+                candidate = source[end]
+                if not candidate.isascii() or not (
+                    candidate.isalnum() or candidate == "_"
+                ):
+                    break
+                end += 1
+            tokens.append(_Token("name", source[index:end]))
+            index = end
+        else:
+            raise SafeMathExpressionError(
+                f"Unexpected character {char!r} at position {index}"
+            )
+        if len(tokens) > _MAX_TOKENS:
+            raise SafeMathExpressionError("Expression has too many tokens")
+    return tokens
+
+
+class _Parser:
+    def __init__(self, tokens: list[_Token]) -> None:
+        self._tokens = tokens
+        self._position = 0
+
+    def parse(self) -> CompiledExpression:
+        expression = self._parse_expression(0)
+        if self._position != len(self._tokens):
+            raise SafeMathExpressionError("Unexpected trailing tokens in expression")
+        return expression
+
+    def _peek(self) -> _Token | None:
+        if self._position >= len(self._tokens):
+            return None
+        return self._tokens[self._position]
+
+    def _next(self) -> _Token:
+        token = self._peek()
+        if token is None:
+            raise SafeMathExpressionError("Unexpected end of expression")
+        self._position += 1
+        return token
+
+    @staticmethod
+    def _check_depth(depth: int) -> None:
+        if depth > _MAX_NESTING:
+            raise SafeMathExpressionError("Expression nesting is too deep")
+
+    def _parse_expression(self, depth: int) -> CompiledExpression:
+        self._check_depth(depth)
+        left = self._parse_term(depth)
+        while True:
+            token = self._peek()
+            if token is None or token.kind != "op" or token.value not in {"+", "-"}:
+                return left
+            self._next()
+            right = self._parse_term(depth)
+            left = _binary_expression(str(token.value), left, right)
+
+    def _parse_term(self, depth: int) -> CompiledExpression:
+        left = self._parse_power(depth)
+        while True:
+            token = self._peek()
+            if token is None or token.kind != "op" or token.value not in {"*", "/", "%"}:
+                return left
+            self._next()
+            right = self._parse_power(depth)
+            left = _binary_expression(str(token.value), left, right)
+
+    def _parse_power(self, depth: int) -> CompiledExpression:
+        base = self._parse_unary(depth)
+        token = self._peek()
+        if token is None or token.kind != "op" or token.value != "^":
+            return base
+        self._next()
+        exponent = self._parse_power(depth + 1)
+        return lambda scope: math.pow(base(scope), exponent(scope))
+
+    def _parse_unary(self, depth: int) -> CompiledExpression:
+        token = self._peek()
+        if token is not None and token.kind == "op" and token.value in {"+", "-"}:
+            self._next()
+            operand = self._parse_unary(depth + 1)
+            if token.value == "-":
+                return lambda scope: -operand(scope)
+            return operand
+        return self._parse_primary(depth)
+
+    def _parse_primary(self, depth: int) -> CompiledExpression:
+        self._check_depth(depth)
+        token = self._next()
+        if token.kind == "number":
+            value = float(token.value)  # type: ignore[arg-type]
+            return lambda _scope: value
+        if token.kind == "lparen":
+            inner = self._parse_expression(depth + 1)
+            if self._next().kind != "rparen":
+                raise SafeMathExpressionError('Expected ")"')
+            return inner
+        if token.kind != "name":
+            raise SafeMathExpressionError("Unexpected token in expression")
+
+        name = str(token.value)
+        return self._parse_name(name, depth)
+
+    def _parse_name(self, name: str, depth: int) -> CompiledExpression:
+        lookahead = self._peek()
+        if lookahead is not None and lookahead.kind == "lparen":
+            function = _FUNCTIONS.get(name)
+            if function is None:
+                raise SafeMathExpressionError(f"Unknown function {name!r}")
+            self._next()
+            arguments: list[CompiledExpression] = []
+            if self._peek() is not None and self._peek().kind != "rparen":
+                arguments.append(self._parse_expression(depth + 1))
+                while self._peek() is not None and self._peek().kind == "comma":
+                    self._next()
+                    arguments.append(self._parse_expression(depth + 1))
+                    if len(arguments) > _MAX_FUNCTION_ARGUMENTS:
+                        raise SafeMathExpressionError("Function has too many arguments")
+            if self._next().kind != "rparen":
+                raise SafeMathExpressionError(
+                    f'Expected ")" after arguments to {name!r}'
+                )
+            return lambda scope: float(
+                function(*(argument(scope) for argument in arguments))
+            )
+        if name in _CONSTANTS:
+            value = _CONSTANTS[name]
+            return lambda _scope: value
+
+        def variable(scope: Scope) -> float:
+            value = scope.get(name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise SafeMathExpressionError(f"Unknown variable {name!r}")
+            return float(value)
+
+        return variable
+
+
+@lru_cache(maxsize=128)
+def compile_safe_math_expression(source: str) -> CompiledExpression:
+    """Compile the frontend mathExpr grammar without eval or dynamic code."""
+
+    trimmed = (source or "").strip()
+    if not trimmed:
+        raise SafeMathExpressionError("Empty expression")
+    if len(trimmed) > _MAX_SOURCE_LENGTH:
+        raise SafeMathExpressionError("Expression is too long")
+    parsed = _Parser(_tokenize(trimmed)).parse()
+
+    def evaluate(scope: Scope) -> float:
+        try:
+            return float(parsed(scope))
+        except SafeMathExpressionError:
+            raise
+        except (ArithmeticError, TypeError, ValueError) as exc:
+            raise SafeMathExpressionError("Expression evaluation failed") from exc
+
+    return evaluate

--- a/apps/api/app/infrastructure/persistence/sqlite_run_repository.py
+++ b/apps/api/app/infrastructure/persistence/sqlite_run_repository.py
@@ -7,7 +7,9 @@ import sqlite3
 
 from app.application.dto.followup_dto import RunFollowUpRecord, RunVersionRecord
 from app.application.dto.pipeline_dto import PipelineRunResponse
+from app.application.ports.run_repository import InteractionVersionConflictError
 from app.domain.models.coverage import CoverageDecision
+from app.domain.models.director import DirectorScript
 from app.domain.models.lesson_plan import LessonPlan
 from app.domain.models.pipeline_run import PipelineRunStatus
 from app.domain.models.playbook import PlaybookScript
@@ -301,6 +303,163 @@ class SqliteRunRepository:
 
         return await asyncio.to_thread(_sync)
 
+    async def commit_interaction_version(
+        self,
+        run_id: str,
+        *,
+        expected_base_version_id: str | None,
+        version_id: str,
+        initial_playbook_json: str,
+        playbook_json: str,
+        quality_report_json: str,
+        director: DirectorScript,
+        summary: str,
+        created_at: str,
+    ) -> None:
+        """Atomically compare-and-swap the active interaction version.
+
+        ``BEGIN IMMEDIATE`` serializes writers before the head is read.  The
+        initial snapshot, child version, director, active playbook, and quality
+        report therefore either become visible together or are all rolled back.
+        """
+
+        if director.run_id != run_id:
+            raise ValueError("interaction director run_id does not match the run")
+        director_json = director.model_dump_json()
+
+        def _sync() -> None:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                run_row = conn.execute(
+                    "SELECT playbook_json FROM pipeline_runs WHERE run_id=?",
+                    (run_id,),
+                ).fetchone()
+                if run_row is None:
+                    raise LookupError(f"Run {run_id!r} not found")
+                active_playbook_json = (
+                    str(run_row["playbook_json"])
+                    if run_row["playbook_json"]
+                    else None
+                )
+                try:
+                    if active_playbook_json is None:
+                        active_playbook = None
+                    else:
+                        active_playbook = PlaybookScript.model_validate_json(
+                            active_playbook_json
+                        ).model_dump(mode="json")
+                    expected_playbook = PlaybookScript.model_validate_json(
+                        initial_playbook_json
+                    ).model_dump(mode="json")
+                except ValueError:
+                    try:
+                        active_playbook = (
+                            json.loads(active_playbook_json)
+                            if active_playbook_json is not None
+                            else None
+                        )
+                        expected_playbook = json.loads(initial_playbook_json)
+                    except json.JSONDecodeError as exc:
+                        raise InteractionVersionConflictError(
+                            "Interaction sandbox source is no longer valid"
+                        ) from exc
+                if active_playbook is None:
+                    raise InteractionVersionConflictError(
+                        "Interaction sandbox source is no longer valid"
+                    )
+                if active_playbook != expected_playbook:
+                    raise InteractionVersionConflictError(
+                        "Interaction sandbox source lesson has changed"
+                    )
+
+                head_version_id = _head_version_id(
+                    conn,
+                    run_id,
+                    active_playbook_json=active_playbook_json,
+                )
+                if head_version_id is not None:
+                    if expected_base_version_id != head_version_id:
+                        raise InteractionVersionConflictError(
+                            "Interaction sandbox base version is no longer current"
+                        )
+                elif expected_base_version_id is not None:
+                    raise InteractionVersionConflictError(
+                        "Interaction sandbox base version is no longer current"
+                    )
+
+                parent_version_id = head_version_id
+                if parent_version_id is None:
+                    parent_version_id = f"{run_id}:v0"
+                    conn.execute(
+                        "INSERT INTO pipeline_run_versions"
+                        " (version_id, run_id, version_number, playbook_json,"
+                        " source, followup_id, parent_version_id, summary, created_at)"
+                        " VALUES (?, ?, 0, ?, 'initial', NULL, NULL, ?, ?)",
+                        (
+                            parent_version_id,
+                            run_id,
+                            initial_playbook_json,
+                            "initial playbook",
+                            created_at,
+                        ),
+                    )
+
+                next_number_row = conn.execute(
+                    "SELECT COALESCE(MAX(version_number), -1) + 1 AS next_number"
+                    " FROM pipeline_run_versions WHERE run_id=?",
+                    (run_id,),
+                ).fetchone()
+                version_number = int(
+                    next_number_row["next_number"] if next_number_row is not None else 0
+                )
+                conn.execute(
+                    "INSERT INTO pipeline_run_versions"
+                    " (version_id, run_id, version_number, playbook_json,"
+                    " source, followup_id, parent_version_id, summary, created_at)"
+                    " VALUES (?, ?, ?, ?, 'interaction', NULL, ?, ?, ?)",
+                    (
+                        version_id,
+                        run_id,
+                        version_number,
+                        playbook_json,
+                        parent_version_id,
+                        summary,
+                        created_at,
+                    ),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO pipeline_run_directors
+                        (run_id, director_json, source, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(run_id) DO UPDATE SET
+                        director_json=excluded.director_json,
+                        source=excluded.source,
+                        updated_at=excluded.updated_at
+                    """,
+                    (
+                        run_id,
+                        director_json,
+                        director.source,
+                        created_at,
+                        created_at,
+                    ),
+                )
+                conn.execute(
+                    "UPDATE pipeline_runs"
+                    " SET playbook_json=?, quality_report_json=? WHERE run_id=?",
+                    (playbook_json, quality_report_json, run_id),
+                )
+                conn.commit()
+            except BaseException:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+
+        await asyncio.to_thread(_sync)
+
     async def attach_followup_version(self, followup_id: str, version_id: str) -> None:
         def _sync() -> None:
             with self._connect() as conn:
@@ -359,21 +518,7 @@ class SqliteRunRepository:
                     if active is not None and active["playbook_json"]
                     else None
                 )
-                if active_playbook_json is not None:
-                    active_head = conn.execute(
-                        "SELECT version_id FROM pipeline_run_versions"
-                        " WHERE run_id=? AND playbook_json=?"
-                        " ORDER BY version_number DESC LIMIT 1",
-                        (run_id, active_playbook_json),
-                    ).fetchone()
-                    if active_head is not None:
-                        return str(active_head["version_id"])
-                row = conn.execute(
-                    "SELECT version_id FROM pipeline_run_versions"
-                    " WHERE run_id=? ORDER BY version_number DESC LIMIT 1",
-                    (run_id,),
-                ).fetchone()
-                return str(row["version_id"]) if row is not None else None
+                return _head_version_id(conn, run_id, active_playbook_json)
 
         return await asyncio.to_thread(_sync)
 
@@ -454,6 +599,28 @@ class SqliteRunRepository:
 
         rows, head_version_id = await asyncio.to_thread(_sync)
         return [_version_row_to_record(row, head_version_id) for row in rows]
+
+
+def _head_version_id(
+    conn: sqlite3.Connection,
+    run_id: str,
+    active_playbook_json: str | None,
+) -> str | None:
+    if active_playbook_json is not None:
+        active_head = conn.execute(
+            "SELECT version_id FROM pipeline_run_versions"
+            " WHERE run_id=? AND playbook_json=?"
+            " ORDER BY version_number DESC LIMIT 1",
+            (run_id, active_playbook_json),
+        ).fetchone()
+        if active_head is not None:
+            return str(active_head["version_id"])
+    row = conn.execute(
+        "SELECT version_id FROM pipeline_run_versions"
+        " WHERE run_id=? ORDER BY version_number DESC LIMIT 1",
+        (run_id,),
+    ).fetchone()
+    return str(row["version_id"]) if row is not None else None
 
 
 def _row_to_response(row: sqlite3.Row) -> PipelineRunResponse:

--- a/apps/api/app/presentation/router_runs.py
+++ b/apps/api/app/presentation/router_runs.py
@@ -17,10 +17,17 @@ from app.application.dto.followup_dto import (
     RestoreVersionResponse,
     RunFollowUpsResponse,
 )
+from app.application.dto.interaction_dto import (
+    ApplyInteractionVersionRequest,
+    ApplyInteractionVersionResponse,
+)
 from app.application.dto.pipeline_dto import PipelineRunResponse
 from app.application.ports.director_repository import IRunDirectorRepository
 from app.application.ports.llm_provider import ILLMProvider
-from app.application.ports.run_repository import IRunRepository
+from app.application.ports.run_repository import (
+    InteractionVersionConflictError,
+    IRunRepository,
+)
 from app.application.use_cases.account import AccountUseCase, InsufficientBalanceError
 from app.application.use_cases.follow_up import FollowUpPatchError, FollowUpPatchUseCase
 from app.config import Settings, get_settings
@@ -28,6 +35,10 @@ from app.domain.models.account import SessionAccount
 from app.domain.models.director import DirectorScript
 from app.domain.models.playbook import PlaybookScript
 from app.domain.services.director_builder import build_default_director
+from app.domain.services.interaction_apply import (
+    InteractionApplyError,
+    apply_interaction_events,
+)
 from app.domain.services.playbook_quality import quality_gate_playbook
 from app.infrastructure.llm.openai_provider import OpenAIProvider
 from app.presentation.dependencies import (
@@ -279,6 +290,87 @@ async def submit_followup(
         change_summary=result.change_summary,
         version_id=version_id,
         playbook=response_playbook,
+        director=director,
+    )
+
+
+@router.post(
+    "/{run_id}/interaction-version",
+    response_model=ApplyInteractionVersionResponse,
+)
+@write_limit()
+async def apply_interaction_version(
+    request: Request,
+    response: Response,
+    run_id: str,
+    payload: ApplyInteractionVersionRequest,
+    settings: Annotated[Settings, Depends(get_settings)],
+    run_repo: Annotated[IRunRepository, Depends(get_run_repo)],
+    account_use_case: Annotated[AccountUseCase, Depends(get_account_use_case)],
+) -> ApplyInteractionVersionResponse:
+    async with _RUN_LOCKS[run_id]:
+        owner = await _owner_session(request, response, settings, account_use_case)
+        owner_user_id = owner.account.user_id if owner is not None else None
+        run = await run_repo.get(run_id, user_id=owner_user_id)
+        if run is None or run.playbook is None:
+            raise HTTPException(status_code=404, detail=f"Run {run_id!r} has no playbook")
+
+        try:
+            applied = apply_interaction_events(run.playbook, payload.events)
+        except InteractionApplyError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        quality_report = quality_gate_playbook(
+            applied.playbook,
+            run.prompt,
+            generator_path="interaction_version",
+            coverage_decision=getattr(run, "coverage_decision", None),
+            lesson_plan=getattr(run, "lesson_plan", None),
+            coverage_mode=(
+                run.coverage_decision.mode
+                if getattr(run, "coverage_decision", None) is not None
+                else (
+                    run.quality_report.coverage_mode
+                    if run.quality_report is not None
+                    else "unknown"
+                )
+            ),
+        )
+        quality_report.actions = [
+            *(run.quality_report.actions if run.quality_report is not None else []),
+            "interaction:quality_gate",
+        ]
+        if quality_report.status in {"repairable", "blocked"}:
+            codes = ", ".join(issue.code for issue in quality_report.issues[:5])
+            raise HTTPException(
+                status_code=422,
+                detail=f"Interaction version failed the canonical quality gate: {codes}",
+            )
+
+        now = _now()
+        current_json = run.playbook.model_dump_json()
+        version_id = str(uuid.uuid4())
+        next_json = applied.playbook.model_dump_json()
+        director = build_default_director(applied.playbook, run_id)
+        try:
+            await run_repo.commit_interaction_version(
+                run_id,
+                expected_base_version_id=payload.base_version_id,
+                version_id=version_id,
+                initial_playbook_json=current_json,
+                playbook_json=next_json,
+                quality_report_json=quality_report.model_dump_json(),
+                director=director,
+                summary=applied.summary,
+                created_at=now,
+            )
+        except InteractionVersionConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return ApplyInteractionVersionResponse(
+        version_id=version_id,
+        summary=applied.summary,
+        playbook=applied.playbook,
         director=director,
     )
 

--- a/apps/api/tests/test_interaction_apply.py
+++ b/apps/api/tests/test_interaction_apply.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import pytest
+
+from app.application.dto.interaction_dto import ApplyInteractionVersionRequest
+from app.domain.models.playbook import (
+    CodeHighlightOverlay,
+    GraphSceneSnapshot,
+    MathPlotSnapshot,
+    PlaybookScript,
+)
+from app.domain.services.interaction_apply import (
+    InteractionApplyError,
+    apply_interaction_events,
+)
+from app.domain.skills.algebra_core.parser import parse_expression
+
+
+def test_derivative_event_recomputes_tangent_without_mutating_source() -> None:
+    base = _math_playbook()
+    request = ApplyInteractionVersionRequest.model_validate(
+        {
+            "manifest_version": "1",
+            "events": [
+                {
+                    "adapter_id": "math.derivative-tangent",
+                    "step_id": "plot",
+                    "target_id": "step:plot:marker-x",
+                    "action": "set-value",
+                    "value": 3,
+                    "sequence": 1,
+                }
+            ],
+        }
+    )
+
+    result = apply_interaction_events(base, request.events)
+
+    snapshot = result.playbook.steps[0].snapshot
+    assert isinstance(snapshot, MathPlotSnapshot)
+    assert snapshot.marker_x == 3
+    assert isinstance(base.steps[0].snapshot, MathPlotSnapshot)
+    assert base.steps[0].snapshot.marker_x == 1
+    tangent = next(curve for curve in snapshot.curves if curve.semantic_role == "tangent")
+    expression, _ = parse_expression(tangent.expression)
+    assert float(expression.subs({"x": 3})) == pytest.approx(9)
+    assert float(expression.subs({"x": 4}) - expression.subs({"x": 3})) == pytest.approx(6)
+    assert result.playbook.steps[0].layers[0].body == snapshot
+    assert result.playbook.total_frames == base.total_frames
+    assert result.summary.startswith("Moved the tangent point")
+
+
+def test_derivative_event_rejects_boundary_cusp_and_ambiguous_layers() -> None:
+    boundary = _math_playbook(expression="sqrt(x)", marker_x=0, x_min=0)
+    with pytest.raises(InteractionApplyError, match="two-sided"):
+        apply_interaction_events(boundary, _derivative_request(0).events)
+
+    cusp = _math_playbook(expression="abs(x)", marker_x=0)
+    with pytest.raises(InteractionApplyError, match="not differentiable"):
+        apply_interaction_events(cusp, _derivative_request(0).events)
+
+    ambiguous = _math_playbook()
+    ambiguous.steps[0].layers.append(ambiguous.steps[0].layers[0].model_copy(deep=True))
+    with pytest.raises(InteractionApplyError, match="exactly one math_plot layer"):
+        apply_interaction_events(ambiguous, _derivative_request(2).events)
+
+
+def test_derivative_event_matches_frontend_param_and_layer_semantics() -> None:
+    params_shadow_x = _math_playbook()
+    layer_snapshot = params_shadow_x.steps[0].layers[0].body
+    assert isinstance(layer_snapshot, MathPlotSnapshot)
+    layer_snapshot.params = {"x": 10}
+
+    result = apply_interaction_events(params_shadow_x, _derivative_request(3).events)
+
+    tangent = next(
+        curve
+        for curve in result.playbook.steps[0].snapshot.curves  # type: ignore[union-attr]
+        if curve.semantic_role == "tangent"
+    )
+    expression, _ = parse_expression(tangent.expression)
+    assert float(expression.subs({"x": 3})) == pytest.approx(9)
+    assert float(expression.subs({"x": 4}) - expression.subs({"x": 3})) == pytest.approx(6)
+
+    layered = _math_playbook().model_dump(mode="json")
+    math_layer = layered["steps"][0]["layers"][0]
+    layered["steps"][0]["snapshot"] = {
+        "kind": "math_formula",
+        "formula_latex": "stale fallback",
+    }
+    layered["steps"][0]["layers"] = [
+        {"body": {"kind": "math_formula", "formula_latex": "overlay"}},
+        math_layer,
+    ]
+
+    applied = apply_interaction_events(
+        PlaybookScript.model_validate(layered),
+        _derivative_request(2).events,
+    ).playbook.steps[0]
+    assert isinstance(applied.snapshot, MathPlotSnapshot)
+    assert applied.snapshot.marker_x == 2
+    assert applied.layers[0].body.kind == "math_formula"
+    assert isinstance(applied.layers[1].body, MathPlotSnapshot)
+    assert applied.layers[1].body.marker_x == 2
+
+
+def test_bfs_event_applies_first_frame_and_preserves_unrelated_scenes() -> None:
+    base = _bfs_playbook()
+    base.steps[0].code_highlight = CodeHighlightOverlay(
+        language="python",
+        lines=["while queue:"],
+        active_lines=[0],
+        active_line=0,
+        variables={"current": "A", "queue": "[B]", "visited": "{A}"},
+    )
+    request = ApplyInteractionVersionRequest.model_validate(
+        {
+            "manifest_version": "1",
+            "events": [
+                {
+                    "adapter_id": "algorithm.bfs",
+                    "step_id": "graph",
+                    "target_id": "step:graph:start-node",
+                    "action": "select",
+                    "value": "C",
+                    "sequence": 1,
+                }
+            ],
+        }
+    )
+
+    result = apply_interaction_events(base, request.events)
+
+    graph = result.playbook.steps[0].snapshot
+    assert isinstance(graph, GraphSceneSnapshot)
+    assert graph.current_node_id == "C"
+    assert graph.visited_node_ids == ["C"]
+    assert graph.queue_node_ids == ["A"]
+    assert result.summary.endswith("C → A → B → D.")
+    assert result.playbook.steps[1] == base.steps[1]
+    assert result.playbook.steps[0].code_highlight is not None
+    assert result.playbook.steps[0].code_highlight.variables == {
+        "current": "C",
+        "queue": "[A]",
+        "visited": "{C}",
+    }
+    assert isinstance(base.steps[0].snapshot, GraphSceneSnapshot)
+    assert base.steps[0].snapshot.current_node_id is None
+
+
+def test_bfs_event_rejects_undeclared_node_and_non_bfs_lesson() -> None:
+    playbook = _bfs_playbook()
+    with pytest.raises(InteractionApplyError, match="does not exist"):
+        apply_interaction_events(playbook, _bfs_request("missing").events)
+
+    playbook.algorithm_id = "dfs"
+    with pytest.raises(InteractionApplyError, match="requires a BFS"):
+        apply_interaction_events(playbook, _bfs_request("A").events)
+
+
+def test_apply_request_rejects_unknown_patch_fields_and_sequence_gaps() -> None:
+    event = {
+        "adapter_id": "algorithm.bfs",
+        "step_id": "graph",
+        "target_id": "step:graph:start-node",
+        "action": "select",
+        "value": "A",
+        "sequence": 1,
+    }
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        ApplyInteractionVersionRequest.model_validate(
+            {
+                "manifest_version": "1",
+                "events": [event],
+                "patch": [{"op": "replace", "path": "/title", "value": "bad"}],
+            }
+        )
+
+    with pytest.raises(ValueError, match="start at 1"):
+        ApplyInteractionVersionRequest.model_validate(
+            {
+                "manifest_version": "1",
+                "events": [{**event, "sequence": 2}],
+            }
+        )
+
+    with pytest.raises(ValueError, match="contiguous"):
+        ApplyInteractionVersionRequest.model_validate(
+            {
+                "manifest_version": "1",
+                "events": [event, {**event, "value": "B", "sequence": 3}],
+            }
+        )
+
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        ApplyInteractionVersionRequest.model_validate(
+            {
+                "manifest_version": "1",
+                "events": [{**event, "path": "/steps/0"}],
+            }
+        )
+
+
+def _derivative_request(value: float) -> ApplyInteractionVersionRequest:
+    return ApplyInteractionVersionRequest.model_validate(
+        {
+            "manifest_version": "1",
+            "events": [
+                {
+                    "adapter_id": "math.derivative-tangent",
+                    "step_id": "plot",
+                    "target_id": "step:plot:marker-x",
+                    "action": "set-value",
+                    "value": value,
+                    "sequence": 1,
+                }
+            ],
+        }
+    )
+
+
+def _bfs_request(value: str) -> ApplyInteractionVersionRequest:
+    return ApplyInteractionVersionRequest.model_validate(
+        {
+            "manifest_version": "1",
+            "events": [
+                {
+                    "adapter_id": "algorithm.bfs",
+                    "step_id": "graph",
+                    "target_id": "step:graph:start-node",
+                    "action": "select",
+                    "value": value,
+                    "sequence": 1,
+                }
+            ],
+        }
+    )
+
+
+def _math_playbook(
+    *,
+    expression: str = "x^2",
+    marker_x: float = 1,
+    x_min: float = -5,
+) -> PlaybookScript:
+    snapshot = {
+        "kind": "math_plot",
+        "curves": [
+            {"expression": expression, "semantic_role": "curve"},
+            {
+                "expression": "2*x - 1",
+                "semantic_role": "tangent",
+                "emphasis": "accent",
+            },
+        ],
+        "x_min": x_min,
+        "x_max": 5,
+        "y_min": -1,
+        "y_max": 25,
+        "marker_x": marker_x,
+    }
+    return PlaybookScript.model_validate(
+        {
+            "fps": 30,
+            "total_frames": 30,
+            "domain": "math",
+            "title": "Derivative",
+            "summary": "Move a tangent point.",
+            "parameter_controls": [],
+            "steps": [
+                {
+                    "step_id": "plot",
+                    "end_frame": 30,
+                    "title": "Tangent",
+                    "voiceover_text": "",
+                    "snapshot": snapshot,
+                    "layers": [{"body": snapshot}],
+                    "tokens": [],
+                }
+            ],
+        }
+    )
+
+
+def _bfs_playbook() -> PlaybookScript:
+    graph = {
+        "kind": "graph_scene",
+        "nodes": [{"id": node} for node in ("A", "B", "C", "D")],
+        "edges": [
+            {"id": "AB", "source": "A", "target": "B"},
+            {"id": "AC", "source": "A", "target": "C"},
+            {"id": "BD", "source": "B", "target": "D"},
+        ],
+        "directed": False,
+    }
+    unrelated = {
+        "kind": "graph_scene",
+        "nodes": [{"id": "X"}, {"id": "Y"}],
+        "edges": [{"source": "X", "target": "Y"}],
+    }
+    return PlaybookScript.model_validate(
+        {
+            "fps": 30,
+            "total_frames": 60,
+            "domain": "algorithm",
+            "algorithm_id": "bfs",
+            "title": "BFS",
+            "summary": "Choose a start node.",
+            "parameter_controls": [],
+            "steps": [
+                {
+                    "step_id": "graph",
+                    "end_frame": 30,
+                    "title": "Graph",
+                    "voiceover_text": "",
+                    "snapshot": graph,
+                    "layers": [{"body": graph}],
+                    "tokens": [],
+                },
+                {
+                    "step_id": "other",
+                    "end_frame": 60,
+                    "title": "Other",
+                    "voiceover_text": "",
+                    "snapshot": unrelated,
+                    "layers": [{"body": unrelated}],
+                    "tokens": [],
+                },
+            ],
+        }
+    )

--- a/apps/api/tests/test_router_interaction_versions.py
+++ b/apps/api/tests/test_router_interaction_versions.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+
+from fastapi.testclient import TestClient
+
+from app.config import get_settings
+from app.domain.models.pipeline_run import PipelineRunStatus
+from app.infrastructure.persistence.db_init import init_db
+from app.infrastructure.persistence.sqlite_account_repository import SqliteAccountRepository
+from app.infrastructure.persistence.sqlite_run_repository import SqliteRunRepository
+from app.main import create_app
+from app.presentation.dependencies import get_run_repo
+
+
+def test_interaction_events_create_a_validated_child_version(monkeypatch, tmp_path) -> None:
+    client, repo, run_id = _client(monkeypatch, tmp_path, _math_playbook())
+
+    with client:
+        response = client.post(
+            f"/api/v1/runs/{run_id}/interaction-version",
+            json=_derivative_payload(3),
+        )
+        history = client.get(f"/api/v1/runs/{run_id}/follow-ups").json()
+
+    get_settings.cache_clear()
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["playbook"]["steps"][0]["snapshot"]["marker_x"] == 3
+    assert data["director"]["run_id"] == run_id
+    assert [version["source"] for version in history["versions"]] == [
+        "initial",
+        "interaction",
+    ]
+    assert history["versions"][1]["version_id"] == data["version_id"]
+    assert history["versions"][1]["parent_version_id"] == history["versions"][0][
+        "version_id"
+    ]
+    stored = _run(repo.get(run_id))
+    assert stored is not None
+    assert stored.playbook is not None
+    assert stored.playbook.steps[0].snapshot.marker_x == 3  # type: ignore[union-attr]
+    assert stored.quality_report is not None
+    assert stored.quality_report.generator_path == "interaction_version"
+    assert "interaction:quality_gate" in stored.quality_report.actions
+
+
+def test_interaction_version_requires_the_current_base_after_first_apply(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    client, _repo, run_id = _client(monkeypatch, tmp_path, _math_playbook())
+
+    with client:
+        first = client.post(
+            f"/api/v1/runs/{run_id}/interaction-version",
+            json=_derivative_payload(2),
+        )
+        assert first.status_code == 200, first.text
+        stale_without_base = client.post(
+            f"/api/v1/runs/{run_id}/interaction-version",
+            json=_derivative_payload(3),
+        )
+        stale_wrong_base = client.post(
+            f"/api/v1/runs/{run_id}/interaction-version",
+            json={**_derivative_payload(3), "base_version_id": "missing"},
+        )
+        current = client.post(
+            f"/api/v1/runs/{run_id}/interaction-version",
+            json={
+                **_derivative_payload(3),
+                "base_version_id": first.json()["version_id"],
+            },
+        )
+
+    get_settings.cache_clear()
+    assert stale_without_base.status_code == 409
+    assert stale_wrong_base.status_code == 409
+    assert current.status_code == 200
+    assert current.json()["playbook"]["steps"][0]["snapshot"]["marker_x"] == 3
+
+
+def test_invalid_interaction_is_rejected_without_an_interaction_version(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    client, _repo, run_id = _client(monkeypatch, tmp_path, _bfs_playbook())
+    payload = _bfs_payload("missing")
+
+    with client:
+        response = client.post(
+            f"/api/v1/runs/{run_id}/interaction-version",
+            json=payload,
+        )
+        history = client.get(f"/api/v1/runs/{run_id}/follow-ups").json()
+
+    get_settings.cache_clear()
+    assert response.status_code == 422
+    assert "does not exist" in response.json()["detail"]
+    assert history["versions"] == []
+
+
+def test_valid_bfs_interaction_syncs_code_state_and_passes_the_quality_gate(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    client, repo, run_id = _client(
+        monkeypatch,
+        tmp_path,
+        _bfs_playbook(),
+        prompt="Explain a BFS queue choice",
+    )
+
+    with client:
+        response = client.post(
+            f"/api/v1/runs/{run_id}/interaction-version",
+            json=_bfs_payload("C"),
+        )
+
+    get_settings.cache_clear()
+    assert response.status_code == 200, response.text
+    code = response.json()["playbook"]["steps"][0]["code_highlight"]
+    assert code["variables"] == {
+        "current": "C",
+        "queue": "[A]",
+        "visited": "{C}",
+    }
+    stored = _run(repo.get(run_id))
+    assert stored is not None
+    assert stored.quality_report is not None
+    assert stored.quality_report.status not in {"repairable", "blocked"}
+    assert all(
+        issue.code != "code.state_mismatch"
+        for issue in stored.quality_report.issues
+    )
+
+
+def test_ops_interaction_requires_login_and_cannot_cross_run_ownership(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    get_settings.cache_clear()
+    monkeypatch.setenv("METAVIEW_APP_EDITION", "ops")
+    monkeypatch.setenv("METAVIEW_RATE_LIMIT_ENABLED", "false")
+    db = str(tmp_path / "ops-interaction.db")
+    monkeypatch.setenv("METAVIEW_HISTORY_DB_PATH", db)
+    init_db(db)
+    repo = SqliteRunRepository(db)
+    owner = _wechat_session(db)
+    other = _wechat_session(db)
+    run_id = "owned-interaction-run"
+    _run(
+        repo.create(
+            run_id,
+            "tangent slope",
+            "2026-07-15T00:00:00+00:00",
+            user_id=owner.account.user_id,
+        )
+    )
+    _run(
+        repo.update(
+            run_id,
+            status=PipelineRunStatus.SUCCEEDED,
+            playbook_json=json.dumps(_math_playbook()),
+        )
+    )
+    app = create_app()
+    app.dependency_overrides[get_run_repo] = lambda: repo
+
+    with TestClient(app) as client:
+        missing = client.post(
+            f"/api/v1/runs/{run_id}/interaction-version",
+            json=_derivative_payload(2),
+        )
+        cross_user = client.post(
+            f"/api/v1/runs/{run_id}/interaction-version",
+            json=_derivative_payload(2),
+            headers={"Cookie": f"mv_session={other.token}"},
+        )
+
+    get_settings.cache_clear()
+    assert missing.status_code == 401
+    assert cross_user.status_code == 404
+    assert _run(repo.list_versions(run_id)) == []
+    stored = _run(repo.get(run_id, user_id=owner.account.user_id))
+    assert stored is not None
+    assert stored.playbook is not None
+    assert stored.playbook.steps[0].snapshot.marker_x == 1  # type: ignore[union-attr]
+
+
+def test_concurrent_interactions_from_the_same_base_commit_only_one_child(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    client, repo, run_id = _client(monkeypatch, tmp_path, _math_playbook())
+
+    with client:
+        first = client.post(
+            f"/api/v1/runs/{run_id}/interaction-version",
+            json=_derivative_payload(2),
+        )
+        assert first.status_code == 200, first.text
+        base_version_id = first.json()["version_id"]
+
+        def _post(value: float):
+            return client.post(
+                f"/api/v1/runs/{run_id}/interaction-version",
+                json={
+                    **_derivative_payload(value),
+                    "base_version_id": base_version_id,
+                },
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            responses = list(executor.map(_post, (3, 4)))
+
+        history = client.get(f"/api/v1/runs/{run_id}/follow-ups").json()
+
+    get_settings.cache_clear()
+    assert sorted(response.status_code for response in responses) == [200, 409]
+    successful = next(response for response in responses if response.status_code == 200)
+    conflict = next(response for response in responses if response.status_code == 409)
+    assert "no longer current" in conflict.json()["detail"]
+    assert [version["source"] for version in history["versions"]] == [
+        "initial",
+        "interaction",
+        "interaction",
+    ]
+    assert sum(version["is_head"] for version in history["versions"]) == 1
+    stored = _run(repo.get(run_id))
+    assert stored is not None
+    assert stored.playbook is not None
+    assert stored.playbook.steps[0].snapshot.marker_x == successful.json()["playbook"][  # type: ignore[union-attr]
+        "steps"
+    ][0]["snapshot"]["marker_x"]
+
+
+def _client(monkeypatch, tmp_path, playbook: dict, *, prompt: str = "tangent slope"):
+    get_settings.cache_clear()
+    monkeypatch.setenv("METAVIEW_RATE_LIMIT_ENABLED", "false")
+    db = str(tmp_path / "interaction-versions.db")
+    init_db(db)
+    repo = SqliteRunRepository(db)
+    run_id = "run-interaction"
+    _run(repo.create(run_id, prompt, "2026-07-15T00:00:00+00:00"))
+    _run(
+        repo.update(
+            run_id,
+            status=PipelineRunStatus.SUCCEEDED,
+            playbook_json=json.dumps(playbook),
+        )
+    )
+    app = create_app()
+    app.dependency_overrides[get_run_repo] = lambda: repo
+    return TestClient(app), repo, run_id
+
+
+def _derivative_payload(value: float) -> dict:
+    return {
+        "manifest_version": "1",
+        "events": [
+            {
+                "adapter_id": "math.derivative-tangent",
+                "step_id": "plot",
+                "target_id": "step:plot:marker-x",
+                "action": "set-value",
+                "value": value,
+                "sequence": 1,
+            }
+        ],
+    }
+
+
+def _bfs_payload(value: str) -> dict:
+    return {
+        "manifest_version": "1",
+        "events": [
+            {
+                "adapter_id": "algorithm.bfs",
+                "step_id": "graph",
+                "target_id": "step:graph:start-node",
+                "action": "select",
+                "value": value,
+                "sequence": 1,
+            }
+        ],
+    }
+
+
+def _math_playbook() -> dict:
+    snapshot = {
+        "kind": "math_plot",
+        "curves": [
+            {"expression": "x^2", "semantic_role": "curve"},
+            {
+                "expression": "2*x - 1",
+                "semantic_role": "tangent",
+                "emphasis": "accent",
+            },
+        ],
+        "x_min": -5,
+        "x_max": 5,
+        "y_min": -1,
+        "y_max": 25,
+        "marker_x": 1,
+    }
+    return {
+        "schema_version": "1.0.0",
+        "fps": 30,
+        "total_frames": 60,
+        "domain": "math",
+        "title": "Derivative tangent",
+        "summary": "Move the tangent point and compare local slope.",
+        "parameter_controls": [],
+        "initial_data": {},
+        "steps": [
+            {
+                "step_id": "plot",
+                "end_frame": 60,
+                "title": "Move the tangent point",
+                "voiceover_text": "Tangent slope.",
+                "snapshot": snapshot,
+                "layers": [{"body": snapshot}],
+                "tokens": [],
+            }
+        ],
+    }
+
+
+def _bfs_playbook() -> dict:
+    graph = {
+        "kind": "graph_scene",
+        "nodes": [{"id": node} for node in ("A", "B", "C")],
+        "edges": [
+            {"id": "AB", "source": "A", "target": "B"},
+            {"id": "AC", "source": "A", "target": "C"},
+        ],
+    }
+    return {
+        "schema_version": "1.0.0",
+        "fps": 30,
+        "total_frames": 60,
+        "domain": "algorithm",
+        "algorithm_id": "bfs",
+        "title": "Breadth-first search",
+        "summary": "Choose a start node and inspect the queue.",
+        "parameter_controls": [],
+        "initial_data": {},
+        "steps": [
+            {
+                "step_id": "graph",
+                "end_frame": 60,
+                "title": "Choose a start node",
+                "voiceover_text": "BFS visits the graph level by level.",
+                "snapshot": graph,
+                "layers": [{"body": graph}],
+                "code_highlight": {
+                    "language": "python",
+                    "lines": ["while queue:"],
+                    "active_lines": [0],
+                    "active_line": 0,
+                    "variables": {
+                        "current": "A",
+                        "queue": "[]",
+                        "visited": "{}",
+                    },
+                },
+                "tokens": [],
+            }
+        ],
+    }
+
+
+def _run(coro):
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)
+
+
+def _wechat_session(db: str):
+    session = _run(SqliteAccountRepository(db).get_or_create_session(None, session_days=30))
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """
+            UPDATE accounts
+            SET login_provider = 'wechat',
+                display_name = '微信用户',
+                wechat_openid = ?
+            WHERE user_id = ?
+            """,
+            (f"openid_{session.account.user_id}", session.account.user_id),
+        )
+        conn.commit()
+    return session

--- a/apps/api/tests/test_safe_math_expr.py
+++ b/apps/api/tests/test_safe_math_expr.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.domain.services.safe_math_expr import (
+    SafeMathExpressionError,
+    compile_safe_math_expression,
+)
+
+_CONTRACT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "eval"
+    / "fixtures"
+    / "interaction_math_expr_contract.json"
+)
+
+
+def test_safe_math_expression_matches_the_frontend_contract() -> None:
+    cases = json.loads(_CONTRACT_PATH.read_text(encoding="utf-8"))
+    for case in cases:
+        scope = {**case["params"], "x": case["x"]}
+        result = compile_safe_math_expression(case["expression"])(scope)
+        assert result == pytest.approx(case["expected"], rel=1e-12, abs=1e-12)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "__import__('os').system('id')",
+        "lambda x: x",
+        "2x",
+        "unknown_fn(x)",
+        "x" * 513,
+        "(" * 40 + "x" + ")" * 40,
+        "+".join(["x"] * 140),
+    ],
+)
+def test_safe_math_expression_rejects_code_and_excessive_complexity(source: str) -> None:
+    with pytest.raises(SafeMathExpressionError):
+        compile_safe_math_expression(source)
+
+
+def test_safe_math_expression_rejects_unknown_variables_at_evaluation() -> None:
+    expression = compile_safe_math_expression("x + missing")
+    with pytest.raises(SafeMathExpressionError, match="Unknown variable"):
+        expression({"x": 1})

--- a/apps/api/tests/test_sqlite_interaction_version_commit.py
+++ b/apps/api/tests/test_sqlite_interaction_version_commit.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+import pytest
+
+from app.application.ports.run_repository import InteractionVersionConflictError
+from app.domain.models.director import DirectorScript
+from app.domain.models.pipeline_run import PipelineRunStatus
+from app.infrastructure.persistence.db_init import init_db
+from app.infrastructure.persistence.sqlite_run_repository import SqliteRunRepository
+
+_RUN_ID = "interaction-atomic-run"
+_CREATED_AT = "2026-07-15T00:00:00+00:00"
+_INITIAL_PLAYBOOK = '{"marker_x":1}'
+_NEXT_PLAYBOOK = '{"marker_x":2}'
+_NEXT_QUALITY = '{"status":"passed"}'
+
+
+@pytest.mark.parametrize(
+    "trigger_sql",
+    [
+        """
+        CREATE TRIGGER fail_interaction_initial
+        BEFORE INSERT ON pipeline_run_versions
+        WHEN NEW.source = 'initial'
+        BEGIN
+            SELECT RAISE(ABORT, 'injected initial version failure');
+        END
+        """,
+        """
+        CREATE TRIGGER fail_interaction_child
+        BEFORE INSERT ON pipeline_run_versions
+        WHEN NEW.source = 'interaction'
+        BEGIN
+            SELECT RAISE(ABORT, 'injected interaction version failure');
+        END
+        """,
+        """
+        CREATE TRIGGER fail_interaction_director
+        BEFORE INSERT ON pipeline_run_directors
+        BEGIN
+            SELECT RAISE(ABORT, 'injected director failure');
+        END
+        """,
+        """
+        CREATE TRIGGER fail_interaction_active_run
+        BEFORE UPDATE OF playbook_json, quality_report_json ON pipeline_runs
+        BEGIN
+            SELECT RAISE(ABORT, 'injected active run failure');
+        END
+        """,
+    ],
+    ids=("initial", "interaction", "director", "active-run"),
+)
+def test_every_interaction_write_failure_rolls_back_without_history_pollution(
+    tmp_path,
+    trigger_sql: str,
+) -> None:
+    db_path = str(tmp_path / "fault-injection.db")
+    repo = _seed_repo(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(trigger_sql)
+
+    with pytest.raises(sqlite3.IntegrityError, match="injected"):
+        _run(
+            _commit(
+                repo,
+                version_id="interaction-v1",
+                expected_base_version_id=None,
+                playbook_json=_NEXT_PLAYBOOK,
+            )
+        )
+
+    with sqlite3.connect(db_path) as conn:
+        versions = conn.execute(
+            "SELECT version_id FROM pipeline_run_versions WHERE run_id=?",
+            (_RUN_ID,),
+        ).fetchall()
+        directors = conn.execute(
+            "SELECT run_id FROM pipeline_run_directors WHERE run_id=?",
+            (_RUN_ID,),
+        ).fetchall()
+        run_row = conn.execute(
+            "SELECT playbook_json, quality_report_json FROM pipeline_runs WHERE run_id=?",
+            (_RUN_ID,),
+        ).fetchone()
+
+    assert versions == []
+    assert directors == []
+    assert run_row == (_INITIAL_PLAYBOOK, None)
+
+
+def test_concurrent_repository_commits_with_one_base_have_one_winner(tmp_path) -> None:
+    db_path = str(tmp_path / "cas.db")
+    repo = _seed_repo(db_path)
+    _run(
+        _commit(
+            repo,
+            version_id="interaction-v1",
+            expected_base_version_id=None,
+            playbook_json=_NEXT_PLAYBOOK,
+        )
+    )
+
+    async def _race() -> list[object]:
+        return await asyncio.gather(
+            _commit(
+                repo,
+                version_id="interaction-v2-a",
+                expected_base_version_id="interaction-v1",
+                playbook_json='{"marker_x":3}',
+                source_playbook_json=_NEXT_PLAYBOOK,
+            ),
+            _commit(
+                repo,
+                version_id="interaction-v2-b",
+                expected_base_version_id="interaction-v1",
+                playbook_json='{"marker_x":4}',
+                source_playbook_json=_NEXT_PLAYBOOK,
+            ),
+            return_exceptions=True,
+        )
+
+    results = _run(_race())
+    assert sum(result is None for result in results) == 1
+    assert sum(isinstance(result, InteractionVersionConflictError) for result in results) == 1
+
+    with sqlite3.connect(db_path) as conn:
+        versions = conn.execute(
+            "SELECT version_id, parent_version_id, playbook_json"
+            " FROM pipeline_run_versions WHERE run_id=? ORDER BY version_number",
+            (_RUN_ID,),
+        ).fetchall()
+        active = conn.execute(
+            "SELECT playbook_json FROM pipeline_runs WHERE run_id=?",
+            (_RUN_ID,),
+        ).fetchone()
+
+    assert [row[0] for row in versions[:2]] == [f"{_RUN_ID}:v0", "interaction-v1"]
+    assert len(versions) == 3
+    assert versions[2][1] == "interaction-v1"
+    assert active == (versions[2][2],)
+
+
+def test_existing_head_requires_an_explicit_base(tmp_path) -> None:
+    repo = _seed_repo(str(tmp_path / "strict-base.db"))
+    _run(
+        _commit(
+            repo,
+            version_id="interaction-v1",
+            expected_base_version_id=None,
+            playbook_json=_NEXT_PLAYBOOK,
+        )
+    )
+
+    with pytest.raises(InteractionVersionConflictError):
+        _run(
+            _commit(
+                repo,
+                version_id="interaction-v2",
+                expected_base_version_id=None,
+                playbook_json='{"marker_x":3}',
+            )
+        )
+
+    versions = _run(repo.list_versions(_RUN_ID))
+    assert [version.version_id for version in versions] == [
+        f"{_RUN_ID}:v0",
+        "interaction-v1",
+    ]
+
+
+def test_source_playbook_change_is_rejected_even_before_a_version_exists(tmp_path) -> None:
+    db_path = str(tmp_path / "source-cas.db")
+    repo = _seed_repo(db_path)
+    _run(repo.update_playbook_json(_RUN_ID, '{"marker_x":9}'))
+
+    with pytest.raises(InteractionVersionConflictError, match="source lesson has changed"):
+        _run(
+            _commit(
+                repo,
+                version_id="interaction-v1",
+                expected_base_version_id=None,
+                playbook_json=_NEXT_PLAYBOOK,
+            )
+        )
+
+    assert _run(repo.list_versions(_RUN_ID)) == []
+
+
+def _seed_repo(db_path: str) -> SqliteRunRepository:
+    init_db(db_path)
+    repo = SqliteRunRepository(db_path)
+    _run(repo.create(_RUN_ID, "move the tangent", _CREATED_AT))
+    _run(
+        repo.update(
+            _RUN_ID,
+            status=PipelineRunStatus.SUCCEEDED,
+            playbook_json=_INITIAL_PLAYBOOK,
+        )
+    )
+    return repo
+
+
+async def _commit(
+    repo: SqliteRunRepository,
+    *,
+    version_id: str,
+    expected_base_version_id: str | None,
+    playbook_json: str,
+    source_playbook_json: str = _INITIAL_PLAYBOOK,
+) -> None:
+    await repo.commit_interaction_version(
+        _RUN_ID,
+        expected_base_version_id=expected_base_version_id,
+        version_id=version_id,
+        initial_playbook_json=source_playbook_json,
+        playbook_json=playbook_json,
+        quality_report_json=_NEXT_QUALITY,
+        director=DirectorScript(run_id=_RUN_ID),
+        summary="move tangent",
+        created_at=_CREATED_AT,
+    )
+
+
+def _run(coro):
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)

--- a/apps/web/src/features/followups/api/followupApi.test.ts
+++ b/apps/web/src/features/followups/api/followupApi.test.ts
@@ -3,7 +3,13 @@ import { http, HttpResponse } from "msw";
 
 import { server } from "../../../mocks/server";
 import { API_BASE_URL } from "../../../shared/config/constants";
-import { listRunFollowUps, restoreRunVersion, submitRunFollowUp } from "./followupApi";
+import {
+  applyRunInteractionVersion,
+  InteractionVersionRequestError,
+  listRunFollowUps,
+  restoreRunVersion,
+  submitRunFollowUp,
+} from "./followupApi";
 
 describe("followupApi", () => {
   it("submits run follow-ups with provider override and returns patched playbook", async () => {
@@ -151,6 +157,75 @@ describe("followupApi", () => {
     expect(history.versions[0].is_head).toBe(true);
     expect(restored.version_id).toBe("v0");
     expect(restored.playbook.title).toBe("Original");
+  });
+
+  it("applies normalized interactions to an explicit child version", async () => {
+    let requestBody: unknown = null;
+    server.use(
+      http.post(
+        `${API_BASE_URL}/api/v1/runs/run-1/interaction-version`,
+        async ({ request }) => {
+          expect(request.credentials).toBe("include");
+          requestBody = await request.json();
+          return HttpResponse.json({
+            version_id: "v2",
+            summary: "Moved the tangent point.",
+            playbook: playbook("Interaction version"),
+            director: { schema_version: "1.0.0", run_id: "run-1", beats: [] },
+          });
+        },
+      ),
+    );
+
+    const result = await applyRunInteractionVersion(
+      "run-1",
+      [{
+        adapter_id: "math.derivative-tangent",
+        step_id: "plot",
+        target_id: "step:plot:marker-x",
+        action: "set-value",
+        value: 3,
+        sequence: 1,
+      }],
+      "v1",
+    );
+
+    expect(result.version_id).toBe("v2");
+    expect(requestBody).toMatchObject({
+      manifest_version: "1",
+      base_version_id: "v1",
+      events: [{ target_id: "step:plot:marker-x", value: 3 }],
+    });
+  });
+
+  it("preserves the response status for interaction version conflicts", async () => {
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/runs/run-1/interaction-version`, () =>
+        HttpResponse.json({ detail: "stale interaction base" }, { status: 409 }),
+      ),
+    );
+
+    const request = applyRunInteractionVersion(
+      "run-1",
+      [{
+        adapter_id: "math.derivative-tangent",
+        step_id: "plot",
+        target_id: "step:plot:marker-x",
+        action: "set-value",
+        value: 3,
+        sequence: 1,
+      }],
+      "v1",
+    );
+
+    await expect(request).rejects.toEqual(expect.objectContaining({
+      name: "InteractionVersionRequestError",
+      message: "stale interaction base",
+      status: 409,
+    }));
+    await request.catch((error) => {
+      expect(error).toBeInstanceOf(InteractionVersionRequestError);
+    });
   });
 });
 

--- a/apps/web/src/features/followups/api/followupApi.ts
+++ b/apps/web/src/features/followups/api/followupApi.ts
@@ -1,6 +1,9 @@
 import { API_BASE_URL, readErrorMessage } from "../../../shared/api/httpClient";
 import type { DirectorScript, PlaybookScript } from "../../playbook/engine/types";
-import type { InteractionFollowUpContext } from "../../playbook/interaction/types";
+import type {
+  InteractionEvent,
+  InteractionFollowUpContext,
+} from "../../playbook/interaction/types";
 import type { ProviderSettings } from "../../providers/hooks/useProviderSettings";
 
 export interface FollowUpChatMessage {
@@ -44,6 +47,23 @@ export interface FollowUpResponse {
   version_id: string | null;
   playbook: PlaybookScript | null;
   director?: DirectorScript | null;
+}
+
+export interface ApplyInteractionVersionResponse {
+  version_id: string;
+  summary: string;
+  playbook: PlaybookScript;
+  director: DirectorScript;
+}
+
+export class InteractionVersionRequestError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "InteractionVersionRequestError";
+    this.status = status;
+  }
 }
 
 export async function submitRunFollowUp(
@@ -97,13 +117,44 @@ export async function listRunFollowUps(
   return (await response.json()) as RunFollowUpsResponse;
 }
 
+export async function applyRunInteractionVersion(
+  runId: string,
+  events: InteractionEvent[],
+  baseVersionId?: string | null,
+  signal?: AbortSignal,
+): Promise<ApplyInteractionVersionResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/v1/runs/${runId}/interaction-version`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({
+        manifest_version: "1",
+        events,
+        base_version_id: baseVersionId ?? null,
+      }),
+      signal,
+    },
+  );
+  if (!response.ok) {
+    throw new InteractionVersionRequestError(
+      await readErrorMessage(response, "Failed to apply interaction version"),
+      response.status,
+    );
+  }
+  return (await response.json()) as ApplyInteractionVersionResponse;
+}
+
 export async function restoreRunVersion(
   runId: string,
   versionId: string,
+  signal?: AbortSignal,
 ): Promise<{ version_id: string; playbook: PlaybookScript; director?: DirectorScript | null }> {
   const response = await fetch(`${API_BASE_URL}/api/v1/runs/${runId}/versions/${versionId}/restore`, {
     method: "POST",
     credentials: "include",
+    signal,
   });
   if (!response.ok) {
     throw new Error(await readErrorMessage(response, "Version restore failed"));

--- a/apps/web/src/features/pipeline/api/pipelineApi.ts
+++ b/apps/web/src/features/pipeline/api/pipelineApi.ts
@@ -40,9 +40,13 @@ export async function submitPipeline(
   return (await response.json()) as SubmitPipelineResponse;
 }
 
-export async function getPipelineRun(runId: string): Promise<PipelineRunResult> {
+export async function getPipelineRun(
+  runId: string,
+  signal?: AbortSignal,
+): Promise<PipelineRunResult> {
   const response = await fetch(`${API_BASE_URL}/api/v1/runs/${runId}`, {
     credentials: "include",
+    signal,
   });
   if (!response.ok) {
     throw new Error(await readErrorMessage(response, "Failed to fetch run"));

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.test.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.test.tsx
@@ -970,8 +970,8 @@ describe("PlaybookPlayer", () => {
     expect(onApplyInteractionVersion).toHaveBeenCalledWith([
       expect.objectContaining({
         adapter_id: "math.derivative-tangent",
-        step_id: "s1",
-        target_id: "step:s1:marker-x",
+        step_id: "plot",
+        target_id: "step:plot:marker-x",
         action: "set-value",
         value: 2,
         sequence: 1,

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.test.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.test.tsx
@@ -903,6 +903,7 @@ describe("PlaybookPlayer", () => {
     );
 
     expect(view.getByText("Explore")).toBeTruthy();
+    expect(view.queryByText("此步骤无可调参数。")).toBeNull();
     expect(view.getByTestId("mock-remotion-player").getAttribute("data-has-interaction"))
       .toBe("true");
 
@@ -944,6 +945,92 @@ describe("PlaybookPlayer", () => {
         sequence: 1,
       })],
     });
+  });
+
+  it("persists semantic sandbox events only through the explicit apply button", async () => {
+    const onApplyInteractionVersion = vi.fn().mockResolvedValue(undefined);
+    const view = render(
+      <PlaybookPlayer
+        script={derivativeScript()}
+        theme="light"
+        enableInteractionSandbox
+        onApplyInteractionVersion={onApplyInteractionVersion}
+      />,
+    );
+
+    expect(onApplyInteractionVersion).not.toHaveBeenCalled();
+    const slider = view.getByRole("slider", { name: "切点 x" });
+    fireEvent.change(slider, { target: { value: "2" } });
+    fireEvent.pointerUp(slider);
+    expect(onApplyInteractionVersion).not.toHaveBeenCalled();
+
+    fireEvent.click(view.getByRole("button", { name: "应用到新版本" }));
+
+    await waitFor(() => expect(onApplyInteractionVersion).toHaveBeenCalledTimes(1));
+    expect(onApplyInteractionVersion).toHaveBeenCalledWith([
+      expect.objectContaining({
+        adapter_id: "math.derivative-tangent",
+        step_id: "s1",
+        target_id: "step:s1:marker-x",
+        action: "set-value",
+        value: 2,
+        sequence: 1,
+      }),
+    ]);
+  });
+
+  it("acknowledges a saved round-trip and clears identical-content sandbox history", async () => {
+    const onApplyInteractionVersion = vi.fn().mockResolvedValue(undefined);
+    const view = render(
+      <PlaybookPlayer
+        script={derivativeScript()}
+        theme="light"
+        enableInteractionSandbox
+        onApplyInteractionVersion={onApplyInteractionVersion}
+      />,
+    );
+
+    const slider = view.getByRole("slider", { name: "切点 x" });
+    fireEvent.change(slider, { target: { value: "2" } });
+    fireEvent.pointerUp(slider);
+    fireEvent.change(slider, { target: { value: "1" } });
+    fireEvent.pointerUp(slider);
+    expect(view.getByText("2 个未保存操作")).toBeTruthy();
+
+    fireEvent.click(view.getByRole("button", { name: "应用到新版本" }));
+
+    await waitFor(() => expect(onApplyInteractionVersion).toHaveBeenCalledTimes(1));
+    expect(onApplyInteractionVersion.mock.calls[0]?.[0]).toHaveLength(2);
+    await waitFor(() => {
+      expect(view.getByText("不会修改原课程")).toBeTruthy();
+      expect(
+        view.getByRole<HTMLButtonElement>("button", { name: "应用到新版本" }).disabled,
+      ).toBe(true);
+    });
+  });
+
+  it("opens the portrait follow-up sheet after an apply outcome", async () => {
+    const onApplyInteractionVersion = vi.fn().mockResolvedValue(undefined);
+    const view = render(
+      <PlaybookPlayer
+        script={derivativeScript()}
+        theme="light"
+        layoutMode="portrait"
+        enableInteractionSandbox
+        onApplyInteractionVersion={onApplyInteractionVersion}
+        followupSlot={<div>版本保存结果</div>}
+      />,
+    );
+
+    fireEvent.click(view.getByRole("tab", { name: "参数" }));
+    const slider = view.getByRole("slider", { name: "切点 x" });
+    fireEvent.change(slider, { target: { value: "2" } });
+    fireEvent.pointerUp(slider);
+    fireEvent.click(view.getByRole("button", { name: "应用到新版本" }));
+
+    await waitFor(() => expect(onApplyInteractionVersion).toHaveBeenCalledTimes(1));
+    expect(view.container.querySelector(".playbook-player__mobile-sheet")).toBeTruthy();
+    expect(view.getByText("版本保存结果")).toBeTruthy();
   });
 
   it("keeps recovery controls after navigating away from the bound plot", async () => {

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
@@ -29,8 +29,12 @@ import { SPEED_STEPS } from "./playbackRates";
 import { DirectorInspector } from "../director/DirectorInspector";
 import type { RendererInteractionEvent } from "../renderers/types";
 import { InteractionSandboxPanel } from "../../interaction/InteractionSandboxPanel";
+import { deriveInteractionManifest } from "../../interaction/engine";
 import { useInteractionSandbox } from "../../interaction/useInteractionSandbox";
-import type { InteractionFollowUpContext } from "../../interaction/types";
+import type {
+  InteractionEvent,
+  InteractionFollowUpContext,
+} from "../../interaction/types";
 
 export type PlaybookLayoutMode = "desktop" | "portrait";
 
@@ -80,6 +84,12 @@ interface PlaybookPlayerProps {
   enableInteractionSandbox?: boolean;
   /** Explicit user-triggered handoff of normalized semantic events to follow-up AI. */
   onExplainInteraction?: (context: InteractionFollowUpContext) => Promise<void>;
+  /** Explicit user-triggered persistence of the current sandbox as a new version. */
+  onApplyInteractionVersion?: (events: InteractionEvent[]) => Promise<void>;
+  /** Prevent sandbox mutations while a Studio interaction action is in flight. */
+  interactionActionPending?: boolean;
+  /** Isolates browser-only sandbox history between runs with identical scripts. */
+  interactionSessionKey?: string;
   topbarCollapsed?: boolean;
   onToggleTopbar?: () => void;
   layoutMode?: PlaybookLayoutMode;
@@ -96,6 +106,9 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
   showLearningConsole = true,
   enableInteractionSandbox = false,
   onExplainInteraction,
+  onApplyInteractionVersion,
+  interactionActionPending = false,
+  interactionSessionKey = "",
   topbarCollapsed = false,
   onToggleTopbar,
   layoutMode,
@@ -109,9 +122,19 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
   const [playbackRate, setPlaybackRate] = useState(1);
   const [mobileTab, setMobileTab] = useState<MobileTabKey>("narration");
   const [mobileSheet, setMobileSheet] = useState<MobileTabKey | null>(null);
-  const script = useResolvedScript(baseScript, overrides);
-  const interactionSandbox = useInteractionSandbox(script);
-  const interactionEnabled = enableInteractionSandbox && showLearningConsole;
+  const resolvedScript = useResolvedScript(baseScript, overrides);
+  const canonicalInteractionManifest = useMemo(
+    () => deriveInteractionManifest(baseScript),
+    [baseScript],
+  );
+  const interactionEnabled = enableInteractionSandbox &&
+    showLearningConsole &&
+    canonicalInteractionManifest.adapters.length > 0;
+  // Persistence replays semantic events against the canonical run playbook.
+  // Pilot previews must use that same base, so frontend-only parameter
+  // overrides cannot produce a different result from the saved version.
+  const script = interactionEnabled ? baseScript : resolvedScript;
+  const interactionSandbox = useInteractionSandbox(script, interactionSessionKey);
   const displayScript = interactionEnabled ? interactionSandbox.previewScript : script;
   const interactionManifest = interactionSandbox.manifest;
   const capability = useMemo(() => domainCapability(script.domain), [script.domain]);
@@ -125,6 +148,7 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
     }
     return true;
   }, [baseScript]);
+  const showDomainPanel = hasDomainPanel && !interactionEnabled;
   const initialPreviewFrame = useMemo(() => resolveInitialPreviewFrame(script), [script]);
   const playerTimelineKey = useMemo(() => resolvePlayerTimelineKey(baseScript), [baseScript]);
 
@@ -290,6 +314,7 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
         ? "math_plot"
         : undefined;
   const handleRendererInteraction = (event: RendererInteractionEvent) => {
+    if (interactionActionPending) return;
     if (event.type === "select-node") {
       if (
         currentInteractionBinding?.target_role !== "start-node" ||
@@ -327,8 +352,22 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
   const showInteractionPanel = interactionEnabled && (
     hasCurrentInteraction || interactionSandbox.dirty || interactionSandbox.lastError != null
   );
+  const persistInteractionVersion = onApplyInteractionVersion
+    ? async (events: InteractionEvent[]) => {
+      try {
+        await onApplyInteractionVersion(events);
+        if (isPortraitLayout) setMobileSheet("followup");
+      } catch (error) {
+        if ((error as Error).name !== "AbortError" && isPortraitLayout) {
+          setMobileSheet("followup");
+        }
+        throw error;
+      }
+    }
+    : undefined;
   const interactionSlot = showInteractionPanel ? (
     <InteractionSandboxPanel
+      key={interactionSessionKey}
       manifest={interactionManifest}
       currentStepId={currentStep.step_id}
       events={interactionSandbox.events}
@@ -337,10 +376,12 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
       lastError={interactionSandbox.lastError}
       latestReplay={interactionSandbox.latestReplay}
       onShowReplayFrame={interactionSandbox.showReplayFrame}
-      onApply={interactionSandbox.apply}
+      onApply={interactionActionPending ? () => undefined : interactionSandbox.apply}
       onUndo={interactionSandbox.undo}
       onReset={interactionSandbox.reset}
       onExplainInteraction={onExplainInteraction}
+      onApplyVersion={persistInteractionVersion}
+      actionPending={interactionActionPending}
     />
   ) : undefined;
   const isDark = theme === "dark";
@@ -354,7 +395,7 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
     currentNarrationFallback,
   );
   const showMobileConsole = isPortraitLayout && showLearningConsole;
-  const hasControlPanel = hasDomainPanel || showInteractionPanel;
+  const hasControlPanel = showDomainPanel || showInteractionPanel;
   const effectiveMobileTab =
     mobileTab === "params" && !hasControlPanel ? "narration" : mobileTab;
   const effectiveMobileSheet =
@@ -379,7 +420,7 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
   const mobileParamsContent = (
     <>
       {interactionSlot}
-      {hasDomainPanel && (
+      {showDomainPanel && (
         <ParamPanelSlot
           domain={baseScript.domain}
           script={baseScript}
@@ -649,7 +690,7 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
           showCodePanelSlot={showCodePanelSlot}
           codeOverlay={codeOverlay}
           theme={theme}
-          hasDomainPanel={hasDomainPanel}
+          hasDomainPanel={showDomainPanel}
           baseScript={baseScript}
           overrides={overrides}
           onOverridesChange={setOverrides}

--- a/apps/web/src/features/playbook/interaction/InteractionSandboxPanel.test.tsx
+++ b/apps/web/src/features/playbook/interaction/InteractionSandboxPanel.test.tsx
@@ -218,6 +218,29 @@ describe("InteractionSandboxPanel", () => {
     expect(view.getByRole("button", { name: "暂停" }).getAttribute("aria-pressed")).toBe("true");
     fireEvent.click(view.getByRole("button", { name: "暂停" }));
     expect(view.getByRole("button", { name: "播放" }).getAttribute("aria-pressed")).toBe("false");
+
+    view.rerender(
+      <InteractionSandboxPanel
+        manifest={manifest}
+        currentStepId="graph"
+        events={[]}
+        dirty
+        canUndo
+        lastError={null}
+        latestReplay={replay}
+        onShowReplayFrame={onShowReplayFrame}
+        onApply={onApply}
+        onUndo={vi.fn()}
+        onReset={vi.fn()}
+        actionPending
+      />,
+    );
+    const callsBeforeLockedClick = onShowReplayFrame.mock.calls.length;
+    for (const name of ["第一帧", "上一帧", "播放", "下一帧", "最后一帧"]) {
+      expect(view.getByRole<HTMLButtonElement>("button", { name }).disabled).toBe(true);
+    }
+    fireEvent.click(view.getByRole("button", { name: "下一帧" }));
+    expect(onShowReplayFrame).toHaveBeenCalledTimes(callsBeforeLockedClick);
   });
 
   it("renders nothing when the current step has no declared binding", () => {
@@ -336,5 +359,62 @@ describe("InteractionSandboxPanel", () => {
     await waitFor(() => {
       expect(view.getByRole("button", { name: "解释我的操作" })).toBeTruthy();
     });
+  });
+
+  it("applies a semantic event snapshot only after an explicit click and locks actions", async () => {
+    let finishApply: (() => void) | undefined;
+    const onApplyVersion = vi.fn(() => new Promise<void>((resolve) => {
+      finishApply = resolve;
+    }));
+    const onExplainInteraction = vi.fn().mockResolvedValue(undefined);
+    const onUndo = vi.fn();
+    const onReset = vi.fn();
+    const event = {
+      adapter_id: "math.derivative-tangent" as const,
+      step_id: "plot",
+      target_id: "step:plot:marker-x",
+      action: "set-value" as const,
+      value: 3,
+      sequence: 1,
+    };
+    const view = render(
+      <InteractionSandboxPanel
+        manifest={derivativeManifest}
+        currentStepId="plot"
+        events={[event]}
+        dirty
+        canUndo
+        lastError={null}
+        latestReplay={null}
+        onShowReplayFrame={vi.fn()}
+        onApply={vi.fn()}
+        onUndo={onUndo}
+        onReset={onReset}
+        onExplainInteraction={onExplainInteraction}
+        onApplyVersion={onApplyVersion}
+      />,
+    );
+
+    expect(onApplyVersion).not.toHaveBeenCalled();
+    fireEvent.click(view.getByRole("button", { name: "应用到新版本" }));
+
+    expect(onApplyVersion).toHaveBeenCalledTimes(1);
+    expect(onApplyVersion).toHaveBeenCalledWith([event]);
+    const pendingButton = view.getByRole<HTMLButtonElement>("button", { name: "应用中…" });
+    expect(pendingButton.disabled).toBe(true);
+    expect(pendingButton.getAttribute("aria-busy")).toBe("true");
+    expect(view.getByRole<HTMLButtonElement>("button", { name: "解释我的操作" }).disabled)
+      .toBe(true);
+    expect(view.getByRole<HTMLButtonElement>("button", { name: "撤销" }).disabled).toBe(true);
+    expect(view.getByRole<HTMLButtonElement>("button", { name: "重置" }).disabled).toBe(true);
+    expect(view.getByRole<HTMLInputElement>("slider", { name: "切点 x" }).disabled).toBe(true);
+
+    finishApply?.();
+    await waitFor(() => {
+      expect(view.getByRole("button", { name: "应用到新版本" })).toBeTruthy();
+    });
+    expect(onExplainInteraction).not.toHaveBeenCalled();
+    expect(onUndo).not.toHaveBeenCalled();
+    expect(onReset).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/features/playbook/interaction/InteractionSandboxPanel.tsx
+++ b/apps/web/src/features/playbook/interaction/InteractionSandboxPanel.tsx
@@ -27,14 +27,18 @@ interface InteractionSandboxPanelProps {
   onUndo: () => void;
   onReset: () => void;
   onExplainInteraction?: (context: InteractionFollowUpContext) => Promise<void>;
+  onApplyVersion?: (events: InteractionEvent[]) => Promise<void>;
+  actionPending?: boolean;
 }
 
 function RangeBinding({
   binding,
   onApply,
+  disabled = false,
 }: {
   binding: DerivativeInteractionBinding;
   onApply: (command: InteractionCommand) => void;
+  disabled?: boolean;
 }) {
   const current = binding.value;
   const [draftState, setDraftState] = useState(() => ({
@@ -44,7 +48,7 @@ function RangeBinding({
   const draft = draftState.source === binding ? draftState.value : current;
 
   const commit = () => {
-    if (!Number.isFinite(draft) || draft === current) return;
+    if (disabled || !Number.isFinite(draft) || draft === current) return;
     onApply({
       adapter_id: binding.adapter_id,
       step_id: binding.step_id,
@@ -71,6 +75,7 @@ function RangeBinding({
         step={step}
         value={draft}
         aria-label={binding.label}
+        disabled={disabled}
         onChange={(event) => setDraftState({
           source: binding,
           value: Number(event.currentTarget.value),
@@ -87,10 +92,12 @@ function ChoiceBinding({
   binding,
   selectedValue,
   onApply,
+  disabled = false,
 }: {
   binding: BfsInteractionBinding;
   selectedValue: string;
   onApply: (command: InteractionCommand) => void;
+  disabled?: boolean;
 }) {
   return (
     <div className="playbook-interaction__choice" role="group" aria-label={binding.label}>
@@ -101,7 +108,7 @@ function ChoiceBinding({
             key={option.id}
             type="button"
             aria-pressed={selectedValue === option.id}
-            disabled={selectedValue === option.id}
+            disabled={disabled || selectedValue === option.id}
             onClick={() => onApply({
               adapter_id: binding.adapter_id,
               step_id: binding.step_id,
@@ -121,19 +128,22 @@ function ChoiceBinding({
 function BfsReplayControls({
   replay,
   onShowFrame,
+  disabled = false,
 }: {
   replay: BfsInteractionReplay;
   onShowFrame: (replay: BfsInteractionReplay, frameIndex: number) => void;
+  disabled?: boolean;
 }) {
   const [frameIndex, setFrameIndex] = useState(0);
   const [playing, setPlaying] = useState(false);
   const lastIndex = Math.max(0, replay.frames.length - 1);
 
   const showFrame = useCallback((nextIndex: number) => {
+    if (disabled) return;
     const bounded = Math.max(0, Math.min(nextIndex, lastIndex));
     setFrameIndex(bounded);
     onShowFrame(replay, bounded);
-  }, [lastIndex, onShowFrame, replay]);
+  }, [disabled, lastIndex, onShowFrame, replay]);
 
   const showManualFrame = (nextIndex: number) => {
     setPlaying(false);
@@ -141,14 +151,14 @@ function BfsReplayControls({
   };
 
   useEffect(() => {
-    if (!playing || frameIndex >= lastIndex) return;
+    if (disabled || !playing || frameIndex >= lastIndex) return;
     const timeout = window.setTimeout(() => {
       const nextIndex = frameIndex + 1;
       showFrame(nextIndex);
       if (nextIndex >= lastIndex) setPlaying(false);
     }, 700);
     return () => window.clearTimeout(timeout);
-  }, [frameIndex, lastIndex, playing, showFrame]);
+  }, [disabled, frameIndex, lastIndex, playing, showFrame]);
 
   return (
     <div className="playbook-interaction__replay" role="group" aria-label="BFS 重放">
@@ -166,14 +176,14 @@ function BfsReplayControls({
         <button
           type="button"
           onClick={() => showManualFrame(0)}
-          disabled={frameIndex === 0}
+          disabled={disabled || frameIndex === 0}
         >
           第一帧
         </button>
         <button
           type="button"
           onClick={() => showManualFrame(frameIndex - 1)}
-          disabled={frameIndex === 0}
+          disabled={disabled || frameIndex === 0}
         >
           上一帧
         </button>
@@ -183,7 +193,7 @@ function BfsReplayControls({
             if (frameIndex >= lastIndex) showFrame(0);
             setPlaying((value) => !value);
           }}
-          disabled={replay.frames.length < 2}
+          disabled={disabled || replay.frames.length < 2}
           aria-pressed={playing}
         >
           {playing ? "暂停" : "播放"}
@@ -191,14 +201,14 @@ function BfsReplayControls({
         <button
           type="button"
           onClick={() => showManualFrame(frameIndex + 1)}
-          disabled={frameIndex >= lastIndex}
+          disabled={disabled || frameIndex >= lastIndex}
         >
           下一帧
         </button>
         <button
           type="button"
           onClick={() => showManualFrame(lastIndex)}
-          disabled={frameIndex >= lastIndex}
+          disabled={disabled || frameIndex >= lastIndex}
         >
           最后一帧
         </button>
@@ -220,8 +230,10 @@ export function InteractionSandboxPanel({
   onUndo,
   onReset,
   onExplainInteraction,
+  onApplyVersion,
+  actionPending = false,
 }: InteractionSandboxPanelProps) {
-  const [explainPending, setExplainPending] = useState(false);
+  const [pendingAction, setPendingAction] = useState<"explain" | "apply" | null>(null);
   const binding = useMemo(
     () => manifest.adapters
       .flatMap((adapter) => adapter.bindings)
@@ -236,16 +248,32 @@ export function InteractionSandboxPanel({
     () => events.slice(-4).map(describeInteractionEvent),
     [events],
   );
+  const controlsPending = actionPending || pendingAction !== null;
 
   const explainInteraction = async () => {
-    if (!onExplainInteraction || !explanationContext || explainPending) return;
-    setExplainPending(true);
+    if (!onExplainInteraction || !explanationContext || controlsPending) return;
+    setPendingAction("explain");
     try {
       await onExplainInteraction(explanationContext);
     } catch {
       // The owning follow-up surface renders request failures in its message stream.
     } finally {
-      setExplainPending(false);
+      setPendingAction(null);
+    }
+  };
+
+  const applyVersion = async () => {
+    if (!onApplyVersion || !dirty || events.length === 0 || controlsPending) return;
+    const eventSnapshot = events.map((event) => ({ ...event }));
+    setPendingAction("apply");
+    try {
+      await onApplyVersion(eventSnapshot);
+      onReset();
+    } catch {
+      // The owning Studio surface renders the outcome in follow-up and opens
+      // that sheet on portrait layouts.
+    } finally {
+      setPendingAction(null);
     }
   };
 
@@ -279,6 +307,7 @@ export function InteractionSandboxPanel({
           key={binding.id}
           binding={binding}
           onApply={onApply}
+          disabled={controlsPending}
         />
       ) : binding?.target_role === "start-node" ? (
         <>
@@ -290,12 +319,14 @@ export function InteractionSandboxPanel({
                 : binding.value
             }
             onApply={onApply}
+            disabled={controlsPending}
           />
           {latestReplay?.step_id === binding.step_id && (
             <BfsReplayControls
               key={`${latestReplay.step_id}:${latestReplay.start_node_id}`}
               replay={latestReplay}
               onShowFrame={onShowReplayFrame}
+              disabled={controlsPending}
             />
           )}
         </>
@@ -317,16 +348,31 @@ export function InteractionSandboxPanel({
             type="button"
             className="playbook-interaction__explain"
             onClick={explainInteraction}
-            disabled={!explanationContext || explainPending}
-            aria-busy={explainPending}
+            disabled={!explanationContext || controlsPending}
+            aria-busy={pendingAction === "explain"}
           >
-            {explainPending ? "解释中…" : "解释我的操作"}
+            {pendingAction === "explain" ? "解释中…" : "解释我的操作"}
           </button>
         )}
-        <button type="button" onClick={onUndo} disabled={!canUndo}>
+        {onApplyVersion && (
+          <button
+            type="button"
+            className="playbook-interaction__apply-version"
+            onClick={applyVersion}
+            disabled={!dirty || events.length === 0 || controlsPending}
+            aria-busy={pendingAction === "apply"}
+          >
+            {pendingAction === "apply" ? "应用中…" : "应用到新版本"}
+          </button>
+        )}
+        <button type="button" onClick={onUndo} disabled={!canUndo || controlsPending}>
           撤销
         </button>
-        <button type="button" onClick={onReset} disabled={!dirty && !lastError}>
+        <button
+          type="button"
+          onClick={onReset}
+          disabled={controlsPending || (!dirty && !lastError)}
+        >
           重置
         </button>
       </div>

--- a/apps/web/src/features/playbook/interaction/useInteractionSandbox.test.tsx
+++ b/apps/web/src/features/playbook/interaction/useInteractionSandbox.test.tsx
@@ -6,7 +6,10 @@ import type {
   MathPlotSnapshot,
   PlaybookScript,
 } from "../engine/types";
-import { useInteractionSandbox } from "./useInteractionSandbox";
+import {
+  MAX_INTERACTION_EVENTS,
+  useInteractionSandbox,
+} from "./useInteractionSandbox";
 
 function plot(markerX = 1): MathPlotSnapshot {
   return {
@@ -221,4 +224,38 @@ describe("useInteractionSandbox", () => {
     expect((result.current.previewScript.steps[0].snapshot as MathPlotSnapshot).marker_x).toBe(-2);
   });
 
+  it("keeps the event history within the server contract limit", () => {
+    const { result } = renderHook(() => useInteractionSandbox(script()));
+
+    act(() => {
+      for (let index = 0; index < MAX_INTERACTION_EVENTS; index += 1) {
+        result.current.apply(moveMarker(index % 2 === 0 ? 2 : 3));
+      }
+    });
+    expect(result.current.events).toHaveLength(MAX_INTERACTION_EVENTS);
+
+    act(() => result.current.apply(moveMarker(4)));
+    expect(result.current.events).toHaveLength(MAX_INTERACTION_EVENTS);
+    expect(result.current.lastError).toContain(`最多记录 ${MAX_INTERACTION_EVENTS} 个操作`);
+
+    act(() => result.current.undo());
+    expect(result.current.events).toHaveLength(MAX_INTERACTION_EVENTS - 1);
+    expect(result.current.lastError).toBeNull();
+  });
+
+  it("isolates sandbox history between sessions with identical playbook content", () => {
+    const base = script();
+    const { result, rerender } = renderHook(
+      ({ sessionKey }) => useInteractionSandbox(base, sessionKey),
+      { initialProps: { sessionKey: "run-a" } },
+    );
+
+    act(() => result.current.apply(moveMarker(3)));
+    expect(result.current.events).toHaveLength(1);
+
+    rerender({ sessionKey: "run-b" });
+    expect(result.current.events).toEqual([]);
+    expect(result.current.dirty).toBe(false);
+    expect((result.current.previewScript.steps[0].snapshot as MathPlotSnapshot).marker_x).toBe(1);
+  });
 });

--- a/apps/web/src/features/playbook/interaction/useInteractionSandbox.ts
+++ b/apps/web/src/features/playbook/interaction/useInteractionSandbox.ts
@@ -13,6 +13,8 @@ import type {
   InteractionManifest,
 } from "./types";
 
+export const MAX_INTERACTION_EVENTS = 100;
+
 interface InteractionSandboxState {
   baseKey: string;
   baseScript: PlaybookScript;
@@ -219,6 +221,14 @@ function reducer(
     }
   }
 
+  if (action.type === "apply" && current.events.length >= MAX_INTERACTION_EVENTS) {
+    return {
+      ...current,
+      previewScript: current.committedScript,
+      lastError: `沙盒最多记录 ${MAX_INTERACTION_EVENTS} 个操作；请先应用到新版本或重置。`,
+    };
+  }
+
   try {
     const result = applyInteraction(
       current.committedScript,
@@ -271,8 +281,14 @@ export interface InteractionSandbox {
   reset: () => void;
 }
 
-export function useInteractionSandbox(baseScript: PlaybookScript): InteractionSandbox {
-  const baseKey = useMemo(() => scriptContentKey(baseScript), [baseScript]);
+export function useInteractionSandbox(
+  baseScript: PlaybookScript,
+  sessionKey = "",
+): InteractionSandbox {
+  const baseKey = useMemo(
+    () => `${sessionKey}\u0000${scriptContentKey(baseScript)}`,
+    [baseScript, sessionKey],
+  );
   const [storedState, dispatch] = useReducer(
     reducer,
     { baseScript, baseKey },

--- a/apps/web/src/pages/Studio/StudioPage.test.tsx
+++ b/apps/web/src/pages/Studio/StudioPage.test.tsx
@@ -43,6 +43,7 @@ vi.mock("../../features/playbook/engine/player/PlaybookPlayer", async () => {
       onExplainInteraction,
       onApplyInteractionVersion,
       interactionActionPending = false,
+      interactionSessionKey,
       enableInteractionSandbox = false,
     }: {
       script: PlaybookScript;
@@ -54,6 +55,7 @@ vi.mock("../../features/playbook/engine/player/PlaybookPlayer", async () => {
       onExplainInteraction?: (context: InteractionFollowUpContext) => Promise<void>;
       onApplyInteractionVersion?: (events: InteractionEvent[]) => Promise<void>;
       interactionActionPending?: boolean;
+      interactionSessionKey?: string;
       enableInteractionSandbox?: boolean;
     }) =>
       ReactModule.createElement(
@@ -62,6 +64,7 @@ vi.mock("../../features/playbook/engine/player/PlaybookPlayer", async () => {
           "data-testid": "mock-player",
           "data-interaction-sandbox": String(enableInteractionSandbox),
           "data-interaction-pending": String(interactionActionPending),
+          "data-interaction-session-key": interactionSessionKey,
         },
         onToggleTopbar
           ? ReactModule.createElement(
@@ -404,6 +407,8 @@ describe("StudioPage", () => {
 
     await waitFor(() => expect(listCalls).toBe(1));
     expect(postCalls).toBe(0);
+    const initialSessionKey = view.getByTestId("mock-player")
+      .getAttribute("data-interaction-session-key");
     fireEvent.click(view.getByRole("button", { name: "模拟应用到新版本" }));
 
     await waitFor(() => expect(view.getByText("Applied lesson")).toBeTruthy());
@@ -479,7 +484,7 @@ describe("StudioPage", () => {
     await waitFor(() => expect(listCalls).toBe(2));
   });
 
-  it("reloads the current head and reports a stale-base interaction conflict", async () => {
+  it("refreshes the current head without resetting sandbox state after a stale-base conflict", async () => {
     mockUsePipelinePoller.mockReturnValue({
       playbook: playbook("Original lesson"),
       director: null,
@@ -506,11 +511,6 @@ describe("StudioPage", () => {
           ],
         });
       }),
-      http.get(`${API_BASE_URL}/api/v1/runs/run-1`, () => HttpResponse.json({
-        status: "succeeded",
-        playbook: playbook("Concurrent lesson"),
-        director: null,
-      })),
       http.post(`${API_BASE_URL}/api/v1/runs/run-1/interaction-version`, () => {
         postCalls += 1;
         return HttpResponse.json(
@@ -538,7 +538,9 @@ describe("StudioPage", () => {
         .toBeTruthy();
     });
     expect(postCalls).toBe(1);
-    expect(view.getByText("Concurrent lesson")).toBeTruthy();
+    expect(view.getByText("Original lesson")).toBeTruthy();
+    expect(view.getByTestId("mock-player").getAttribute("data-interaction-session-key"))
+      .toBe(initialSessionKey);
     expect(view.queryByText(/已将沙盒操作应用为新版本/)).toBeNull();
     expect(listCalls).toBe(2);
     expect(view.getByRole("button", { name: "模拟应用到新版本" })).toBeTruthy();

--- a/apps/web/src/pages/Studio/StudioPage.test.tsx
+++ b/apps/web/src/pages/Studio/StudioPage.test.tsx
@@ -5,7 +5,10 @@ import { http, HttpResponse } from "msw";
 
 import { TWEAK_DEFAULTS } from "../../features/studio-editor/hooks/useTweaks";
 import type { PlaybookScript } from "../../features/playbook/engine/types";
-import type { InteractionFollowUpContext } from "../../features/playbook/interaction/types";
+import type {
+  InteractionEvent,
+  InteractionFollowUpContext,
+} from "../../features/playbook/interaction/types";
 import { server } from "../../mocks/server";
 import { API_BASE_URL } from "../../shared/config/constants";
 import { StudioPage } from "./StudioPage";
@@ -38,6 +41,8 @@ vi.mock("../../features/playbook/engine/player/PlaybookPlayer", async () => {
       onToggleTopbar,
       onOpenExport,
       onExplainInteraction,
+      onApplyInteractionVersion,
+      interactionActionPending = false,
       enableInteractionSandbox = false,
     }: {
       script: PlaybookScript;
@@ -47,6 +52,8 @@ vi.mock("../../features/playbook/engine/player/PlaybookPlayer", async () => {
       onToggleTopbar?: () => void;
       onOpenExport?: () => void;
       onExplainInteraction?: (context: InteractionFollowUpContext) => Promise<void>;
+      onApplyInteractionVersion?: (events: InteractionEvent[]) => Promise<void>;
+      interactionActionPending?: boolean;
       enableInteractionSandbox?: boolean;
     }) =>
       ReactModule.createElement(
@@ -54,6 +61,7 @@ vi.mock("../../features/playbook/engine/player/PlaybookPlayer", async () => {
         {
           "data-testid": "mock-player",
           "data-interaction-sandbox": String(enableInteractionSandbox),
+          "data-interaction-pending": String(interactionActionPending),
         },
         onToggleTopbar
           ? ReactModule.createElement(
@@ -91,6 +99,24 @@ vi.mock("../../features/playbook/engine/player/PlaybookPlayer", async () => {
                 }),
               },
               "模拟解释我的操作",
+            )
+          : null,
+        onApplyInteractionVersion
+          ? ReactModule.createElement(
+              "button",
+              {
+                type: "button",
+                disabled: interactionActionPending,
+                onClick: () => void onApplyInteractionVersion([{
+                  adapter_id: "math.derivative-tangent",
+                  step_id: "step_01",
+                  target_id: "step:step_01:marker-x",
+                  action: "set-value",
+                  value: 3,
+                  sequence: 1,
+                }]).catch(() => undefined),
+              },
+              "模拟应用到新版本",
             )
           : null,
         ReactModule.createElement("strong", null, script.title),
@@ -197,7 +223,7 @@ describe("StudioPage", () => {
       ),
     );
 
-    const { getByPlaceholderText, getByRole, getByText } = render(
+    const { findByPlaceholderText, getByRole, getByText } = render(
       <StudioPage
         runId="run-1"
         t={TWEAK_DEFAULTS}
@@ -206,7 +232,7 @@ describe("StudioPage", () => {
       />,
     );
 
-    const input = getByPlaceholderText("还有什么想问的");
+    const input = await findByPlaceholderText("还有什么想问的");
     fireEvent.change(input, { target: { value: "这里为什么这样讲？" } });
     fireEvent.click(getByRole("button", { name: /发送/ }));
 
@@ -215,6 +241,48 @@ describe("StudioPage", () => {
     });
     expect(getByText("Original lesson")).toBeTruthy();
     expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps history-dependent actions visibly disabled until the initial history is ready", async () => {
+    mockUsePipelinePoller.mockReturnValue({
+      playbook: playbook("Loading lesson"),
+      director: null,
+      error: null,
+      isLoading: false,
+      status: "succeeded",
+    });
+    let releaseHistory: (() => void) | undefined;
+    const historyGate = new Promise<void>((resolve) => {
+      releaseHistory = resolve;
+    });
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/runs/run-1/follow-ups`, async () => {
+        await historyGate;
+        return HttpResponse.json({ followups: [], versions: [] });
+      }),
+    );
+
+    const view = render(
+      <StudioPage
+        runId="run-1"
+        t={TWEAK_DEFAULTS}
+        onNavigate={vi.fn()}
+        isProviderConfigured
+      />,
+    );
+
+    expect(view.getByText("正在加载对话与版本记录…")).toBeTruthy();
+    expect(view.getByPlaceholderText<HTMLTextAreaElement>("正在加载记录").disabled).toBe(true);
+    expect(view.queryByRole("button", { name: "模拟解释我的操作" })).toBeNull();
+    expect(view.queryByRole("button", { name: "模拟应用到新版本" })).toBeNull();
+
+    releaseHistory?.();
+    await waitFor(() => {
+      expect(view.getByPlaceholderText<HTMLTextAreaElement>("还有什么想问的").disabled)
+        .toBe(false);
+    });
+    expect(view.getByRole("button", { name: "模拟解释我的操作" })).toBeTruthy();
+    expect(view.getByRole("button", { name: "模拟应用到新版本" })).toBeTruthy();
   });
 
   it("sends semantic interaction context only after the explicit explain action", async () => {
@@ -281,6 +349,199 @@ describe("StudioPage", () => {
       },
     });
     expect(view.getByText("Explicit lesson")).toBeTruthy();
+  });
+
+  it("applies sandbox events as a new version only after the explicit action", async () => {
+    mockUsePipelinePoller.mockReturnValue({
+      playbook: playbook("Original lesson"),
+      director: null,
+      error: null,
+      isLoading: false,
+      status: "succeeded",
+    });
+    let listCalls = 0;
+    let postCalls = 0;
+    let submittedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/runs/run-1/follow-ups`, () => {
+        listCalls += 1;
+        return HttpResponse.json({
+          followups: [],
+          versions: listCalls === 1
+            ? [
+              version("older", "00000000", 0, false, "initial", "initial"),
+              version("v1", "11111111", 1, true, "followup", "current"),
+            ]
+            : [
+              version("v1", "11111111", 1, false, "followup", "current"),
+              version("v2", "22222222", 2, true, "interaction", "move tangent"),
+            ],
+        });
+      }),
+      http.post(
+        `${API_BASE_URL}/api/v1/runs/run-1/interaction-version`,
+        async ({ request }) => {
+          postCalls += 1;
+          submittedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            version_id: "v2",
+            summary: "interaction: move tangent",
+            playbook: playbook("Applied lesson"),
+            director: null,
+          });
+        },
+      ),
+    );
+
+    const view = render(
+      <StudioPage
+        runId="run-1"
+        t={TWEAK_DEFAULTS}
+        onNavigate={vi.fn()}
+        isProviderConfigured
+      />,
+    );
+
+    await waitFor(() => expect(listCalls).toBe(1));
+    expect(postCalls).toBe(0);
+    fireEvent.click(view.getByRole("button", { name: "模拟应用到新版本" }));
+
+    await waitFor(() => expect(view.getByText("Applied lesson")).toBeTruthy());
+    expect(postCalls).toBe(1);
+    expect(submittedBody).toEqual({
+      manifest_version: "1",
+      base_version_id: "v1",
+      events: [{
+        adapter_id: "math.derivative-tangent",
+        step_id: "step_01",
+        target_id: "step:step_01:marker-x",
+        action: "set-value",
+        value: 3,
+        sequence: 1,
+      }],
+    });
+    expect(view.getByText(/已将沙盒操作应用为新版本（v2）/)).toBeTruthy();
+    expect(view.getByText("interaction: move tangent")).toBeTruthy();
+    await waitFor(() => expect(listCalls).toBe(2));
+  });
+
+  it("uses a null base version for the first interaction version of a fresh run", async () => {
+    mockUsePipelinePoller.mockReturnValue({
+      playbook: playbook("Fresh lesson"),
+      director: null,
+      error: null,
+      isLoading: false,
+      status: "succeeded",
+    });
+    let listCalls = 0;
+    let submittedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/runs/run-1/follow-ups`, () => {
+        listCalls += 1;
+        return HttpResponse.json({
+          followups: [],
+          versions: listCalls === 1
+            ? []
+            : [version("v1", "11111111", 1, true, "interaction", "first interaction")],
+        });
+      }),
+      http.post(
+        `${API_BASE_URL}/api/v1/runs/run-1/interaction-version`,
+        async ({ request }) => {
+          submittedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            version_id: "v1",
+            summary: "first interaction",
+            playbook: playbook("Fresh applied lesson"),
+            director: null,
+          });
+        },
+      ),
+    );
+
+    const view = render(
+      <StudioPage
+        runId="run-1"
+        t={TWEAK_DEFAULTS}
+        onNavigate={vi.fn()}
+        isProviderConfigured
+      />,
+    );
+
+    await waitFor(() => expect(listCalls).toBe(1));
+    fireEvent.click(view.getByRole("button", { name: "模拟应用到新版本" }));
+
+    await waitFor(() => expect(view.getByText("Fresh applied lesson")).toBeTruthy());
+    expect(submittedBody).toMatchObject({
+      manifest_version: "1",
+      base_version_id: null,
+    });
+    await waitFor(() => expect(listCalls).toBe(2));
+  });
+
+  it("reloads the current head and reports a stale-base interaction conflict", async () => {
+    mockUsePipelinePoller.mockReturnValue({
+      playbook: playbook("Original lesson"),
+      director: null,
+      error: null,
+      isLoading: false,
+      status: "succeeded",
+    });
+    let listCalls = 0;
+    let postCalls = 0;
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/runs/run-1/follow-ups`, () => {
+        listCalls += 1;
+        return HttpResponse.json({
+          followups: [],
+          versions: [
+            version(
+              listCalls === 1 ? "v1" : "v2",
+              listCalls === 1 ? "11111111" : "22222222",
+              listCalls,
+              true,
+              "followup",
+              listCalls === 1 ? "current" : "concurrent update",
+            ),
+          ],
+        });
+      }),
+      http.get(`${API_BASE_URL}/api/v1/runs/run-1`, () => HttpResponse.json({
+        status: "succeeded",
+        playbook: playbook("Concurrent lesson"),
+        director: null,
+      })),
+      http.post(`${API_BASE_URL}/api/v1/runs/run-1/interaction-version`, () => {
+        postCalls += 1;
+        return HttpResponse.json(
+          { detail: "Interaction sandbox base version is no longer current" },
+          { status: 409 },
+        );
+      }),
+    );
+
+    const view = render(
+      <StudioPage
+        runId="run-1"
+        t={TWEAK_DEFAULTS}
+        onNavigate={vi.fn()}
+        isProviderConfigured
+      />,
+    );
+
+    await waitFor(() => expect(listCalls).toBe(1));
+    expect(postCalls).toBe(0);
+    fireEvent.click(view.getByRole("button", { name: "模拟应用到新版本" }));
+
+    await waitFor(() => {
+      expect(view.getByText(/Interaction sandbox base version is no longer current/))
+        .toBeTruthy();
+    });
+    expect(postCalls).toBe(1);
+    expect(view.getByText("Concurrent lesson")).toBeTruthy();
+    expect(view.queryByText(/已将沙盒操作应用为新版本/)).toBeNull();
+    expect(listCalls).toBe(2);
+    expect(view.getByRole("button", { name: "模拟应用到新版本" })).toBeTruthy();
   });
 
   it("uses guided follow-up suggestions for study sessions", async () => {
@@ -491,6 +752,75 @@ describe("StudioPage", () => {
     });
     expect(getByText("已切换到选中的历史版本。")).toBeTruthy();
     expect(queryByText(/^revert: restore/)).toBeNull();
+  });
+
+  it("ignores an in-flight restore after switching to another run", async () => {
+    mockUsePipelinePoller.mockReturnValue({
+      playbook: playbook("Run one"),
+      director: null,
+      error: null,
+      isLoading: false,
+      status: "succeeded",
+    });
+    let restoreCalls = 0;
+    let releaseRestore: (() => void) | undefined;
+    const restoreGate = new Promise<void>((resolve) => {
+      releaseRestore = resolve;
+    });
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/runs/run-1/follow-ups`, () =>
+        HttpResponse.json({
+          followups: [],
+          versions: [
+            version("v0", "a1b2c3d4", 0, false, "initial", "initial playbook"),
+            version("v1", "c0ffee12", 1, true, "followup", "updated lesson"),
+          ],
+        }),
+      ),
+      http.get(`${API_BASE_URL}/api/v1/runs/run-2/follow-ups`, () =>
+        HttpResponse.json({ followups: [], versions: [] }),
+      ),
+      http.post(`${API_BASE_URL}/api/v1/runs/run-1/versions/v0/restore`, async () => {
+        restoreCalls += 1;
+        await restoreGate;
+        return HttpResponse.json({
+          version_id: "v0",
+          playbook: playbook("Stale restored lesson"),
+          director: null,
+        });
+      }),
+    );
+
+    const props = {
+      t: TWEAK_DEFAULTS,
+      onNavigate: vi.fn(),
+      isProviderConfigured: true,
+    };
+    const view = render(<StudioPage runId="run-1" {...props} />);
+
+    await waitFor(() => {
+      expect(view.getByRole("button", { name: "展开版本记录" })).toBeTruthy();
+    });
+    fireEvent.click(view.getByRole("button", { name: "展开版本记录" }));
+    fireEvent.click(view.getByRole("button", { name: "恢复版本 a1b2c3d4" }));
+    await waitFor(() => expect(restoreCalls).toBe(1));
+
+    mockUsePipelinePoller.mockReturnValue({
+      playbook: playbook("Run two"),
+      director: null,
+      error: null,
+      isLoading: false,
+      status: "succeeded",
+    });
+    view.rerender(<StudioPage runId="run-2" {...props} />);
+    releaseRestore?.();
+
+    await waitFor(() => expect(view.getByText("Run two")).toBeTruthy());
+    expect(view.queryByText("Stale restored lesson")).toBeNull();
+    expect(view.queryByText("已切换到选中的历史版本。")).toBeNull();
+    await waitFor(() => {
+      expect(view.getByRole("button", { name: "模拟应用到新版本" })).toBeTruthy();
+    });
   });
 
   it("shows a visible commit-log error when restoring a historical version fails", async () => {

--- a/apps/web/src/pages/Studio/StudioPage.test.tsx
+++ b/apps/web/src/pages/Studio/StudioPage.test.tsx
@@ -407,8 +407,6 @@ describe("StudioPage", () => {
 
     await waitFor(() => expect(listCalls).toBe(1));
     expect(postCalls).toBe(0);
-    const initialSessionKey = view.getByTestId("mock-player")
-      .getAttribute("data-interaction-session-key");
     fireEvent.click(view.getByRole("button", { name: "模拟应用到新版本" }));
 
     await waitFor(() => expect(view.getByText("Applied lesson")).toBeTruthy());
@@ -531,6 +529,8 @@ describe("StudioPage", () => {
 
     await waitFor(() => expect(listCalls).toBe(1));
     expect(postCalls).toBe(0);
+    const initialSessionKey = view.getByTestId("mock-player")
+      .getAttribute("data-interaction-session-key");
     fireEvent.click(view.getByRole("button", { name: "模拟应用到新版本" }));
 
     await waitFor(() => {

--- a/apps/web/src/pages/Studio/StudioPage.tsx
+++ b/apps/web/src/pages/Studio/StudioPage.tsx
@@ -490,7 +490,7 @@ function ChatPanel({
             if ((refreshError as Error).name === "AbortError") throw refreshError;
             if (
               refreshError instanceof Error &&
-              refreshError.message === "已加载最新版本，请重新执行沙盒操作。"
+              refreshError.message === "已同步最新版本基线，请再次应用当前沙盒操作。"
             ) {
               throw refreshError;
             }

--- a/apps/web/src/pages/Studio/StudioPage.tsx
+++ b/apps/web/src/pages/Studio/StudioPage.tsx
@@ -20,7 +20,6 @@ import {
   submitRunFollowUp,
   type RunVersionRecord,
 } from "../../features/followups/api/followupApi";
-import { getPipelineRun } from "../../features/pipeline/api/pipelineApi";
 import { FollowupCommitLog } from "../../features/followups/ui/FollowupCommitLog";
 import type {
   InteractionEvent,
@@ -473,14 +472,7 @@ function ChatPanel({
         if (err instanceof InteractionVersionRequestError && err.status === 409) {
           setHeadVersionId(undefined);
           try {
-            const [history, latestRun] = await Promise.all([
-              listRunFollowUps(runId!, controller.signal),
-              getPipelineRun(runId!, controller.signal),
-            ]);
-            if (latestRun.playbook) {
-              onPlaybookPatched(latestRun.playbook, latestRun.director);
-              setInteractionEpoch((current) => current + 1);
-            }
+            const history = await listRunFollowUps(runId!, controller.signal);
             setVersions(history.versions);
             setHeadVersionId(
               history.versions.find((version) => version.is_head)?.version_id ?? null,
@@ -489,11 +481,11 @@ function ChatPanel({
               ...current,
               {
                 from: "ai",
-                text: `（版本冲突：${err.message}。已加载最新版本，请重新执行沙盒操作。）`,
+                text: `（版本冲突：${err.message}。已同步最新版本基线，请再次应用当前沙盒操作。）`,
                 error: true,
               },
             ]);
-            throw new Error("已加载最新版本，请重新执行沙盒操作。");
+            throw new Error("已同步最新版本基线，请再次应用当前沙盒操作。");
           } catch (refreshError) {
             if ((refreshError as Error).name === "AbortError") throw refreshError;
             if (

--- a/apps/web/src/pages/Studio/StudioPage.tsx
+++ b/apps/web/src/pages/Studio/StudioPage.tsx
@@ -13,13 +13,19 @@ import { PipelineErrorCard } from "../../features/pipeline/ui/PipelineErrorCard"
 import { PipelineSkeleton } from "../../features/pipeline/ui/PipelineSkeleton";
 import { createAssetAttributionReportForScript } from "../../features/playbook/engine/assets/assetAttributionSummary";
 import {
+  applyRunInteractionVersion,
+  InteractionVersionRequestError,
   listRunFollowUps,
   restoreRunVersion,
   submitRunFollowUp,
   type RunVersionRecord,
 } from "../../features/followups/api/followupApi";
+import { getPipelineRun } from "../../features/pipeline/api/pipelineApi";
 import { FollowupCommitLog } from "../../features/followups/ui/FollowupCommitLog";
-import type { InteractionFollowUpContext } from "../../features/playbook/interaction/types";
+import type {
+  InteractionEvent,
+  InteractionFollowUpContext,
+} from "../../features/playbook/interaction/types";
 
 // ── Domain mapping ────────────────────────────────────────────────────────
 
@@ -63,6 +69,9 @@ interface ChatPanelProps {
     followupSlot: React.ReactNode;
     relatedSlot: React.ReactNode;
     onExplainInteraction?: (context: InteractionFollowUpContext) => Promise<void>;
+    onApplyInteractionVersion?: (events: InteractionEvent[]) => Promise<void>;
+    interactionActionPending: boolean;
+    interactionSessionKey: string;
   }) => React.ReactNode;
 }
 
@@ -86,6 +95,9 @@ function ChatPanel({
 }: ChatPanelProps) {
   const [msgs, setMsgs] = useState<ChatMessage[]>([]);
   const [versions, setVersions] = useState<RunVersionRecord[]>([]);
+  const [headVersionId, setHeadVersionId] = useState<string | null | undefined>(undefined);
+  const [historyReady, setHistoryReady] = useState(false);
+  const [interactionEpoch, setInteractionEpoch] = useState(0);
   const [input, setInput] = useState("");
   const [pending, setPending] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -102,8 +114,13 @@ function ChatPanel({
     abortRef.current?.abort();
     setMsgs([]);
     setVersions([]);
+    setHeadVersionId(undefined);
+    setHistoryReady(false);
+    setInteractionEpoch(0);
+    setPending(false);
     if (!runId) return;
     const controller = new AbortController();
+    abortRef.current = controller;
     listRunFollowUps(runId, controller.signal)
       .then((data) => {
         const loaded: ChatMessage[] = data.followups.flatMap((item) => [
@@ -117,13 +134,22 @@ function ChatPanel({
         ]);
         setMsgs(loaded);
         setVersions(data.versions);
+        setHeadVersionId(data.versions.find((version) => version.is_head)?.version_id ?? null);
+        setHistoryReady(true);
       })
       .catch((err) => {
         if ((err as Error).name !== "AbortError") {
           setMsgs([{ from: "ai", text: formatChatError(err), error: true }]);
+          setHistoryReady(true);
         }
+      })
+      .finally(() => {
+        if (abortRef.current === controller) abortRef.current = null;
       });
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      if (abortRef.current === controller) abortRef.current = null;
+    };
   }, [runId]);
 
   const domain = playbook?.domain ?? "";
@@ -135,10 +161,11 @@ function ChatPanel({
     interactionContext?: InteractionFollowUpContext,
   ) => {
     const userText = (text ?? input).trim();
-    if (!userText || pending || !canModify) return;
+    if (!userText || pending || !canModify || !historyReady) return;
 
     abortRef.current?.abort();
-    abortRef.current = new AbortController();
+    const controller = new AbortController();
+    abortRef.current = controller;
 
     const nextMsgs: ChatMessage[] = [...msgs, { from: "user", text: userText }];
       setMsgs([...nextMsgs, { from: "ai", text: "回复中…", pending: true }]);
@@ -164,12 +191,14 @@ function ChatPanel({
         userText,
         history,
         provider,
-        abortRef.current.signal,
+        controller.signal,
         activeVersionId,
         interactionContext,
       );
       if (result.kind === "patch" && result.playbook) {
         onPlaybookPatched(result.playbook, result.director, result.version_id);
+        setHeadVersionId(result.version_id);
+        setInteractionEpoch((current) => current + 1);
       }
       setMsgs([
         ...nextMsgs,
@@ -181,9 +210,16 @@ function ChatPanel({
         },
       ]);
       if (result.kind === "patch") {
-        listRunFollowUps(runId!, abortRef.current.signal)
-          .then((data) => setVersions(data.versions))
-          .catch(() => undefined);
+        try {
+          const data = await listRunFollowUps(runId!, controller.signal);
+          setVersions(data.versions);
+          setHeadVersionId(
+            data.versions.find((version) => version.is_head)?.version_id
+              ?? result.version_id,
+          );
+        } catch (historyError) {
+          if ((historyError as Error).name === "AbortError") throw historyError;
+        }
       }
     } catch (err) {
       if ((err as Error).name === "AbortError") return;
@@ -192,16 +228,24 @@ function ChatPanel({
         { from: "ai", text: formatChatError(err), error: true },
       ]);
     } finally {
-      setPending(false);
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setPending(false);
+      }
     }
   };
 
   const restore = async (versionId: string) => {
     if (!runId || pending) return;
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
     setPending(true);
     try {
-      const result = await restoreRunVersion(runId, versionId);
+      const result = await restoreRunVersion(runId, versionId, controller.signal);
       onPlaybookPatched(result.playbook, result.director, result.version_id);
+      setHeadVersionId(result.version_id);
+      setInteractionEpoch((current) => current + 1);
       setMsgs((current) => [
         ...current,
         {
@@ -210,17 +254,35 @@ function ChatPanel({
           versionId: result.version_id,
         },
       ]);
-      listRunFollowUps(runId)
-        .then((data) => setVersions(data.versions))
-        .catch(() => undefined);
+      try {
+        const data = await listRunFollowUps(runId, controller.signal);
+        setVersions(data.versions);
+        setHeadVersionId(
+          data.versions.find((version) => version.is_head)?.version_id ?? result.version_id,
+        );
+      } catch (historyError) {
+        if ((historyError as Error).name === "AbortError") throw historyError;
+        setMsgs((current) => [
+          ...current,
+          {
+            from: "ai",
+            text: "版本已恢复，但版本列表暂时无法刷新。",
+            error: true,
+          },
+        ]);
+      }
     } catch (err) {
+      if ((err as Error).name === "AbortError") throw err;
       setMsgs((current) => [
         ...current,
         { from: "ai", text: formatChatError(err), error: true },
       ]);
       throw err;
     } finally {
-      setPending(false);
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setPending(false);
+      }
     }
   };
 
@@ -243,7 +305,12 @@ function ChatPanel({
   ) : (
     <div className="mv-followup-panel">
       <div className="mv-chat-stream" ref={scrollRef}>
-        {msgs.length === 0 && !isProviderConfigured && (
+        {msgs.length === 0 && !historyReady && (
+          <div style={{ fontSize: 12, color: "var(--ink-3)" }}>
+            正在加载对话与版本记录…
+          </div>
+        )}
+        {msgs.length === 0 && historyReady && !isProviderConfigured && (
           <div
             style={{
               fontSize: 12,
@@ -267,12 +334,12 @@ function ChatPanel({
             )}
           </div>
         )}
-        {msgs.length === 0 && isProviderConfigured && canModify && (
+        {msgs.length === 0 && historyReady && isProviderConfigured && canModify && (
           <div style={{ fontSize: 12, color: "var(--ink-3)" }}>
             可以继续提问，也可以要求调整当前讲解。
           </div>
         )}
-        {msgs.length === 0 && !canModify && (
+        {msgs.length === 0 && historyReady && !canModify && (
           <div style={{ fontSize: 12, color: "var(--ink-3)" }}>
             需要真实生成任务后才能保存修改版本。
           </div>
@@ -306,7 +373,7 @@ function ChatPanel({
             key={s}
             className="mv-suggestion"
             onClick={() => send(s)}
-            disabled={pending || !canModify}
+            disabled={pending || !canModify || !historyReady}
           >
             {s}
           </button>
@@ -317,7 +384,9 @@ function ChatPanel({
         <textarea
           rows={1}
           className="mv-chat-input"
-          placeholder={canModify ? "还有什么想问的" : "等待真实任务"}
+          placeholder={
+            !historyReady ? "正在加载记录" : canModify ? "还有什么想问的" : "等待真实任务"
+          }
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => {
@@ -326,14 +395,14 @@ function ChatPanel({
               send();
             }
           }}
-          disabled={!canModify}
+          disabled={!canModify || !historyReady}
         />
         <div className="mv-chat-actions">
           <div className="mv-spacer" />
           <button
             className="mv-send"
             onClick={() => send()}
-            disabled={pending || !input.trim() || !canModify}
+            disabled={pending || !input.trim() || !canModify || !historyReady}
           >
             {pending ? "回复中…" : "发送 ↵"}
           </button>
@@ -351,11 +420,121 @@ function ChatPanel({
       />
     ) : null;
 
-  const onExplainInteraction = canModify
+  const onExplainInteraction = canModify && historyReady
     ? (context: InteractionFollowUpContext) => send("请解释我刚才的操作", context)
     : undefined;
 
-  return <>{children({ followupSlot, relatedSlot, onExplainInteraction })}</>;
+  const onApplyInteractionVersion = canModify && headVersionId !== undefined
+    ? async (events: InteractionEvent[]) => {
+      if (pending || events.length === 0) return;
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setPending(true);
+      try {
+        const result = await applyRunInteractionVersion(
+          runId!,
+          events,
+          headVersionId,
+          controller.signal,
+        );
+        onPlaybookPatched(result.playbook, result.director);
+        setHeadVersionId(result.version_id);
+        setInteractionEpoch((current) => current + 1);
+        setMsgs((current) => [
+          ...current,
+          {
+            from: "ai",
+            text: `已将沙盒操作应用为新版本（${result.version_id.slice(0, 8)}）。`,
+            changeSummary: result.summary,
+            versionId: result.version_id,
+          },
+        ]);
+        try {
+          const data = await listRunFollowUps(runId!, controller.signal);
+          setVersions(data.versions);
+          setHeadVersionId(
+            data.versions.find((version) => version.is_head)?.version_id
+              ?? result.version_id,
+          );
+        } catch (err) {
+          if ((err as Error).name === "AbortError") throw err;
+          setMsgs((current) => [
+            ...current,
+            {
+              from: "ai",
+              text: "新版本已保存，但版本列表暂时无法刷新。",
+              error: true,
+            },
+          ]);
+        }
+      } catch (err) {
+        if ((err as Error).name === "AbortError") throw err;
+        if (err instanceof InteractionVersionRequestError && err.status === 409) {
+          setHeadVersionId(undefined);
+          try {
+            const [history, latestRun] = await Promise.all([
+              listRunFollowUps(runId!, controller.signal),
+              getPipelineRun(runId!, controller.signal),
+            ]);
+            if (latestRun.playbook) {
+              onPlaybookPatched(latestRun.playbook, latestRun.director);
+              setInteractionEpoch((current) => current + 1);
+            }
+            setVersions(history.versions);
+            setHeadVersionId(
+              history.versions.find((version) => version.is_head)?.version_id ?? null,
+            );
+            setMsgs((current) => [
+              ...current,
+              {
+                from: "ai",
+                text: `（版本冲突：${err.message}。已加载最新版本，请重新执行沙盒操作。）`,
+                error: true,
+              },
+            ]);
+            throw new Error("已加载最新版本，请重新执行沙盒操作。");
+          } catch (refreshError) {
+            if ((refreshError as Error).name === "AbortError") throw refreshError;
+            if (
+              refreshError instanceof Error &&
+              refreshError.message === "已加载最新版本，请重新执行沙盒操作。"
+            ) {
+              throw refreshError;
+            }
+            setMsgs((current) => [
+              ...current,
+              {
+                from: "ai",
+                text: `（版本冲突：${err.message}。请刷新页面后重新操作。）`,
+                error: true,
+              },
+            ]);
+            throw new Error("版本冲突，请刷新页面后重新操作。");
+          }
+        }
+        setMsgs((current) => [
+          ...current,
+          { from: "ai", text: formatChatError(err), error: true },
+        ]);
+        throw err;
+      } finally {
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+          setPending(false);
+        }
+      }
+    }
+    : undefined;
+
+  return <>{children({
+    followupSlot,
+    relatedSlot,
+    onExplainInteraction,
+    onApplyInteractionVersion,
+    interactionActionPending: pending,
+    interactionSessionKey: `${runId ?? "no-run"}:${interactionEpoch}`,
+  })}</>;
 }
 
 // ── StudioPage ────────────────────────────────────────────────────────────
@@ -482,13 +661,23 @@ export function StudioPage({
                 }
               }}
             >
-              {({ followupSlot, relatedSlot, onExplainInteraction }) => (
+              {({
+                followupSlot,
+                relatedSlot,
+                onExplainInteraction,
+                onApplyInteractionVersion,
+                interactionActionPending,
+                interactionSessionKey,
+              }) => (
                 <PlaybookPlayer
                   script={activePlaybook}
                   director={activeDirector}
                   theme={isDark ? "dark" : "light"}
                   enableInteractionSandbox
                   onExplainInteraction={onExplainInteraction}
+                  onApplyInteractionVersion={onApplyInteractionVersion}
+                  interactionActionPending={interactionActionPending}
+                  interactionSessionKey={interactionSessionKey}
                   swapDurationFrames={t.swapFrames}
                   onOpenExport={canExport ? () => setExportOpen(true) : undefined}
                   topbarCollapsed={topbarCollapsed}

--- a/apps/web/src/shared/lib/mathExpr.test.ts
+++ b/apps/web/src/shared/lib/mathExpr.test.ts
@@ -8,6 +8,16 @@ import {
   sampleExpr,
   sampleVectorField,
 } from "./mathExpr";
+import interactionContract from "../../../../../eval/fixtures/interaction_math_expr_contract.json";
+
+describe("mathExpr — interaction server contract", () => {
+  it.each(interactionContract)(
+    "matches the safe server evaluator for $expression",
+    ({ expression, params, x, expected }) => {
+      expect(compileExpr(expression)({ ...params, x })).toBeCloseTo(expected, 10);
+    },
+  );
+});
 
 describe("mathExpr — evaluation", () => {
   it("evaluates arithmetic with precedence", () => {

--- a/apps/web/src/styles/pages/playbook.css
+++ b/apps/web/src/styles/pages/playbook.css
@@ -936,12 +936,20 @@
 
 .playbook-interaction__actions {
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .playbook-interaction__actions .playbook-interaction__explain {
   margin-right: auto;
   border-color: color-mix(in srgb, var(--player-accent) 42%, var(--player-line));
   color: var(--player-accent);
+}
+
+.playbook-interaction__actions .playbook-interaction__apply-version {
+  border-color: color-mix(in srgb, var(--player-accent) 62%, var(--player-line));
+  background: var(--player-accent);
+  color: #172012;
+  font-weight: 650;
 }
 
 .playbook-interaction__actions button:disabled,

--- a/eval/fixtures/interaction_math_expr_contract.json
+++ b/eval/fixtures/interaction_math_expr_contract.json
@@ -1,0 +1,68 @@
+[
+  {
+    "expression": "x^2 + a",
+    "params": { "x": 10, "a": 2 },
+    "x": 3,
+    "expected": 11
+  },
+  {
+    "expression": "2^3^2",
+    "params": {},
+    "x": 0,
+    "expected": 512
+  },
+  {
+    "expression": "-2^2",
+    "params": {},
+    "x": 0,
+    "expected": 4
+  },
+  {
+    "expression": "-5 % 2",
+    "params": {},
+    "x": 0,
+    "expected": -1
+  },
+  {
+    "expression": "sin(pi / 2) + sqrt(9) + log(e) + ln(e)",
+    "params": { "pi": 1, "e": 1 },
+    "x": 0,
+    "expected": 6
+  },
+  {
+    "expression": "cos(0) + tan(0) + asin(0) + acos(1) + atan(0) + atan2(1, 1)",
+    "params": {},
+    "x": 0,
+    "expected": 1.7853981633974483
+  },
+  {
+    "expression": "sinh(0) + cosh(0) + tanh(0) + exp(0)",
+    "params": {},
+    "x": 0,
+    "expected": 2
+  },
+  {
+    "expression": "log2(8) + log10(100) + cbrt(8)",
+    "params": {},
+    "x": 0,
+    "expected": 7
+  },
+  {
+    "expression": "abs(-3) + floor(1.9) + ceil(1.1) + round(-1.5) + round(1.5) + sign(-5)",
+    "params": {},
+    "x": 0,
+    "expected": 6
+  },
+  {
+    "expression": "max(x, 2) + min(5, a) + pow(2, 3) + hypot(3, 4)",
+    "params": { "a": 4 },
+    "x": 1,
+    "expected": 19
+  },
+  {
+    "expression": "pi + tau + e",
+    "params": { "pi": 1, "tau": 1, "e": 1 },
+    "x": 0,
+    "expected": 12.143059789228424
+  }
+]


### PR DESCRIPTION
## Summary

- add the explicit `应用到新版本` action for normalized tangent/BFS sandbox events
- replay only typed semantic events on the server; no model call, raw DOM/canvas payload, or arbitrary JSON Patch
- validate through the canonical quality gate and commit version/history/director/active playbook atomically with a SQLite CAS
- keep fresh-run (`base_version_id: null`), stale-base 409 recovery, cross-run cancellation, and portrait result visibility explicit
- isolate sandbox sessions and cap the browser event log at the server's 100-event contract

## Safety boundaries

- no automatic persistence: preview, drag, select, undo, and reset stay browser-only until the user clicks the apply button
- successful writes reset the sandbox; failed, cancelled, or conflicting writes preserve it
- canonical playbook data drives pilot previews so frontend-only overrides cannot diverge from server replay
- safe math grammar mirrors the frontend contract and replaces dynamic SymPy parsing

## Validation

- API: 985 passed
- Web: 1066 passed
- Agent: 63 passed
- MCP server: 18 passed
- Web lint: 0 errors (2 pre-existing Fast Refresh warnings)
- Web/Agent build, MCP typecheck, Ruff, and `git diff --check`: passed

## Stack

This is a Draft stacked after #132 (`9239e587`). Review the delta from #132 to this PR head. Keep Draft; do not merge or mark Ready yet.