### PR TITLE
fix(web): hide unavailable parameter surfaces

### DIFF
--- a/apps/web/src/features/playbook/engine/param-panels/MathParamPanel.tsx
+++ b/apps/web/src/features/playbook/engine/param-panels/MathParamPanel.tsx
@@ -1,18 +1,7 @@
 import React, { useMemo } from "react";
 import "katex/dist/katex.min.css";
 import type { ParamPanelProps } from "./types";
-
-const PARAM_ID_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
-
-interface NumericControl {
-  control: ParamPanelProps["script"]["parameter_controls"][number];
-  initial: number;
-}
-
-function parseNumber(value: string): number | null {
-  const n = Number(value.trim());
-  return Number.isFinite(n) ? n : null;
-}
+import { resolveEditableMathControls } from "./mathParams";
 
 function sliderRange(initial: number): { min: number; max: number; step: number } {
   const span = Math.max(5, Math.abs(initial) * 2);
@@ -20,27 +9,6 @@ function sliderRange(initial: number): { min: number; max: number; step: number 
   const max = initial + span;
   const step = span <= 5 ? 0.1 : 0.5;
   return { min, max, step };
-}
-
-export function resolveEditableMathControls(
-  script: ParamPanelProps["script"],
-): NumericControl[] {
-  const controls: NumericControl[] = [];
-  // Older playbooks (pre-execution_map) may serialize without
-  // parameter_controls at all. Invalid or non-numeric controls are not
-  // editable and therefore must not make the Params surface visible.
-  for (const control of script.parameter_controls ?? []) {
-    const initial = parseNumber(control.value);
-    if (initial == null || !PARAM_ID_RE.test(control.id)) continue;
-    controls.push({ control, initial });
-  }
-  return controls;
-}
-
-export function hasEditableMathParams(
-  script: ParamPanelProps["script"],
-): boolean {
-  return resolveEditableMathControls(script).length > 0;
 }
 
 export function MathParamPanel({
@@ -52,7 +20,7 @@ export function MathParamPanel({
   const theme = isDark ? "dark" : "light";
 
   const numericControls = useMemo(
-    () => resolveEditableMathControls(script),
+    () => resolveEditableMathControls(script.parameter_controls),
     [script.parameter_controls],
   );
 

--- a/apps/web/src/features/playbook/engine/param-panels/MathParamPanel.tsx
+++ b/apps/web/src/features/playbook/engine/param-panels/MathParamPanel.tsx
@@ -22,6 +22,27 @@ function sliderRange(initial: number): { min: number; max: number; step: number 
   return { min, max, step };
 }
 
+export function resolveEditableMathControls(
+  script: ParamPanelProps["script"],
+): NumericControl[] {
+  const controls: NumericControl[] = [];
+  // Older playbooks (pre-execution_map) may serialize without
+  // parameter_controls at all. Invalid or non-numeric controls are not
+  // editable and therefore must not make the Params surface visible.
+  for (const control of script.parameter_controls ?? []) {
+    const initial = parseNumber(control.value);
+    if (initial == null || !PARAM_ID_RE.test(control.id)) continue;
+    controls.push({ control, initial });
+  }
+  return controls;
+}
+
+export function hasEditableMathParams(
+  script: ParamPanelProps["script"],
+): boolean {
+  return resolveEditableMathControls(script).length > 0;
+}
+
 export function MathParamPanel({
   script,
   overrides,
@@ -30,19 +51,10 @@ export function MathParamPanel({
 }: ParamPanelProps): React.JSX.Element {
   const theme = isDark ? "dark" : "light";
 
-  const numericControls = useMemo<NumericControl[]>(() => {
-    const controls: NumericControl[] = [];
-    // Older playbooks (pre-execution_map) may serialize without
-    // parameter_controls at all — treat missing array as empty so we render
-    // the "no editable params" placeholder instead of throwing.
-    const list = script.parameter_controls ?? [];
-    for (const control of list) {
-      const initial = parseNumber(control.value);
-      if (initial == null || !PARAM_ID_RE.test(control.id)) continue;
-      controls.push({ control, initial });
-    }
-    return controls;
-  }, [script.parameter_controls]);
+  const numericControls = useMemo(
+    () => resolveEditableMathControls(script),
+    [script.parameter_controls],
+  );
 
   const setScriptParam = (key: string, value: number): void => {
     onOverridesChange({

--- a/apps/web/src/features/playbook/engine/param-panels/mathParams.test.ts
+++ b/apps/web/src/features/playbook/engine/param-panels/mathParams.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { hasEditableMathParams, resolveEditableMathControls } from "./mathParams";
+
+describe("math parameter controls", () => {
+  it("rejects empty and whitespace-only numeric values", () => {
+    const controls = [
+      { id: "a", label: "a", value: "" },
+      { id: "b", label: "b", value: "   " },
+    ];
+
+    expect(resolveEditableMathControls(controls)).toEqual([]);
+    expect(hasEditableMathParams(controls)).toBe(false);
+  });
+
+  it("keeps finite numeric values, including explicit zero", () => {
+    const controls = [{ id: "a", label: "a", value: "0" }];
+
+    expect(resolveEditableMathControls(controls)).toEqual([
+      { control: controls[0], initial: 0 },
+    ]);
+    expect(hasEditableMathParams(controls)).toBe(true);
+  });
+});

--- a/apps/web/src/features/playbook/engine/param-panels/mathParams.ts
+++ b/apps/web/src/features/playbook/engine/param-panels/mathParams.ts
@@ -1,0 +1,33 @@
+import type { PlaybookScript } from "../types";
+
+const PARAM_ID_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+type ParameterControl = PlaybookScript["parameter_controls"][number];
+
+export interface EditableMathControl {
+  control: ParameterControl;
+  initial: number;
+}
+
+function parseNumber(value: string): number | null {
+  const parsed = Number(value.trim());
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function resolveEditableMathControls(
+  parameterControls: PlaybookScript["parameter_controls"] | undefined,
+): EditableMathControl[] {
+  const controls: EditableMathControl[] = [];
+  for (const control of parameterControls ?? []) {
+    const initial = parseNumber(control.value);
+    if (initial == null || !PARAM_ID_RE.test(control.id)) continue;
+    controls.push({ control, initial });
+  }
+  return controls;
+}
+
+export function hasEditableMathParams(
+  parameterControls: PlaybookScript["parameter_controls"] | undefined,
+): boolean {
+  return resolveEditableMathControls(parameterControls).length > 0;
+}

--- a/apps/web/src/features/playbook/engine/param-panels/mathParams.ts
+++ b/apps/web/src/features/playbook/engine/param-panels/mathParams.ts
@@ -10,7 +10,9 @@ export interface EditableMathControl {
 }
 
 function parseNumber(value: string): number | null {
-  const parsed = Number(value.trim());
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : null;
 }
 

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.test.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.test.tsx
@@ -168,8 +168,8 @@ describe("PlaybookPlayer", () => {
     expect(learningConsole.textContent).toContain("n = 3");
   });
 
-  it("hides code sync for non-code lessons while keeping params above follow-up", () => {
-    const { queryByText, getByText, getByTestId } = render(
+  it("hides empty math params and lets follow-up occupy the remaining console", () => {
+    const { container, queryByText, getByTestId } = render(
       <PlaybookPlayer
         script={baseScript()}
         theme="light"
@@ -178,9 +178,23 @@ describe("PlaybookPlayer", () => {
     );
 
     expect(queryByText("Code Sync")).toBeNull();
-    expect(getByText("Params")).toBeTruthy();
+    expect(queryByText("Params")).toBeNull();
+    expect(container.querySelector(".playbook-player__params-card")).toBeNull();
+    expect(container.querySelector(".playbook-player__follow-card")).toBeTruthy();
     expect(getByTestId("followup-slot")).toBeTruthy();
-    expect(getByText("Ask a follow-up")).toBeTruthy();
+  });
+
+  it("shows math params when at least one editable control is available", () => {
+    const script = baseScript({
+      parameter_controls: [{ id: "a", label: "斜率 a", value: "1" }],
+    });
+
+    const { getByText, getByLabelText } = render(
+      <PlaybookPlayer script={script} theme="light" />,
+    );
+
+    expect(getByText("Params")).toBeTruthy();
+    expect(getByLabelText("斜率 a")).toBeTruthy();
   });
 
   it("keeps subtitles inside the composition and moves playback options into settings", () => {
@@ -246,7 +260,7 @@ describe("PlaybookPlayer", () => {
 
   it("uses a portrait shell with mobile tabs while keeping export and more actions visible", () => {
     const onOpenExport = vi.fn();
-    const { container } = render(
+    const { container, queryByRole } = render(
       <PlaybookPlayer
         script={baseScript()}
         theme="light"
@@ -269,7 +283,8 @@ describe("PlaybookPlayer", () => {
     expect(player?.getAttribute("data-show-subtitles")).toBe("false");
 
     const tabs = container.querySelectorAll(".playbook-player__mobile-tabs button");
-    expect(tabs).toHaveLength(5);
+    expect(tabs).toHaveLength(4);
+    expect(queryByRole("tab", { name: "参数" })).toBeNull();
 
     fireEvent.click(tabs[1]);
     expect(player?.getAttribute("data-show-subtitles")).toBe("true");
@@ -291,6 +306,29 @@ describe("PlaybookPlayer", () => {
 
     fireEvent.click(moreButton!);
     expect(container.querySelector(".playbook-player__mobile-sheet")).toBeTruthy();
+  });
+
+  it("leaves the params tab when a portrait lesson loses editable controls", () => {
+    const withParams = baseScript({
+      parameter_controls: [{ id: "a", label: "斜率 a", value: "1" }],
+    });
+    const view = render(
+      <PlaybookPlayer script={withParams} theme="light" layoutMode="portrait" />,
+    );
+
+    fireEvent.click(view.getByRole("tab", { name: "参数" }));
+    expect(view.getByRole("tab", { name: "参数" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+
+    view.rerender(
+      <PlaybookPlayer script={baseScript()} theme="light" layoutMode="portrait" />,
+    );
+
+    expect(view.queryByRole("tab", { name: "参数" })).toBeNull();
+    expect(view.getByRole("tab", { name: "讲解" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
   });
 
   it("shows only the active code context in the portrait code tab", () => {
@@ -363,7 +401,7 @@ describe("PlaybookPlayer", () => {
   });
 
   it("opens follow-up content in a portrait bottom sheet", () => {
-    const { container, getByLabelText } = render(
+    const { container, getByLabelText, getByRole } = render(
       <PlaybookPlayer
         script={baseScript()}
         theme="light"
@@ -372,10 +410,7 @@ describe("PlaybookPlayer", () => {
       />,
     );
 
-    const followupTab = container.querySelectorAll<HTMLButtonElement>(
-      ".playbook-player__mobile-tabs button",
-    )[3];
-    fireEvent.click(followupTab);
+    fireEvent.click(getByRole("tab", { name: "追问" }));
 
     expect(container.querySelector(".playbook-player__mobile-sheet")).toBeTruthy();
     expect(getByLabelText("Ask follow-up")).toBeTruthy();

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
@@ -15,6 +15,7 @@ import { CodeHighlightRenderer } from "../renderers/CodeHighlightRenderer";
 import { domainCapability } from "../domainCapabilities";
 import { getParamPanel } from "../param-panels/registry";
 import { hasReplayableAlgorithmParams } from "../param-panels/AlgorithmParamPanel";
+import { hasEditableMathParams } from "../param-panels/MathParamPanel";
 import { resolveDirectorVoiceover } from "../director";
 import { emitNativeEvent } from "../../../../shared/native/emitNativeEvent";
 import { MobileSheet } from "./MobileSheet";
@@ -104,8 +105,17 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
     if (baseScript.domain === "algorithm") {
       return hasReplayableAlgorithmParams(baseScript);
     }
+    if (baseScript.domain === "math") {
+      return hasEditableMathParams(baseScript);
+    }
     return true;
   }, [baseScript]);
+
+  useEffect(() => {
+    if (hasDomainPanel) return;
+    if (mobileTab === "params") setMobileTab("narration");
+    if (mobileSheet === "params") setMobileSheet(null);
+  }, [hasDomainPanel, mobileSheet, mobileTab]);
   const initialPreviewFrame = useMemo(() => resolveInitialPreviewFrame(script), [script]);
   const playerTimelineKey = useMemo(() => resolvePlayerTimelineKey(baseScript), [baseScript]);
 
@@ -263,7 +273,9 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
     currentNarrationFallback,
   );
   const showMobileConsole = isPortraitLayout && showLearningConsole;
-  const showStageSubtitles = !(showMobileConsole && mobileTab === "narration");
+  const effectiveMobileTab =
+    mobileTab === "params" && !hasDomainPanel ? "narration" : mobileTab;
+  const showStageSubtitles = !(showMobileConsole && effectiveMobileTab === "narration");
   const mobileSheetTitle =
     mobileSheet === "code"
       ? "全部代码"
@@ -461,7 +473,7 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
           stageSlot={stageSlot}
           controlsSlot={controlsSlot}
           showMobileConsole={showMobileConsole}
-          activeTab={mobileTab}
+          activeTab={effectiveMobileTab}
           onSelectTab={selectMobileTab}
           onOpenSheet={openMobileSheet}
           mobileCodeOverlay={mobileCodeOverlay}

--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
@@ -15,7 +15,7 @@ import { CodeHighlightRenderer } from "../renderers/CodeHighlightRenderer";
 import { domainCapability } from "../domainCapabilities";
 import { getParamPanel } from "../param-panels/registry";
 import { hasReplayableAlgorithmParams } from "../param-panels/AlgorithmParamPanel";
-import { hasEditableMathParams } from "../param-panels/MathParamPanel";
+import { hasEditableMathParams } from "../param-panels/mathParams";
 import { resolveDirectorVoiceover } from "../director";
 import { emitNativeEvent } from "../../../../shared/native/emitNativeEvent";
 import { MobileSheet } from "./MobileSheet";
@@ -106,25 +106,25 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
       return hasReplayableAlgorithmParams(baseScript);
     }
     if (baseScript.domain === "math") {
-      return hasEditableMathParams(baseScript);
+      return hasEditableMathParams(baseScript.parameter_controls);
     }
     return true;
   }, [baseScript]);
-
-  useEffect(() => {
-    if (hasDomainPanel) return;
-    if (mobileTab === "params") setMobileTab("narration");
-    if (mobileSheet === "params") setMobileSheet(null);
-  }, [hasDomainPanel, mobileSheet, mobileTab]);
   const initialPreviewFrame = useMemo(() => resolveInitialPreviewFrame(script), [script]);
   const playerTimelineKey = useMemo(() => resolvePlayerTimelineKey(baseScript), [baseScript]);
 
   useEffect(() => {
     const id = setTimeout(() => {
       setOverrides((current) => (Object.keys(current).length > 0 ? {} : current));
+      setMobileTab((current) =>
+        current === "params" && !hasDomainPanel ? "narration" : current,
+      );
+      setMobileSheet((current) =>
+        current === "params" && !hasDomainPanel ? null : current,
+      );
     }, 0);
     return () => clearTimeout(id);
-  }, [baseScript]);
+  }, [baseScript, hasDomainPanel]);
 
   const tts = useTTS();
   // Push the playbook domain into useTTS so AUTO-voice resolution still
@@ -275,13 +275,15 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
   const showMobileConsole = isPortraitLayout && showLearningConsole;
   const effectiveMobileTab =
     mobileTab === "params" && !hasDomainPanel ? "narration" : mobileTab;
+  const effectiveMobileSheet =
+    mobileSheet === "params" && !hasDomainPanel ? null : mobileSheet;
   const showStageSubtitles = !(showMobileConsole && effectiveMobileTab === "narration");
   const mobileSheetTitle =
-    mobileSheet === "code"
+    effectiveMobileSheet === "code"
       ? "全部代码"
-      : mobileSheet === "params"
+      : effectiveMobileSheet === "params"
         ? "参数"
-        : mobileSheet === "followup"
+        : effectiveMobileSheet === "followup"
           ? "追问"
           : "更多";
   const selectMobileTab = (tab: MobileTabKey) => {
@@ -565,9 +567,9 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
         />
       )}
 
-      {showMobileConsole && mobileSheet && (
+      {showMobileConsole && effectiveMobileSheet && (
         <MobileSheet title={mobileSheetTitle} onClose={() => setMobileSheet(null)}>
-          {mobileSheet === "code" && (
+          {effectiveMobileSheet === "code" && (
             <div className="playbook-player__mobile-sheet-code">
               {codeOverlay ? (
                 <CodeHighlightRenderer overlay={codeOverlay} theme={theme} />
@@ -576,7 +578,7 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
               )}
             </div>
           )}
-          {mobileSheet === "params" && (
+          {effectiveMobileSheet === "params" && (
             <div className="playbook-player__mobile-sheet-section">
               {hasDomainPanel ? (
                 <ParamPanelSlot
@@ -591,14 +593,14 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
               )}
             </div>
           )}
-          {mobileSheet === "followup" && (
+          {effectiveMobileSheet === "followup" && (
             <div className="playbook-player__mobile-followup-sheet">
               {followupSlot ?? (
                 <div className="playbook-player__mobile-empty">当前讲解暂不能继续追问。</div>
               )}
             </div>
           )}
-          {mobileSheet === "more" && (
+          {effectiveMobileSheet === "more" && (
             <div className="playbook-player__mobile-more-sheet">
               <div className="playbook-player__mobile-sheet-actions">
                 {onOpenExport && (

--- a/apps/web/src/features/playbook/engine/player/PlaybookPortraitShell.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPortraitShell.tsx
@@ -157,6 +157,10 @@ export function PlaybookPortraitShell({
   hasDomainPanel,
   paramsContent,
 }: PlaybookPortraitShellProps) {
+  const visibleTabs = hasDomainPanel
+    ? MOBILE_TABS
+    : MOBILE_TABS.filter((tab) => tab.key !== "params");
+
   return (
     <div className="playbook-player__workspace">
       <header className="playbook-player__header">
@@ -186,7 +190,7 @@ export function PlaybookPortraitShell({
       {showMobileConsole && (
         <section className="playbook-player__mobile-console" aria-label="移动学习面板">
           <div className="playbook-player__mobile-tabs" role="tablist" aria-label="移动学习面板">
-            {MOBILE_TABS.map((tab) => (
+            {visibleTabs.map((tab) => (
               <button
                 key={tab.key}
                 type="button"

--- a/apps/web/src/styles/mobileWebSmoke.test.tsx
+++ b/apps/web/src/styles/mobileWebSmoke.test.tsx
@@ -151,7 +151,8 @@ describe("mobile web smoke", () => {
       );
       expect(container.querySelector(".playbook-player__export-btn")).toBeTruthy();
       expect(container.querySelector(".playbook-player__mobile-more-btn")).toBeTruthy();
-      expect(container.querySelectorAll(".playbook-player__mobile-tabs button")).toHaveLength(5);
+      expect(container.querySelectorAll(".playbook-player__mobile-tabs button")).toHaveLength(4);
+      expect(container.querySelector('[role="tab"][aria-label="参数"]')).toBeNull();
       expect(container.querySelector(".playbook-player__console")).toBeNull();
     },
   );

--- a/apps/web/src/styles/mobileWebSmoke.test.tsx
+++ b/apps/web/src/styles/mobileWebSmoke.test.tsx
@@ -152,7 +152,11 @@ describe("mobile web smoke", () => {
       expect(container.querySelector(".playbook-player__export-btn")).toBeTruthy();
       expect(container.querySelector(".playbook-player__mobile-more-btn")).toBeTruthy();
       expect(container.querySelectorAll(".playbook-player__mobile-tabs button")).toHaveLength(4);
-      expect(container.querySelector('[role="tab"][aria-label="参数"]')).toBeNull();
+      expect(
+        Array.from(container.querySelectorAll(".playbook-player__mobile-tabs button")).some(
+          (tab) => tab.textContent?.includes("参数"),
+        ),
+      ).toBe(false);
       expect(container.querySelector(".playbook-player__console")).toBeNull();
     },
   );


### PR DESCRIPTION
## What changed

- derive math Params visibility from validated editable controls instead of domain registration alone
- omit the desktop Params card when no effective controls exist so Follow-up keeps the remaining console space
- remove the portrait Params tab when unavailable
- recover to the narration tab when a patched lesson loses its parameter controls
- replace the regression test that previously required an empty math Params card
- add coverage for valid math controls, portrait lesson transitions, and mobile smoke behavior

## Why

Math playbooks with an empty or invalid `parameter_controls` array were treated as parameter-capable. The panel then rendered an empty-state message while still consuming console space, and portrait mode always exposed a Params tab.

## Validation

- GitHub Actions `Check` passed: lint, tests, build, and coverage
- regression coverage verifies that empty parameter surfaces are absent on desktop and portrait layouts
- keep this pull request Draft until the adaptive layout is reviewed