### PR TITLE
fix: disable generation button, show testing announcement

### DIFF
--- a/apps/web/src/app/App.edition.test.tsx
+++ b/apps/web/src/app/App.edition.test.tsx
@@ -168,14 +168,12 @@ describe("App edition shells", () => {
         status: "succeeded",
       }),
     }));
-    window.history.pushState({}, "", "/create");
+    window.history.pushState({}, "", "/run/run-shell");
 
     const { App } = await import("./App");
     const { container, getByRole, getByText } = render(<App />);
 
     expect(container.querySelectorAll(".mv-top")).toHaveLength(1);
-    fireEvent.click(getByRole("button", { name: /二分查找/ }));
-    fireEvent.click(getByRole("button", { name: "生成讲解" }));
 
     await waitFor(() =>
       expect(getByRole("button", { name: "显示顶部栏" })).toBeTruthy(),

--- a/apps/web/src/features/studio-editor/ui/IntakeScreen.test.tsx
+++ b/apps/web/src/features/studio-editor/ui/IntakeScreen.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/web/src/features/studio-editor/ui/IntakeScreen.test.tsx
+++ b/apps/web/src/features/studio-editor/ui/IntakeScreen.test.tsx
@@ -81,35 +81,22 @@ describe("IntakeScreen smart-routed intake", () => {
     );
   });
 
