### PR TITLE
fix(ops): restore fail-closed transport allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,14 +89,14 @@ METAVIEW_OPS_ADMIN_USER_ID=
 # the dedicated ops build is served on (deploy.sh's second nginx server block,
 # proxying to the web-ops container). Empty = single-host self edition. In ops
 # edition the API refuses to boot without it and scopes credentialed CORS to
-# https://METAVIEW_OPS_HOST. Transport-layer IP allowlist at nginx
-# (METAVIEW_OPS_ALLOW_IPS); the bound-admin backend check
-# (METAVIEW_OPS_ADMIN_USER_ID) remains the authoritative /admin gate.
+# https://METAVIEW_OPS_HOST. The transport-layer IP allowlist at nginx
+# (METAVIEW_OPS_ALLOW_IPS) and the bound-admin backend check
+# (METAVIEW_OPS_ADMIN_USER_ID) are both required in ops edition.
 METAVIEW_OPS_HOST=
-# Production / ops edition — 可选传输层预门禁（issue #234）。Space/comma-separated IP or
-# CIDR allowlist rendered as nginx `allow` rules before a final `deny all;`, applied to the
-# whole ops server block. 留空 = 不渲染传输层门禁（开放访问）；后端 bound-admin 校验
-# (METAVIEW_OPS_ADMIN_USER_ID) 仍是 /admin 的唯一权威门禁。
+# Production / ops edition — MUST set. Space/comma-separated IP or CIDR
+# allowlist rendered as nginx `allow` rules before a final `deny all;`, applied
+# to the whole ops server block. Empty or invalid = API startup fails closed;
+# configure at least one trusted source before starting an ops deployment.
 METAVIEW_OPS_ALLOW_IPS=
 # Production / ops edition — MUST set (issue #226). In ops edition the cookie
 # setter forces Secure + SameSite=strict regardless of this flag, but local

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -8,6 +8,7 @@ from app.config import get_settings
 from app.infrastructure.persistence.db_init import init_db
 from app.presentation.error_handlers import register_error_handlers
 from app.presentation.middleware import BodySizeLimitMiddleware
+from app.presentation.ops_transport_policy import validate_ops_transport_allowlist
 from app.presentation.rate_limit import install_rate_limiter
 from app.presentation.router_account import router as account_router
 from app.presentation.router_agent import router as agent_router
@@ -29,6 +30,7 @@ async def lifespan(app: FastAPI):
 
 def create_app() -> FastAPI:
     settings = get_settings()
+    validate_ops_transport_allowlist(settings)
 
     app = FastAPI(
         title=settings.app_name,

--- a/apps/api/app/presentation/ops_transport_policy.py
+++ b/apps/api/app/presentation/ops_transport_policy.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import ipaddress
+import os
+
+from app.config import Settings
+
+
+def validate_ops_transport_allowlist(settings: Settings) -> tuple[str, ...]:
+    """Fail closed when an ops deployment has no valid IP/CIDR pre-gate.
+
+    The actual nginx allow rules are rendered by the deployment host, but the
+    versioned API must not boot an ops edition that silently omitted the
+    transport boundary. Self edition intentionally ignores this setting.
+    """
+
+    if settings.app_edition != "ops":
+        return ()
+
+    raw = os.getenv("METAVIEW_OPS_ALLOW_IPS", "")
+    entries = tuple(part for part in raw.replace(",", " ").split() if part)
+    if not entries:
+        raise RuntimeError(
+            "METAVIEW_OPS_ALLOW_IPS is required when app_edition='ops'; "
+            "configure at least one trusted IP/CIDR before starting the ops API"
+        )
+
+    for entry in entries:
+        try:
+            ipaddress.ip_network(entry, strict=False)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"METAVIEW_OPS_ALLOW_IPS contains an invalid IP/CIDR: {entry}"
+            ) from exc
+
+    return entries

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -30,6 +30,10 @@ _TEST_ENV_DEFAULTS = {
     # it. Tests that opt into ops edition would otherwise fail at Settings
     # construction; keep the same inert-for-routes default.
     "METAVIEW_OPS_HOST": "ops.metaview.top",
+    # Ops transport boundary: production must explicitly name trusted source
+    # networks. Loopback is inert for tests but keeps any ops-shaped app
+    # construction fail-closed rather than relying on an empty allowlist.
+    "METAVIEW_OPS_ALLOW_IPS": "127.0.0.1/32",
 }
 
 

--- a/apps/api/tests/test_ops_transport_policy.py
+++ b/apps/api/tests/test_ops_transport_policy.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from app.config import Settings
+from app.presentation.ops_transport_policy import validate_ops_transport_allowlist
+
+
+def ops_settings() -> Settings:
+    return Settings(
+        app_edition="ops",
+        ops_admin_user_id="ops-admin",
+        ops_host="ops.metaview.top",
+        wechat_login_success_url="https://ops.metaview.top/",
+        _env_file=None,
+    )
+
+
+def test_ops_transport_allowlist_is_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("METAVIEW_OPS_ALLOW_IPS", raising=False)
+    with pytest.raises(RuntimeError, match="METAVIEW_OPS_ALLOW_IPS is required"):
+        validate_ops_transport_allowlist(ops_settings())
+
+
+def test_ops_transport_allowlist_rejects_invalid_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("METAVIEW_OPS_ALLOW_IPS", "203.0.113.7 definitely-not-a-cidr")
+    with pytest.raises(RuntimeError, match="invalid IP/CIDR"):
+        validate_ops_transport_allowlist(ops_settings())
+
+
+def test_ops_transport_allowlist_accepts_ips_and_cidrs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "METAVIEW_OPS_ALLOW_IPS",
+        "203.0.113.7, 198.51.100.0/24 2001:db8::/48",
+    )
+    assert validate_ops_transport_allowlist(ops_settings()) == (
+        "203.0.113.7",
+        "198.51.100.0/24",
+        "2001:db8::/48",
+    )
+
+
+def test_self_edition_does_not_require_ops_transport_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("METAVIEW_OPS_ALLOW_IPS", raising=False)
+    settings = Settings(app_edition="self", _env_file=None)
+    assert validate_ops_transport_allowlist(settings) == ()


### PR DESCRIPTION
## Summary

- restore the ops transport boundary to fail closed when `METAVIEW_OPS_ALLOW_IPS` is empty;
- validate every configured entry as an IP or CIDR before the API starts;
- keep self edition unchanged and free of any ops allowlist requirement;
- seed an inert loopback allowlist for ops-shaped test fixtures;
- update `.env.example` so the documented contract matches runtime behavior.

## Why

The ops subdomain previously had a fail-safe `deny all` default, but a later documentation/config change made an empty allowlist mean open transport access. The backend bound-admin check remains authoritative for `/admin`, but this removed the intended defense-in-depth boundary and made deployment behavior depend on a gitignored/local nginx renderer.

This PR puts the fail-closed decision back into versioned code: an ops API cannot boot unless at least one valid trusted IP/CIDR is configured.

## Validation

Focused tests added in `apps/api/tests/test_ops_transport_policy.py` for empty, invalid, valid, and self-edition cases. This connector session cannot execute the local suite; GitHub Actions remains the authoritative execution check.

## Deployment

Before promoting an ops build, set `METAVIEW_OPS_ALLOW_IPS` to the exact trusted source IP/CIDR set used by the nginx renderer. An empty value now intentionally prevents ops API startup.