### PR TITLE
feat(templates): polish conic preview illustrations

### DIFF
--- a/apps/web/src/app/routing.test.tsx
+++ b/apps/web/src/app/routing.test.tsx
@@ -108,7 +108,7 @@ describe("App routing", () => {
     const { App } = await import("./App");
     const { getByRole, getByText } = render(<App />);
 
-    expect(getByRole("heading", { name: "模板本身，就是可以播放的案例" })).toBeTruthy();
+    expect(getByRole("heading", { name: "挑一个感兴趣的知识点，从这里慢慢看懂它" })).toBeTruthy();
     expect(getByText("工作台")).toBeTruthy();
     expect(getByRole("button", { name: /模板/ }).getAttribute("aria-current")).toBe("page");
     await waitFor(() => expect(accountHits).toBe(1));
@@ -185,7 +185,7 @@ describe("App routing", () => {
     const { getByRole } = render(<App />);
 
     await waitFor(() => expect(window.location.pathname).toBe("/templates"));
-    expect(getByRole("heading", { name: "模板本身，就是可以播放的案例" })).toBeTruthy();
+    expect(getByRole("heading", { name: "挑一个感兴趣的知识点，从这里慢慢看懂它" })).toBeTruthy();
   });
 
   it("returns the retired factorial showcase link to the template catalog", async () => {

--- a/apps/web/src/pages/Templates/TemplateLinePreview.test.tsx
+++ b/apps/web/src/pages/Templates/TemplateLinePreview.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TemplateLinePreview } from "./TemplateLinePreview";
+import type { TemplatePreviewCaseId } from "./templatePreviewCases";
+
+const CONIC_PREVIEWS: ReadonlyArray<{
+  caseId: TemplatePreviewCaseId;
+  geometry: string;
+  objects: Record<string, number>;
+}> = [
+  {
+    caseId: "ellipse-focus-definition",
+    geometry: "ellipse-focal-sum",
+    objects: { conic: 1, focus: 2, "focal-distance": 2, "moving-point": 1 },
+  },
+  {
+    caseId: "parabola-focus-directrix",
+    geometry: "parabola-focus-directrix",
+    objects: { conic: 1, directrix: 1, focus: 1, "projection-foot": 1, "moving-point": 1 },
+  },
+  {
+    caseId: "hyperbola-asymptotes",
+    geometry: "hyperbola-asymptotes",
+    objects: { "conic-branch": 2, asymptotes: 1, "moving-point": 1 },
+  },
+  {
+    caseId: "line-ellipse-position",
+    geometry: "line-ellipse-position",
+    objects: { conic: 1, "tangent-reference": 1, "disjoint-reference": 1, secant: 1, intersection: 2 },
+  },
+  {
+    caseId: "ellipse-chord-midpoint-locus",
+    geometry: "ellipse-chord-midpoint-locus",
+    objects: { conic: 1, chord: 1, "chord-endpoint": 2, "fixed-point": 1, "theoretical-locus": 1, "chord-midpoint": 1 },
+  },
+];
+
+describe("TemplateLinePreview conic descriptors", () => {
+  afterEach(cleanup);
+
+  it.each(CONIC_PREVIEWS)("keeps $caseId mathematically identifiable", ({ caseId, geometry, objects }) => {
+    const { container } = render(<TemplateLinePreview caseId={caseId} />);
+    const preview = container.querySelector(`[data-preview='${caseId}']`);
+    const svg = preview?.querySelector(`svg[data-preview-geometry='${geometry}']`);
+
+    expect(svg).toBeTruthy();
+    for (const [object, count] of Object.entries(objects)) {
+      expect(svg?.querySelectorAll(`[data-object='${object}']`)).toHaveLength(count);
+    }
+  });
+
+  it("keeps the pole-polar reference preview unchanged and separate", () => {
+    const { container } = render(<TemplateLinePreview caseId="pole-polar" />);
+
+    expect(container.querySelector("[data-preview='pole-polar'] svg")).toBeTruthy();
+    expect(container.querySelector("[data-preview-geometry]")).toBeNull();
+  });
+});

--- a/apps/web/src/pages/Templates/TemplateLinePreview.tsx
+++ b/apps/web/src/pages/Templates/TemplateLinePreview.tsx
@@ -1,4 +1,109 @@
+import type { ReactNode } from "react";
 import type { TemplatePreviewCaseId } from "./templatePreviewCases";
+
+const LINE_PREVIEWS: Record<TemplatePreviewCaseId, ReactNode> = {
+  "binary-search": (
+    <svg viewBox="0 0 160 56" fill="none">
+      <path className="is-guide" d="M20 13v-5h116v5M20 43v5h116v-5" />
+      {[24, 42, 60, 78, 96, 114, 132].map((x, index) => (
+        <rect key={x} className={index === 3 ? "is-accent" : undefined} x={x} y="19" width="14" height="18" rx="2" />
+      ))}
+      <path className="is-accent" d="M85 8v8m-4-4 4 4 4-4" />
+    </svg>
+  ),
+  "bfs-tree": (
+    <svg viewBox="0 0 160 56" fill="none">
+      <path className="is-guide" d="M80 12 48 27m32-15 32 15M48 27 32 42m16-15 16 15m48-15-16 15m16-15 16 15" />
+      <circle className="is-accent" cx="80" cy="10" r="5" />
+      <circle cx="48" cy="27" r="4" /><circle cx="112" cy="27" r="4" />
+      <circle cx="32" cy="44" r="3.5" /><circle cx="64" cy="44" r="3.5" />
+      <circle cx="96" cy="44" r="3.5" /><circle cx="128" cy="44" r="3.5" />
+      <path className="is-accent" d="M20 52h40" />
+    </svg>
+  ),
+  "derivative-tangent": (
+    <svg viewBox="0 0 160 56" fill="none">
+      <path className="is-guide" d="M18 45h124M40 50V7" />
+      <path d="M28 43c18-1 26-4 34-11 10-9 18-22 34-22 13 0 23 10 36 31" />
+      <path className="is-accent" d="m55 42 64-31" />
+      <circle className="is-accent" cx="83" cy="28" r="3.5" />
+    </svg>
+  ),
+  "ellipse-focus-definition": (
+    <svg viewBox="0 0 160 56" fill="none" data-preview-geometry="ellipse-focal-sum">
+      <path className="is-guide is-dashed" d="M22 28h116" data-object="focal-axis" />
+      <ellipse cx="80" cy="28" rx="52" ry="20" data-object="conic" />
+      <path className="is-guide" d="M58 28 106 13" data-object="focal-distance" />
+      <path className="is-accent" d="M106 13 102 28" data-object="focal-distance" />
+      <circle cx="58" cy="28" r="2.7" data-object="focus" />
+      <circle cx="102" cy="28" r="2.7" data-object="focus" />
+      <circle className="is-accent" cx="106" cy="13" r="3.4" data-object="moving-point" />
+    </svg>
+  ),
+  "parabola-focus-directrix": (
+    <svg viewBox="0 0 160 56" fill="none" data-preview-geometry="parabola-focus-directrix">
+      <path className="is-guide" d="M43 28h91" data-object="axis" />
+      <path className="is-guide is-dashed" d="M59 4v48" data-object="directrix" />
+      <path d="M112 4C80 8 64 16 64 28s16 20 48 24" data-object="conic" />
+      <path className="is-guide" d="M80 10H59" data-object="directrix-distance" />
+      <path className="is-accent" d="M80 10 69 28" data-object="focal-distance" />
+      <circle cx="69" cy="28" r="2.8" data-object="focus" />
+      <circle cx="59" cy="10" r="2.1" data-object="projection-foot" />
+      <circle className="is-accent" cx="80" cy="10" r="3.4" data-object="moving-point" />
+    </svg>
+  ),
+  "hyperbola-asymptotes": (
+    <svg viewBox="0 0 160 56" fill="none" data-preview-geometry="hyperbola-asymptotes">
+      <path className="is-guide" d="M18 28h124M80 4v48" data-object="axes" />
+      <path className="is-guide is-dashed" d="m28 51 104-46M28 5l104 46" data-object="asymptotes" />
+      <path d="M34 5c18 7 29 16 31 23-2 7-13 16-31 23" data-object="conic-branch" />
+      <path d="M126 5c-18 7-29 16-31 23 2 7 13 16 31 23" data-object="conic-branch" />
+      <circle className="is-accent" cx="111" cy="11" r="3.4" data-object="moving-point" />
+    </svg>
+  ),
+  "line-ellipse-position": (
+    <svg viewBox="0 0 160 56" fill="none" data-preview-geometry="line-ellipse-position">
+      <path className="is-guide is-dotted" d="M31 4h98" data-object="disjoint-reference" />
+      <path className="is-guide is-dashed" d="M31 9h98" data-object="tangent-reference" />
+      <ellipse cx="80" cy="28" rx="48" ry="19" data-object="conic" />
+      <path className="is-accent" d="m24 45 112-34" data-object="secant" />
+      <circle className="is-accent" cx="48" cy="38" r="3" data-object="intersection" />
+      <circle className="is-accent" cx="113" cy="18" r="3" data-object="intersection" />
+    </svg>
+  ),
+  "ellipse-chord-midpoint-locus": (
+    <svg viewBox="0 0 160 56" fill="none" data-preview-geometry="ellipse-chord-midpoint-locus">
+      <ellipse cx="80" cy="28" rx="52" ry="20" data-object="conic" />
+      <ellipse className="is-accent is-dashed" cx="88" cy="28" rx="13" ry="7" data-object="theoretical-locus" />
+      <path className="is-guide" d="m36 43 86-28" data-object="chord" />
+      <circle cx="38" cy="42.3" r="2.5" data-object="chord-endpoint" />
+      <circle cx="120" cy="15.7" r="2.5" data-object="chord-endpoint" />
+      <circle cx="95" cy="23.8" r="2.6" data-object="fixed-point" />
+      <circle className="is-accent" cx="80" cy="24" r="1.7" data-object="locus-trail" />
+      <circle className="is-accent" cx="88" cy="21" r="1.7" data-object="locus-trail" />
+      <circle className="is-accent" cx="97" cy="24" r="1.7" data-object="locus-trail" />
+      <circle className="is-accent" cx="79" cy="29" r="3.4" data-object="chord-midpoint" />
+    </svg>
+  ),
+  "pole-polar": (
+    <svg viewBox="0 0 160 56" fill="none">
+      <path className="is-guide" d="M18 48h126M42 53V5" />
+      <circle cx="76" cy="29" r="19" />
+      <path d="m94 13 34 4M94 45l34-28" />
+      <path className="is-accent" d="m94 13 0 32" />
+      <circle className="is-accent" cx="128" cy="17" r="3.5" />
+      <circle cx="94" cy="13" r="2.5" /><circle cx="94" cy="45" r="2.5" />
+    </svg>
+  ),
+  projectile: (
+    <svg viewBox="0 0 160 56" fill="none">
+      <path className="is-guide" d="M16 47h130" />
+      <path d="M25 45c26-36 61-39 108 0" />
+      <path className="is-accent" d="m27 44 18-20m0 0-1 7m1-7-7 2" />
+      <circle className="is-accent" cx="80" cy="17" r="3.5" />
+    </svg>
+  ),
+};
 
 export function TemplateLinePreview({ caseId }: { caseId?: TemplatePreviewCaseId }) {
   if (!caseId) {
@@ -13,91 +118,7 @@ export function TemplateLinePreview({ caseId }: { caseId?: TemplatePreviewCaseId
 
   return (
     <span className="mv-template-entry__line-preview" data-preview={caseId} aria-hidden="true">
-      {caseId === "binary-search" && (
-        <svg viewBox="0 0 160 56" fill="none">
-          <path className="is-guide" d="M20 13v-5h116v5M20 43v5h116v-5" />
-          {[24, 42, 60, 78, 96, 114, 132].map((x, index) => (
-            <rect key={x} className={index === 3 ? "is-accent" : undefined} x={x} y="19" width="14" height="18" rx="2" />
-          ))}
-          <path className="is-accent" d="M85 8v8m-4-4 4 4 4-4" />
-        </svg>
-      )}
-      {caseId === "bfs-tree" && (
-        <svg viewBox="0 0 160 56" fill="none">
-          <path className="is-guide" d="M80 12 48 27m32-15 32 15M48 27 32 42m16-15 16 15m48-15-16 15m16-15 16 15" />
-          <circle className="is-accent" cx="80" cy="10" r="5" />
-          <circle cx="48" cy="27" r="4" /><circle cx="112" cy="27" r="4" />
-          <circle cx="32" cy="44" r="3.5" /><circle cx="64" cy="44" r="3.5" />
-          <circle cx="96" cy="44" r="3.5" /><circle cx="128" cy="44" r="3.5" />
-          <path className="is-accent" d="M20 52h40" />
-        </svg>
-      )}
-      {caseId === "derivative-tangent" && (
-        <svg viewBox="0 0 160 56" fill="none">
-          <path className="is-guide" d="M18 45h124M40 50V7" />
-          <path d="M28 43c18-1 26-4 34-11 10-9 18-22 34-22 13 0 23 10 36 31" />
-          <path className="is-accent" d="m55 42 64-31" />
-          <circle className="is-accent" cx="83" cy="28" r="3.5" />
-        </svg>
-      )}
-      {caseId === "ellipse-focus-definition" && (
-        <svg viewBox="0 0 160 56" fill="none">
-          <ellipse cx="80" cy="28" rx="52" ry="20" />
-          <circle cx="60" cy="28" r="2.5" /><circle cx="100" cy="28" r="2.5" />
-          <circle className="is-accent" cx="102" cy="12" r="3.5" />
-          <path className="is-guide" d="m60 28 42-16m0 0-2 16" />
-        </svg>
-      )}
-      {caseId === "parabola-focus-directrix" && (
-        <svg viewBox="0 0 160 56" fill="none">
-          <path d="M48 6c38 8 38 36 0 44" />
-          <path className="is-guide" d="M35 5v46m32-23H35" />
-          <circle cx="62" cy="28" r="2.5" />
-          <circle className="is-accent" cx="76" cy="15" r="3.5" />
-          <path className="is-accent" d="m76 15-14 13m14-13H35" />
-        </svg>
-      )}
-      {caseId === "hyperbola-asymptotes" && (
-        <svg viewBox="0 0 160 56" fill="none">
-          <path className="is-guide" d="m28 49 104-42M28 7l104 42" />
-          <path d="M63 6c-20 10-20 34 0 44M97 6c20 10 20 34 0 44" />
-          <circle className="is-accent" cx="108" cy="17" r="3.5" />
-        </svg>
-      )}
-      {caseId === "line-ellipse-position" && (
-        <svg viewBox="0 0 160 56" fill="none">
-          <ellipse cx="80" cy="28" rx="48" ry="19" />
-          <path className="is-accent" d="m24 45 112-34" />
-          <circle className="is-accent" cx="48" cy="38" r="3" />
-          <circle className="is-accent" cx="113" cy="18" r="3" />
-        </svg>
-      )}
-      {caseId === "ellipse-chord-midpoint-locus" && (
-        <svg viewBox="0 0 160 56" fill="none">
-          <ellipse cx="80" cy="28" rx="52" ry="20" />
-          <path className="is-guide" d="m34 45 92-31" />
-          <ellipse className="is-accent" cx="72" cy="28" rx="18" ry="7" />
-          <circle className="is-accent" cx="72" cy="28" r="3.5" />
-        </svg>
-      )}
-      {caseId === "pole-polar" && (
-        <svg viewBox="0 0 160 56" fill="none">
-          <path className="is-guide" d="M18 48h126M42 53V5" />
-          <circle cx="76" cy="29" r="19" />
-          <path d="m94 13 34 4M94 45l34-28" />
-          <path className="is-accent" d="m94 13 0 32" />
-          <circle className="is-accent" cx="128" cy="17" r="3.5" />
-          <circle cx="94" cy="13" r="2.5" /><circle cx="94" cy="45" r="2.5" />
-        </svg>
-      )}
-      {caseId === "projectile" && (
-        <svg viewBox="0 0 160 56" fill="none">
-          <path className="is-guide" d="M16 47h130" />
-          <path d="M25 45c26-36 61-39 108 0" />
-          <path className="is-accent" d="m27 44 18-20m0 0-1 7m1-7-7 2" />
-          <circle className="is-accent" cx="80" cy="17" r="3.5" />
-        </svg>
-      )}
+      {LINE_PREVIEWS[caseId]}
     </span>
   );
 }

--- a/apps/web/src/pages/Templates/TemplatesPage.test.tsx
+++ b/apps/web/src/pages/Templates/TemplatesPage.test.tsx
@@ -28,6 +28,14 @@ describe("TemplatesPage lesson atlas", () => {
     vi.restoreAllMocks();
   });
 
+  it("introduces the examples as ready-to-play teaching explanations", () => {
+    const view = renderPage();
+
+    expect(view.getByText("从一个好问题开始")).toBeTruthy();
+    expect(view.getByRole("heading", { name: "挑一个感兴趣的知识点，从这里慢慢看懂它" })).toBeTruthy();
+    expect(view.getByText("这些案例已经准备好了。先看一眼，再跟着完整讲解一步步走下去。")).toBeTruthy();
+  });
+
   it("expands a real poster on the first click and enters the player on the second", () => {
     const view = renderPage();
     const firstState = view.getByRole("button", { name: "二分查找，展开预览" });

--- a/apps/web/src/pages/Templates/TemplatesPage.tsx
+++ b/apps/web/src/pages/Templates/TemplatesPage.tsx
@@ -67,9 +67,9 @@ export function TemplatesPage({ onOpenTemplate }: TemplatesPageProps = {}) {
     <main className="mv-templates-body">
       <header className="mv-templates-head">
         <div className="mv-templates-head__copy">
-          <div className="mv-eyebrow-mini">LESSON ATLAS / 讲解图谱</div>
-          <h1 className="mv-templates-title">模板本身，就是可以播放的案例</h1>
-          <p className="mv-templates-sub">先展开查看真实画面，再进入完整 Playbook；整个过程不生成新任务。</p>
+          <div className="mv-eyebrow-mini">从一个好问题开始</div>
+          <h1 className="mv-templates-title">挑一个感兴趣的知识点，从这里慢慢看懂它</h1>
+          <p className="mv-templates-sub">这些案例已经准备好了。先看一眼，再跟着完整讲解一步步走下去。</p>
         </div>
         <div className="mv-templates-index-mark" aria-label={`${filtered.length} 个模板`}>
           <strong>{String(filtered.length).padStart(2, "0")}</strong>

--- a/apps/web/src/styles/pages/templates.css
+++ b/apps/web/src/styles/pages/templates.css
@@ -227,8 +227,14 @@
   transition: color var(--mv-template-motion-fast) ease;
 }
 
+.mv-template-entry__line-preview svg * {
+  vector-effect: non-scaling-stroke;
+}
+
 .mv-template-entry__line-preview .is-guide { stroke: var(--line); }
 .mv-template-entry__line-preview .is-accent { stroke: var(--accent); }
+.mv-template-entry__line-preview .is-dashed { stroke-dasharray: 4 3.5; }
+.mv-template-entry__line-preview .is-dotted { stroke-dasharray: 1 3; }
 
 .mv-template-entry:hover .mv-template-entry__line-preview,
 .mv-template-entry.is-selected .mv-template-entry__line-preview {


### PR DESCRIPTION
## Summary

- redraw the five conic template list thumbnails with clearer mathematical silhouettes
- keep the template atlas color system to currentColor, --line, and --accent
- soften the template page introduction copy
- add structural regression coverage for each conic thumbnail

## Validation

- focused template tests: 12 passed
- npm --workspace apps/web run build: passed
- git diff --check: passed
- 1440x900 and 390x844 checked in light and dark themes
- make check: did not complete because web ESLint remained in its scan phase without output; no lint error was emitted