-  it.each([
-    "求函数 f(x)=x² 在 x=1 处的导数",
-    "解释速度为什么会随时间变化",
-    "逐行解释递归函数的返回过程",
-  ])("submits text without exposing a frontend domain for %s", async (prompt) => {
-    const { getByRole, getByPlaceholderText, props } = renderIntake();
-
-    fireEvent.change(getByPlaceholderText(/例如：用动画解释导数/), {
-      target: { value: prompt },
-    });
-    fireEvent.click(getByRole("button", { name: "生成讲解" }));
-
-    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledTimes(1));
-    expect(props.onSubmit).toHaveBeenCalledWith({ prompt });
-    expect(props.onSubmit.mock.calls[0][0]).not.toHaveProperty("domain");
-    expect(props.onSubmit.mock.calls[0][0]).not.toHaveProperty("language");
-  });
-
-  it("uses Ctrl/Cmd + Enter without submitting empty input", async () => {
-    const { getByPlaceholderText, props } = renderIntake();
+  it("shows a testing-in-progress announcement and keeps generation disabled", async () => {
+    const { getByRole, getByPlaceholderText, getByText, props } = renderIntake();
     const textarea = getByPlaceholderText(/例如：用动画解释导数/);
 
-    fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
-    expect(props.onSubmit).not.toHaveBeenCalled();
+    expect(
+      getByText("MetaView 目前处于测试阶段，生成效果仍在优化中，新建生成功能暂时关闭，感谢理解。"),
+    ).toBeTruthy();
 
-    fireEvent.change(textarea, { target: { value: "讲解抛体运动" } });
+    fireEvent.change(textarea, { target: { value: "求函数 f(x)=x² 在 x=1 处的导数" } });
+    const submitButton = getByRole("button", { name: "生成讲解" }) as HTMLButtonElement;
+    expect(submitButton.disabled).toBe(true);
+
+    fireEvent.click(submitButton);
     fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
 
-    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledTimes(1));
+    expect(props.onSubmit).not.toHaveBeenCalled();
   });
 
   it("seeds initialPrompt and caps textarea growth at 320px", () => {
@@ -184,60 +171,18 @@ describe("IntakeScreen smart-routed intake", () => {
     expect(queryByText("large.py")).toBeNull();
   });
 
-  it("submits real code metadata while leaving domain ownership to the backend", async () => {
+  it("keeps generation disabled even with a valid code file attached", () => {
     const { container, getByRole, getByText, props } = renderIntake();
     const file = pythonFile();
 
     fireEvent.change(fileInput(container), { target: { files: [file] } });
     expect(getByText("solution.py")).toBeTruthy();
-    fireEvent.click(getByRole("button", { name: "生成讲解" }));
 
-    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledTimes(1));
-    expect(props.onSubmit).toHaveBeenCalledWith({
-      prompt: "讲解 solution.py 中的代码。",
-      sourceCode: "def solve():\n    return 42\n",
-      language: "python",
-      sourceFilename: "solution.py",
-      sourceSizeBytes: file.size,
-    });
-    expect(props.onSubmit.mock.calls[0][0]).not.toHaveProperty("domain");
-  });
+    const submitButton = getByRole("button", { name: "生成讲解" }) as HTMLButtonElement;
+    expect(submitButton.disabled).toBe(true);
+    fireEvent.click(submitButton);
 
-  it("surfaces file read failures and does not submit", async () => {
-    vi.spyOn(FileReader.prototype, "readAsText").mockImplementation(function (
-      this: FileReader,
-    ) {
-      queueMicrotask(() => this.onerror?.(new ProgressEvent("error")));
-    });
-    const { container, getByRole, getByText, props } = renderIntake();
-
-    fireEvent.change(fileInput(container), {
-      target: { files: [pythonFile()] },
-    });
-    fireEvent.click(getByRole("button", { name: "生成讲解" }));
-
-    await waitFor(() =>
-      expect(getByText("文件读取失败，请重新选择代码文件。")).toBeTruthy(),
-    );
     expect(props.onSubmit).not.toHaveBeenCalled();
-  });
-
-  it("does not submit twice while an asynchronous submission is pending", async () => {
-    let resolveSubmit: (() => void) | undefined;
-    const onSubmit = vi.fn(
-      () => new Promise<void>((resolve) => (resolveSubmit = resolve)),
-    );
-    const { getByRole, getByPlaceholderText } = renderIntake({ onSubmit });
-    fireEvent.change(getByPlaceholderText(/例如：用动画解释导数/), {
-      target: { value: "讲解二分查找" },
-    });
-    const submitButton = getByRole("button", { name: "生成讲解" });
-
-    fireEvent.click(submitButton);
-    fireEvent.click(submitButton);
-
-    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
-    resolveSubmit?.();
   });
 
   it("exposes pending and submit errors accessibly", () => {

--- a/apps/web/src/features/studio-editor/ui/IntakeScreen.tsx
+++ b/apps/web/src/features/studio-editor/ui/IntakeScreen.tsx
@@ -8,6 +8,11 @@ const MAX_CODE_FILE_BYTES = 256 * 1024;
 const TEXTAREA_MIN_HEIGHT = 168;
 const TEXTAREA_MAX_HEIGHT = 320;
 
+/** Kill switch for new-run generation while output quality is under active tuning. */
+const GENERATION_DISABLED = true;
+const GENERATION_DISABLED_MESSAGE =
+  "MetaView 目前处于测试阶段，生成效果仍在优化中，新建生成功能暂时关闭，感谢理解。";
+
 const EXAMPLE_PROMPTS = [
   {
     label: "导数与切线",
@@ -129,6 +134,7 @@ export function IntakeScreen({
   };
 
   const submit = async () => {
+    if (GENERATION_DISABLED) return;
     const prompt = input.trim();
     if ((!prompt && !attachment) || pending || busyRef.current) return;
 
@@ -196,6 +202,11 @@ export function IntakeScreen({
         <header className="mv-intake-hero" aria-label="MetaView 创建讲解">
           <h1 className="mv-intake-title">新建可视化讲解</h1>
           <p className="mv-intake-sub">输入一道题、一个知识点，或粘贴代码。</p>
+          {GENERATION_DISABLED && (
+            <p className="mv-intake-announcement" role="note">
+              {GENERATION_DISABLED_MESSAGE}
+            </p>
+          )}
         </header>
 
         <div className="mv-intake-layout">
@@ -323,7 +334,8 @@ export function IntakeScreen({
                   className="mv-send mv-intake-send"
                   type="button"
                   onClick={() => void submit()}
-                  disabled={pending || (!input.trim() && !attachment)}
+                  disabled={GENERATION_DISABLED || pending || (!input.trim() && !attachment)}
+                  title={GENERATION_DISABLED ? GENERATION_DISABLED_MESSAGE : undefined}
                 >
                   生成讲解
                   <svg

--- a/apps/web/src/styles/pages/studio.css
+++ b/apps/web/src/styles/pages/studio.css
@@ -2165,6 +2165,18 @@
   text-wrap: balance;
 }
 
+.mv-intake-announcement {
+  margin: 14px 0 0;
+  padding: 9px 12px;
+  border: 1px solid color-mix(in srgb, var(--warn) 30%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--warn) 10%, transparent);
+  color: color-mix(in srgb, var(--warn) 70%, var(--ink));
+  font-size: 12.5px;
+  line-height: 1.55;
+  text-wrap: balance;
+}
+
 .mv-intake-composer {
   width: 100%;
   min-width: 0;


### PR DESCRIPTION
## Summary
- 生成效果还在优化中，但已经有真实用户在用了——先临时关闭主入口的"生成讲解"按钮（点击和 Cmd/Ctrl+Enter 都被拦截），避免用户在效果不达预期时继续消耗生成。
- 页面顶部加了一条测试公告，告知用户站点正处于测试阶段。
- 用一个模块级常量 `GENERATION_DISABLED`（当前 `true`）做开关，部署后立即生效，不依赖任何环境变量配置；后续想恢复只需把它改回 `false`（对应测试用例也需要一并恢复）。
- 范围只覆盖主入口按钮，失败后的"重新生成"按钮未改动。

## Test plan
- [x] `npx vitest run` — 142 个测试文件、1204 条用例全部通过
- [x] `npx tsc --noEmit` — 无类型错误
- [ ] 合并后确认线上按钮确实变灰、公告正常展示

🤖 Generated with [Claude Code](https://claude.com/claude-code)