### PR TITLE
feat(agent): add bounded trace and auth hardening

### DIFF
--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -216,7 +216,7 @@ export async function runAgentGenerationWithTrace(
       if (report.status !== "blocked") {
         trace.runtime("sidecar.completed", {
           attempt_count: attemptNumber,
-          tool_call_count: trace.toolEvents.length,
+          tool_call_count: trace.toolCallCount,
         });
         attachTraceSummary(playbook, trace);
         return {

--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -7,13 +7,20 @@
 import { Agent, type AgentTool } from "@earendil-works/pi-agent-core";
 import { getModel, type Api, type KnownProvider, type Model } from "@earendil-works/pi-ai";
 
+import { resolveOptionalEnv } from "./env.js";
 import { PlaybookEmitter } from "./state/playbookEmitter.js";
 import {
   AgentSelfCheckError,
   selfCheckPlaybook,
   type SelfCheckReport,
 } from "./state/playbookSelfCheck.js";
-import type { PlaybookOutput } from "./state/types.js";
+import { AgentTraceCollector } from "./state/trace.js";
+import type {
+  AgentGenerationResult,
+  PlaybookOutput,
+  RuntimeTraceEvent,
+  ToolTraceEvent,
+} from "./state/types.js";
 import { makeAssertTools } from "./tools/asserts.js";
 import { makeAnimationToolTools } from "./tools/animationTools.js";
 import { makeDrawingTools } from "./tools/drawing.js";
@@ -45,6 +52,8 @@ export interface GenerateOptions {
   defaultModel: string;
   defaultApiKey?: string;
   defaultBaseUrl?: string;
+  /** Optional live collector so the HTTP boundary can retain timeout traces. */
+  traceCollector?: AgentTraceCollector;
 }
 
 export const SYSTEM_PROMPT =
@@ -135,10 +144,48 @@ Output discipline:
 `.trim();
 
 const MAX_SELF_REPAIR_ATTEMPTS = 2;
+const DEFAULT_MAX_TOOL_EVENTS = 512;
+const MAX_RUNTIME_EVENTS = 256;
+
+export class AgentGenerationTraceError extends Error {
+  readonly originalError: unknown;
+  readonly toolEvents: ToolTraceEvent[];
+  readonly runtimeEvents: RuntimeTraceEvent[];
+
+  constructor(
+    originalError: unknown,
+    toolEvents: ToolTraceEvent[],
+    runtimeEvents: RuntimeTraceEvent[],
+  ) {
+    super(
+      originalError instanceof Error
+        ? originalError.message
+        : String(originalError),
+    );
+    this.name = "AgentGenerationTraceError";
+    this.originalError = originalError;
+    this.toolEvents = toolEvents;
+    this.runtimeEvents = runtimeEvents;
+  }
+}
 
 export async function runAgentGeneration(
   opts: GenerateOptions,
 ): Promise<PlaybookOutput> {
+  try {
+    return (await runAgentGenerationWithTrace(opts)).playbook;
+  } catch (error) {
+    if (error instanceof AgentGenerationTraceError) {
+      throw error.originalError;
+    }
+    throw error;
+  }
+}
+
+export async function runAgentGenerationWithTrace(
+  opts: GenerateOptions,
+): Promise<AgentGenerationResult> {
+  const trace = opts.traceCollector ?? createAgentTraceCollector(opts.constraints);
   let userPrompt = buildAgentPrompt(
     opts.prompt,
     opts.routeDecision,
@@ -147,41 +194,82 @@ export async function runAgentGeneration(
   );
   let lastReport: SelfCheckReport | null = null;
 
-  for (let attempt = 0; attempt <= MAX_SELF_REPAIR_ATTEMPTS; attempt++) {
-    const playbook = await runAgentAttempt(opts, userPrompt);
-    const report = selfCheckPlaybook(playbook, opts.prompt);
-    if (report.status !== "blocked") {
-      return playbook;
+  try {
+    for (let attempt = 0; attempt <= MAX_SELF_REPAIR_ATTEMPTS; attempt++) {
+      const attemptNumber = attempt + 1;
+      trace.runtime("sidecar.attempt.started", {
+        attempt: attemptNumber,
+        run_id: opts.runId ?? null,
+      });
+      const playbook = await runAgentAttempt(
+        opts,
+        userPrompt,
+        trace,
+        attemptNumber,
+      );
+      const report = selfCheckPlaybook(playbook, opts.prompt);
+      trace.runtime("sidecar.self_check.completed", {
+        attempt: attemptNumber,
+        status: report.status,
+        issue_count: report.issues.length,
+      });
+      if (report.status !== "blocked") {
+        trace.runtime("sidecar.completed", {
+          attempt_count: attemptNumber,
+          tool_call_count: trace.toolEvents.length,
+        });
+        attachTraceSummary(playbook, trace);
+        return {
+          playbook,
+          toolEvents: trace.toolEvents,
+          runtimeEvents: trace.runtimeEvents,
+        };
+      }
+      lastReport = report;
+      if (attempt >= MAX_SELF_REPAIR_ATTEMPTS) {
+        throw new AgentSelfCheckError(report);
+      }
+      userPrompt = buildAgentSelfRepairPrompt({
+        originalPrompt: opts.prompt,
+        routeDecision: opts.routeDecision,
+        coverageDecision: opts.coverageDecision,
+        lessonPlan: opts.lessonPlan,
+        previousPlaybook: playbook,
+        report,
+        repairAttempt: attempt + 1,
+      });
     }
-    lastReport = report;
-    if (attempt >= MAX_SELF_REPAIR_ATTEMPTS) {
-      throw new AgentSelfCheckError(report);
-    }
-    userPrompt = buildAgentSelfRepairPrompt({
-      originalPrompt: opts.prompt,
-      routeDecision: opts.routeDecision,
-      coverageDecision: opts.coverageDecision,
-      lessonPlan: opts.lessonPlan,
-      previousPlaybook: playbook,
-      report,
-      repairAttempt: attempt + 1,
-    });
-  }
 
-  throw new AgentSelfCheckError(
-    lastReport ?? { status: "blocked", issues: [] },
-  );
+    throw new AgentSelfCheckError(
+      lastReport ?? { status: "blocked", issues: [] },
+    );
+  } catch (error) {
+    trace.runtime("sidecar.failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new AgentGenerationTraceError(
+      error,
+      trace.toolEvents,
+      trace.runtimeEvents,
+    );
+  }
 }
 
 async function runAgentAttempt(
   opts: GenerateOptions,
   userPrompt: string,
+  trace: AgentTraceCollector,
+  attemptNumber: number,
 ): Promise<PlaybookOutput> {
   const emitter = new PlaybookEmitter();
   let runtimePlaybook: PlaybookOutput | null = null;
 
   const drawingTools = makeDrawingTools({ emitter });
-  const assertTools = makeAssertTools({ emitter, apiBaseUrl: opts.apiBaseUrl });
+  const assertTools = makeAssertTools({
+    emitter,
+    apiBaseUrl: opts.apiBaseUrl,
+    sharedToken: opts.agentSharedToken,
+  });
   const runtimeTools = makeRuntimeToolTools({
     apiBaseUrl: opts.apiBaseUrl,
     sharedToken: opts.agentSharedToken,
@@ -191,19 +279,21 @@ async function runAgentAttempt(
     sharedToken: opts.agentSharedToken,
   });
   const templateTools = makeTemplateTools({ emitter });
-  const tools: AgentTool[] = [
+  const rawTools: AgentTool[] = [
     ...drawingTools,
     ...runtimeTools,
     ...animationToolBridge,
     ...templateTools,
     ...assertTools,
   ];
+  const attemptId = `${opts.runId ?? "run"}:attempt:${attemptNumber}`;
+  const tools = trace.wrapTools(rawTools, attemptId, () => emitter.state());
 
   const providerName =
     (opts.provider?.provider as string | undefined) ?? opts.defaultProvider;
   const modelName = opts.provider?.model ?? opts.defaultModel;
-  const apiKey = opts.provider?.api_key ?? opts.defaultApiKey;
-  const baseUrl = opts.provider?.base_url ?? opts.defaultBaseUrl;
+  const apiKey = resolveOptionalEnv(opts.provider?.api_key, opts.defaultApiKey);
+  const baseUrl = resolveOptionalEnv(opts.provider?.base_url, opts.defaultBaseUrl);
 
   const model = resolveModel(providerName, modelName, baseUrl);
 
@@ -220,6 +310,11 @@ async function runAgentAttempt(
         return undefined;
       }
       runtimePlaybook = playbook;
+      trace.runtime("sidecar.runtime_playbook.accepted", {
+        attempt: attemptNumber,
+        step_count: playbook.steps.length,
+        domain: playbook.domain,
+      });
       return { terminate: true };
     },
   });
@@ -232,6 +327,40 @@ async function runAgentAttempt(
   // The emitter has all committed steps by now even if finalize_playbook
   // wasn't explicitly called — its idempotent ``finalize`` covers the case.
   return emitter.finalize();
+}
+
+export function createAgentTraceCollector(
+  constraints?: Record<string, unknown>,
+): AgentTraceCollector {
+  return new AgentTraceCollector(
+    resolveMaxToolEvents(constraints),
+    MAX_RUNTIME_EVENTS,
+  );
+}
+
+function resolveMaxToolEvents(constraints?: Record<string, unknown>): number {
+  const configured = Number(constraints?.max_tool_events);
+  if (!Number.isFinite(configured)) return DEFAULT_MAX_TOOL_EVENTS;
+  return Math.max(32, Math.min(2048, Math.trunc(configured)));
+}
+
+function attachTraceSummary(
+  playbook: PlaybookOutput,
+  trace: AgentTraceCollector,
+): void {
+  playbook.initial_data = {
+    ...(playbook.initial_data ?? {}),
+    agent_tool_trace: trace.toolEvents.slice(-64).map((event) => {
+      const transition = event.state_before && event.state_after
+        ? `:${event.state_before}->${event.state_after}`
+        : "";
+      const outcome = event.ok ? "ok" : "error";
+      return `${event.sequence}:${event.attempt_id}:${event.tool}:${outcome}${transition}`;
+    }),
+    agent_runtime_trace: trace.runtimeEvents.slice(-32).map(
+      (event) => `${event.sequence}:${event.event}`,
+    ),
+  };
 }
 
 function resolveModel(

--- a/apps/agent/src/auth.ts
+++ b/apps/agent/src/auth.ts
@@ -1,7 +1,13 @@
+import { timingSafeEqual } from "node:crypto";
+
 export function hasValidSharedToken(
   configuredToken: string | undefined,
   providedToken: string | undefined,
 ): boolean {
   if (!configuredToken) return true;
-  return providedToken === configuredToken;
+  if (providedToken === undefined) return false;
+  const expected = Buffer.from(configuredToken, "utf8");
+  const actual = Buffer.from(providedToken, "utf8");
+  if (expected.length !== actual.length) return false;
+  return timingSafeEqual(expected, actual);
 }

--- a/apps/agent/src/env.ts
+++ b/apps/agent/src/env.ts
@@ -1,0 +1,12 @@
+/** Small env helpers for optional / blank-as-unset configuration. */
+
+export function resolveOptionalEnv(
+  ...candidates: Array<string | undefined | null>
+): string | undefined {
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") continue;
+    const trimmed = candidate.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}

--- a/apps/agent/src/server.ts
+++ b/apps/agent/src/server.ts
@@ -12,8 +12,13 @@
 import express, { type Request, type Response } from "express";
 import pino from "pino";
 
-import { runAgentGeneration } from "./agent.js";
+import {
+  AgentGenerationTraceError,
+  createAgentTraceCollector,
+  runAgentGenerationWithTrace,
+} from "./agent.js";
 import { hasValidSharedToken } from "./auth.js";
+import { resolveOptionalEnv } from "./env.js";
 import { AgentSelfCheckError } from "./state/playbookSelfCheck.js";
 
 const log = pino({ level: process.env.LOG_LEVEL ?? "info" });
@@ -21,13 +26,19 @@ const PORT = Number(process.env.PORT ?? 8001);
 const API_BASE_URL = process.env.API_BASE_URL ?? "http://api:8000";
 const DEFAULT_PROVIDER = process.env.AGENT_DEFAULT_PROVIDER ?? "openai";
 const DEFAULT_MODEL = process.env.AGENT_DEFAULT_MODEL ?? "gpt-4o-mini";
-const DEFAULT_API_KEY =
-  process.env.AGENT_DEFAULT_API_KEY ??
-  process.env.METAVIEW_OPENAI_API_KEY ??
-  process.env.OPENAI_API_KEY;
-const DEFAULT_BASE_URL =
-  process.env.AGENT_DEFAULT_BASE_URL ?? process.env.METAVIEW_OPENAI_BASE_URL;
-const SHARED_TOKEN = process.env.AGENT_SHARED_TOKEN ?? process.env.METAVIEW_AGENT_SHARED_TOKEN;
+const DEFAULT_API_KEY = resolveOptionalEnv(
+  process.env.AGENT_DEFAULT_API_KEY,
+  process.env.METAVIEW_OPENAI_API_KEY,
+  process.env.OPENAI_API_KEY,
+);
+const DEFAULT_BASE_URL = resolveOptionalEnv(
+  process.env.AGENT_DEFAULT_BASE_URL,
+  process.env.METAVIEW_OPENAI_BASE_URL,
+);
+const SHARED_TOKEN = resolveOptionalEnv(
+  process.env.AGENT_SHARED_TOKEN,
+  process.env.METAVIEW_AGENT_SHARED_TOKEN,
+);
 // Hard ceiling so a hung agent loop can't block the worker indefinitely.
 // The API forwards its own agent timeout via the request body (``timeout_ms``,
 // issue #238); the effective per-request timeout is the lower of that value
@@ -104,15 +115,18 @@ app.post("/generate", async (req: Request, res: Response) => {
     return;
   }
   const timeoutMs = resolveGenerateTimeoutMs(timeout_ms, GENERATE_TIMEOUT_MS);
-  const timeout = new Promise<never>((_, reject) =>
-    setTimeout(
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(
       () => reject(new Error(`agent timed out after ${timeoutMs}ms`)),
       timeoutMs,
-    ),
-  );
+    );
+    timeoutHandle.unref?.();
+  });
+  const trace = createAgentTraceCollector(constraints);
   try {
-    const playbook = await Promise.race([
-      runAgentGeneration({
+    const result = await Promise.race([
+      runAgentGenerationWithTrace({
         prompt,
         runId: run_id,
         sourceCode: source_code,
@@ -130,28 +144,59 @@ app.post("/generate", async (req: Request, res: Response) => {
         defaultModel: DEFAULT_MODEL,
         defaultApiKey: DEFAULT_API_KEY,
         defaultBaseUrl: DEFAULT_BASE_URL,
+        traceCollector: trace,
       }),
       timeout,
     ]);
     res.json({
-      playbook,
+      playbook: result.playbook,
       provider: "pi",
-      tool_events: [],
-      runtime_events: [{ event: "sidecar.completed" }],
+      tool_events: result.toolEvents,
+      runtime_events: result.runtimeEvents,
       review: null,
       artifacts: {},
     });
   } catch (err) {
-    log.error({ err }, "generate failed");
-    if (err instanceof AgentSelfCheckError) {
+    const originalError = err instanceof AgentGenerationTraceError
+      ? err.originalError
+      : err;
+    if (!(err instanceof AgentGenerationTraceError)) {
+      const message = originalError instanceof Error
+        ? originalError.message
+        : String(originalError);
+      if (message.includes("timed out")) {
+        trace.runtime("sidecar.timeout", { timeout_ms: timeoutMs });
+      }
+    }
+    const toolEvents = err instanceof AgentGenerationTraceError
+      ? err.toolEvents
+      : trace.toolEvents;
+    const runtimeEvents = err instanceof AgentGenerationTraceError
+      ? err.runtimeEvents
+      : trace.runtimeEvents;
+    log.error(
+      { err: originalError, tool_events: toolEvents, runtime_events: runtimeEvents },
+      "generate failed",
+    );
+    if (originalError instanceof AgentSelfCheckError) {
       res.status(500).json({
-        detail: err.message,
-        self_check: err.report,
+        detail: originalError.message,
+        self_check: originalError.report,
+        tool_events: toolEvents,
+        runtime_events: runtimeEvents,
       });
       return;
     }
-    const message = err instanceof Error ? err.message : String(err);
-    res.status(500).json({ detail: message });
+    const message = originalError instanceof Error
+      ? originalError.message
+      : String(originalError);
+    res.status(500).json({
+      detail: message,
+      tool_events: toolEvents,
+      runtime_events: runtimeEvents,
+    });
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 });
 

--- a/apps/agent/src/state/playbookEmitter.ts
+++ b/apps/agent/src/state/playbookEmitter.ts
@@ -10,6 +10,7 @@ import type {
   AlgorithmRangeBuilder,
   ArrayTokenBuilder,
   CurveBuilder,
+  DraftState,
   Emphasis,
   MetaStepOutput,
   ParameterControl,
@@ -51,6 +52,14 @@ export class PlaybookEmitter {
       fps: DEFAULT_FPS,
       step_frames: DEFAULT_STEP_FRAMES,
     };
+  }
+
+  /** Coarse lifecycle state used by bounded tool traces. */
+  state(): DraftState {
+    if (this.finalized) return "finalized";
+    if (this.currentStep) return "draft_open";
+    if (this.skeleton.step_titles.length > 0) return "outlined";
+    return "empty";
   }
 
   // ── Plan / outline ────────────────────────────────────────────────────

--- a/apps/agent/src/state/trace.ts
+++ b/apps/agent/src/state/trace.ts
@@ -17,6 +17,7 @@ export class AgentTraceCollector {
   private sequence = 0;
   private readonly toolEventBuffer: ToolTraceEvent[] = [];
   private readonly runtimeEventBuffer: RuntimeTraceEvent[] = [];
+  private totalToolCalls = 0;
   private droppedToolEvents = 0;
   private droppedRuntimeEvents = 0;
   private runtimeTruncationTimestamp: string | null = null;
@@ -35,6 +36,10 @@ export class AgentTraceCollector {
 
   get toolEvents(): ToolTraceEvent[] {
     return [...this.toolEventBuffer];
+  }
+
+  get toolCallCount(): number {
+    return this.totalToolCalls;
   }
 
   get runtimeEvents(): RuntimeTraceEvent[] {
@@ -109,6 +114,7 @@ export class AgentTraceCollector {
   }
 
   private appendTool(event: ToolTraceEvent): void {
+    this.totalToolCalls += 1;
     if (this.toolEventBuffer.length >= this.maxToolEvents) {
       this.toolEventBuffer.shift();
       this.droppedToolEvents += 1;

--- a/apps/agent/src/state/trace.ts
+++ b/apps/agent/src/state/trace.ts
@@ -1,0 +1,193 @@
+import { createHash } from "node:crypto";
+
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+
+import type {
+  DraftState,
+  RuntimeTraceEvent,
+  ToolTraceEvent,
+} from "./types.js";
+
+const SENSITIVE_KEY = /api[_-]?key|authorization|cookie|secret|token|password/i;
+const MAX_TEXT_LENGTH = 240;
+const MAX_ARRAY_ITEMS = 50;
+const MAX_OBJECT_KEYS = 100;
+
+export class AgentTraceCollector {
+  private sequence = 0;
+  private readonly toolEventBuffer: ToolTraceEvent[] = [];
+  private readonly runtimeEventBuffer: RuntimeTraceEvent[] = [];
+  private droppedToolEvents = 0;
+  private droppedRuntimeEvents = 0;
+  private runtimeTruncationTimestamp: string | null = null;
+
+  constructor(
+    private readonly maxToolEvents = 512,
+    private readonly maxRuntimeEvents = 256,
+  ) {
+    if (!Number.isInteger(maxToolEvents) || maxToolEvents < 1) {
+      throw new Error("maxToolEvents must be a positive integer");
+    }
+    if (!Number.isInteger(maxRuntimeEvents) || maxRuntimeEvents < 1) {
+      throw new Error("maxRuntimeEvents must be a positive integer");
+    }
+  }
+
+  get toolEvents(): ToolTraceEvent[] {
+    return [...this.toolEventBuffer];
+  }
+
+  get runtimeEvents(): RuntimeTraceEvent[] {
+    const events = [...this.runtimeEventBuffer];
+    if (this.droppedRuntimeEvents === 0) return events;
+    const marker: RuntimeTraceEvent = {
+      sequence: this.sequence + 1,
+      timestamp: this.runtimeTruncationTimestamp ?? new Date().toISOString(),
+      event: "trace.runtime_events_truncated",
+      detail: { dropped_count: this.droppedRuntimeEvents },
+    };
+    if (events.length >= this.maxRuntimeEvents) events.shift();
+    events.push(marker);
+    return events;
+  }
+
+  runtime(event: string, detail?: Record<string, unknown>): void {
+    this.appendRuntime({
+      sequence: ++this.sequence,
+      timestamp: new Date().toISOString(),
+      event,
+      detail: detail ? asRecord(redact(detail)) : undefined,
+    });
+  }
+
+  wrapTools(
+    tools: AgentTool[],
+    attemptId: string,
+    state: () => DraftState,
+  ): AgentTool[] {
+    return tools.map((tool) => {
+      const execute = tool.execute.bind(tool);
+      return {
+        ...tool,
+        execute: async (toolCallId: string, args: unknown) => {
+          const started = Date.now();
+          const before = state();
+          try {
+            const result = await execute(toolCallId, args as never);
+            const outcome = resultOutcome(result);
+            this.appendTool({
+              sequence: ++this.sequence,
+              timestamp: new Date().toISOString(),
+              tool: tool.name,
+              attempt_id: attemptId,
+              ok: outcome.ok,
+              duration_ms: Date.now() - started,
+              args: redact(args),
+              error: outcome.error,
+              state_before: before,
+              state_after: state(),
+            });
+            return result;
+          } catch (error) {
+            this.appendTool({
+              sequence: ++this.sequence,
+              timestamp: new Date().toISOString(),
+              tool: tool.name,
+              attempt_id: attemptId,
+              ok: false,
+              duration_ms: Date.now() - started,
+              args: redact(args),
+              error: safeError(error),
+              state_before: before,
+              state_after: state(),
+            });
+            throw error;
+          }
+        },
+      } as AgentTool;
+    });
+  }
+
+  private appendTool(event: ToolTraceEvent): void {
+    if (this.toolEventBuffer.length >= this.maxToolEvents) {
+      this.toolEventBuffer.shift();
+      this.droppedToolEvents += 1;
+    }
+    this.toolEventBuffer.push(event);
+    if (this.droppedToolEvents > 0) {
+      const existing = this.runtimeEventBuffer.find(
+        (item) => item.event === "trace.tool_events_truncated",
+      );
+      if (existing) {
+        existing.detail = { dropped_count: this.droppedToolEvents };
+      } else {
+        this.runtime("trace.tool_events_truncated", {
+          dropped_count: this.droppedToolEvents,
+        });
+      }
+    }
+  }
+
+  private appendRuntime(event: RuntimeTraceEvent): void {
+    if (this.runtimeEventBuffer.length >= this.maxRuntimeEvents) {
+      this.runtimeEventBuffer.shift();
+      this.droppedRuntimeEvents += 1;
+      this.runtimeTruncationTimestamp ??= new Date().toISOString();
+    }
+    this.runtimeEventBuffer.push(event);
+  }
+}
+
+function resultOutcome(result: unknown): { ok: boolean; error?: string } {
+  if (!isRecord(result) || !isRecord(result.details)) return { ok: true };
+  if (typeof result.details.ok !== "boolean") return { ok: true };
+  if (result.details.ok) return { ok: true };
+  return {
+    ok: false,
+    error: safeError(result.details.error ?? "tool returned ok=false"),
+  };
+}
+
+function redact(value: unknown, key = ""): unknown {
+  if (SENSITIVE_KEY.test(key)) return "[REDACTED]";
+  if (typeof value === "string") {
+    if (value.length > MAX_TEXT_LENGTH) {
+      return {
+        sha256: createHash("sha256").update(value).digest("hex"),
+        length: value.length,
+      };
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, MAX_ARRAY_ITEMS)
+      .map((item) => redact(item, key));
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .slice(0, MAX_OBJECT_KEYS)
+        .map(([childKey, child]) => [childKey, redact(child, childKey)]),
+    );
+  }
+  return value;
+}
+
+function safeError(error: unknown): string {
+  const raw = error instanceof Error
+    ? error.message
+    : typeof error === "string"
+      ? error
+      : JSON.stringify(redact(error));
+  const value = redact(raw ?? "unknown tool error", "error");
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}

--- a/apps/agent/src/state/types.ts
+++ b/apps/agent/src/state/types.ts
@@ -6,6 +6,7 @@
  */
 
 export type Emphasis = "primary" | "secondary" | "accent";
+export type DraftState = "empty" | "outlined" | "draft_open" | "finalized";
 
 export interface CurveBuilder {
   curve_id: number;
@@ -18,6 +19,7 @@ export interface CurveBuilder {
   label: string;
   emphasis: Emphasis;
   is_parametric: boolean;
+  semantic_role?: string;
 }
 
 export interface PointBuilder {
@@ -26,6 +28,7 @@ export interface PointBuilder {
   y: number;
   label: string;
   emphasis: Emphasis;
+  semantic_role?: string;
 }
 
 export interface SegmentBuilder {
@@ -36,12 +39,14 @@ export interface SegmentBuilder {
   y1: number;
   arrow: boolean;
   label: string;
+  semantic_role?: string;
 }
 
 export interface RegionBuilder {
   vertices: Array<[number, number]>;
   label: string;
   emphasis: Emphasis;
+  semantic_role?: string;
 }
 
 export interface ArrayTokenBuilder {
@@ -145,6 +150,15 @@ export interface LayerOutput {
   body: Record<string, unknown>;
 }
 
+export interface CodeHighlightOutput {
+  language: string;
+  lines: string[];
+  active_lines: number[];
+  active_line: number;
+  variables: Record<string, string>;
+  operation_label?: string;
+}
+
 export interface MetaStepOutput {
   step_id: string;
   title: string;
@@ -157,7 +171,7 @@ export interface MetaStepOutput {
     value: string | null;
     emphasis: Emphasis;
   }>;
-  code_highlight: null;
+  code_highlight: CodeHighlightOutput | null;
   snapshot: Record<string, unknown>;
   layers: LayerOutput[];
 }
@@ -171,4 +185,31 @@ export interface PlaybookOutput {
   summary: string;
   steps: MetaStepOutput[];
   parameter_controls: ParameterControl[];
+  initial_data?: Record<string, string[]>;
+}
+
+export interface ToolTraceEvent {
+  sequence: number;
+  timestamp: string;
+  tool: string;
+  attempt_id: string;
+  ok: boolean;
+  duration_ms: number;
+  args: unknown;
+  error?: string;
+  state_before?: DraftState;
+  state_after?: DraftState;
+}
+
+export interface RuntimeTraceEvent {
+  sequence: number;
+  timestamp: string;
+  event: string;
+  detail?: Record<string, unknown>;
+}
+
+export interface AgentGenerationResult {
+  playbook: PlaybookOutput;
+  toolEvents: ToolTraceEvent[];
+  runtimeEvents: RuntimeTraceEvent[];
 }

--- a/apps/agent/src/tools/asserts.ts
+++ b/apps/agent/src/tools/asserts.ts
@@ -15,6 +15,8 @@ export interface AssertToolDeps {
   emitter: PlaybookEmitter;
   /** FastAPI base URL (e.g. ``http://api:8000``). */
   apiBaseUrl: string;
+  /** Shared token pre-wired for the assert routes' coordinated fail-closed rollout. */
+  sharedToken?: string;
 }
 
 interface OrientationResult {
@@ -35,13 +37,19 @@ interface MonotonicResult {
 }
 
 export function makeAssertTools(deps: AssertToolDeps): AgentTool[] {
-  const { emitter, apiBaseUrl } = deps;
+  const { emitter, apiBaseUrl, sharedToken } = deps;
   const base = apiBaseUrl.replace(/\/$/, "");
 
   async function post<T>(path: string, body: unknown): Promise<T> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (sharedToken) {
+      headers["X-MetaView-Agent-Token"] = sharedToken;
+    }
     const resp = await fetch(`${base}${path}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify(body),
     });
     if (!resp.ok) {

--- a/apps/agent/test/agentRuntimeToolAdoption.test.ts
+++ b/apps/agent/test/agentRuntimeToolAdoption.test.ts
@@ -181,6 +181,15 @@ describe("agent runtime SceneBlueprint adoption", () => {
     );
     expect(result).toEqual(playbook);
     expect(result.steps[0].snapshot.kind).toBe("geo_map_scene");
+    expect(result.initial_data?.agent_tool_trace?.[0]).toContain(
+      "runtime_tool_execute:ok",
+    );
+    expect(result.initial_data?.agent_runtime_trace).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("sidecar.runtime_playbook.accepted"),
+        expect.stringContaining("sidecar.completed"),
+      ]),
+    );
     expect(agentMock.prompts[0]).toContain("LESSON_PLAN_ONLY_MARKER");
     expect(JSON.stringify(result)).not.toContain("LESSON_PLAN_ONLY_MARKER");
     expect(JSON.stringify(result)).not.toContain("algorithm_array");

--- a/apps/agent/test/asserts.test.ts
+++ b/apps/agent/test/asserts.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PlaybookEmitter } from "../src/state/playbookEmitter.js";
+import { makeAssertTools } from "../src/tools/asserts.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("assert tool authentication", () => {
+  it("sends the shared token when configured", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) => ({
+      ok: true,
+      json: async () => ({ verdict: "increasing", reason: "positive derivative" }),
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const tools = makeAssertTools({
+      emitter: new PlaybookEmitter(),
+      apiBaseUrl: "http://api:8000",
+      sharedToken: "shared-secret",
+    });
+    const monotonic = tools.find((item) => item.name === "assert_monotonic");
+    if (!monotonic) throw new Error("assert_monotonic tool missing");
+
+    await monotonic.execute("call-1", {
+      expression: "x**2",
+      x_min: 0.1,
+      x_max: 2,
+    } as never);
+
+    const init = fetchMock.mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    expect(init.headers["X-MetaView-Agent-Token"]).toBe("shared-secret");
+  });
+});

--- a/apps/agent/test/auth.test.ts
+++ b/apps/agent/test/auth.test.ts
@@ -15,4 +15,9 @@ describe("agent shared-token auth", () => {
     expect(hasValidSharedToken("secret", undefined)).toBe(false);
     expect(hasValidSharedToken("secret", "wrong")).toBe(false);
   });
+
+  it("rejects length-mismatched tokens without throwing", () => {
+    expect(hasValidSharedToken("secret", "sec")).toBe(false);
+    expect(hasValidSharedToken("sec", "secret")).toBe(false);
+  });
 });

--- a/apps/agent/test/env.test.ts
+++ b/apps/agent/test/env.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveOptionalEnv } from "../src/env.js";
+
+describe("resolveOptionalEnv", () => {
+  it("returns the first non-blank trimmed candidate", () => {
+    expect(resolveOptionalEnv("  https://api.example/v1  ", "fallback")).toBe(
+      "https://api.example/v1",
+    );
+  });
+
+  it("treats blank strings as unset", () => {
+    expect(resolveOptionalEnv("", "   ", undefined, null, "https://ok")).toBe(
+      "https://ok",
+    );
+  });
+
+  it("returns undefined when every candidate is blank or missing", () => {
+    expect(resolveOptionalEnv(undefined, null, "", "  ")).toBeUndefined();
+  });
+});

--- a/apps/agent/test/trace.test.ts
+++ b/apps/agent/test/trace.test.ts
@@ -1,0 +1,138 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { Type } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+
+import { PlaybookEmitter } from "../src/state/playbookEmitter.js";
+import { AgentTraceCollector } from "../src/state/trace.js";
+import type { DraftState } from "../src/state/types.js";
+
+function tool(
+  name: string,
+  execute: (args: unknown) => Promise<unknown>,
+): AgentTool {
+  return {
+    name,
+    label: name,
+    description: name,
+    parameters: Type.Object({}),
+    execute: async (_toolCallId: string, args: unknown) => execute(args),
+  } as AgentTool;
+}
+
+describe("AgentTraceCollector", () => {
+  it("observes the existing emitter lifecycle without changing it", () => {
+    const emitter = new PlaybookEmitter();
+    expect(emitter.state()).toBe("empty");
+    emitter.setOutline("math", ["Introduce the function"]);
+    expect(emitter.state()).toBe("outlined");
+    emitter.beginStep(1, "Introduce the function");
+    expect(emitter.state()).toBe("draft_open");
+    emitter.setNarration(["Introduce the function with a concrete example."]);
+    emitter.addFormula("f(x)=x^2");
+    emitter.commitStep();
+    expect(emitter.state()).toBe("outlined");
+    emitter.finalize();
+    expect(emitter.state()).toBe("finalized");
+  });
+
+  it("records state transitions and redacts bounded arguments", async () => {
+    let state: DraftState = "empty";
+    const collector = new AgentTraceCollector();
+    const [wrapped] = collector.wrapTools(
+      [
+        tool("plan_outline", async () => {
+          state = "outlined";
+          return { content: [], details: { accepted: true } };
+        }),
+      ],
+      "run-1:attempt:1",
+      () => state,
+    );
+
+    await wrapped.execute("call-1", {
+      token: "secret-value",
+      prompt: "x".repeat(241),
+      values: Array.from({ length: 60 }, (_, index) => index),
+    } as never);
+
+    const [event] = collector.toolEvents;
+    expect(event.ok).toBe(true);
+    expect(event.state_before).toBe("empty");
+    expect(event.state_after).toBe("outlined");
+    expect(event.args).toMatchObject({
+      token: "[REDACTED]",
+      prompt: { length: 241 },
+    });
+    expect((event.args as { values: unknown[] }).values).toHaveLength(50);
+  });
+
+  it("treats a structured ok=false result as a failed tool event", async () => {
+    const collector = new AgentTraceCollector();
+    const [wrapped] = collector.wrapTools(
+      [
+        tool("runtime_tool_execute", async () => ({
+          content: [],
+          details: {
+            ok: false,
+            error: {
+              code: "runtime_tool.capability_denied",
+              token: "must-not-leak",
+            },
+          },
+        })),
+      ],
+      "run-1:attempt:1",
+      () => "empty",
+    );
+
+    await wrapped.execute("call-1", {} as never);
+
+    expect(collector.toolEvents[0]).toMatchObject({
+      ok: false,
+      tool: "runtime_tool_execute",
+    });
+    expect(collector.toolEvents[0].error).toContain(
+      "runtime_tool.capability_denied",
+    );
+    expect(collector.toolEvents[0].error).not.toContain("must-not-leak");
+  });
+
+  it("records thrown failures and rethrows the original error", async () => {
+    const collector = new AgentTraceCollector();
+    const failure = new Error("tool exploded");
+    const [wrapped] = collector.wrapTools(
+      [tool("broken", async () => { throw failure; })],
+      "run-1:attempt:1",
+      () => "draft_open",
+    );
+
+    await expect(wrapped.execute("call-1", {} as never)).rejects.toBe(failure);
+    expect(collector.toolEvents[0]).toMatchObject({
+      ok: false,
+      error: "tool exploded",
+      state_before: "draft_open",
+      state_after: "draft_open",
+    });
+  });
+
+  it("enforces the in-memory event cap and reports truncation", async () => {
+    const collector = new AgentTraceCollector(2, 8);
+    const [wrapped] = collector.wrapTools(
+      [tool("bounded", async () => ({ content: [], details: {} }))],
+      "run-1:attempt:1",
+      () => "empty",
+    );
+
+    await wrapped.execute("call-1", { index: 1 } as never);
+    await wrapped.execute("call-2", { index: 2 } as never);
+    await wrapped.execute("call-3", { index: 3 } as never);
+
+    expect(collector.toolEvents).toHaveLength(2);
+    expect(collector.runtimeEvents).toContainEqual(
+      expect.objectContaining({
+        event: "trace.tool_events_truncated",
+        detail: { dropped_count: 1 },
+      }),
+    );
+  });
+});

--- a/apps/agent/test/trace.test.ts
+++ b/apps/agent/test/trace.test.ts
@@ -128,6 +128,7 @@ describe("AgentTraceCollector", () => {
     await wrapped.execute("call-3", { index: 3 } as never);
 
     expect(collector.toolEvents).toHaveLength(2);
+    expect(collector.toolCallCount).toBe(3);
     expect(collector.runtimeEvents).toContainEqual(
       expect.objectContaining({
         event: "trace.tool_events_truncated",

--- a/apps/api/app/application/agent/types.py
+++ b/apps/api/app/application/agent/types.py
@@ -13,6 +13,7 @@ class AgentConstraints(BaseModel):
     max_reviewer_repair_attempts: int = 1
     legacy_single_enabled: bool = True
     executable_tools_available: bool = True
+    max_tool_events: int = Field(default=512, ge=32, le=2048)
 
 
 class ToolManifest(BaseModel):
@@ -27,11 +28,21 @@ class ToolEvent(BaseModel):
     tool: str
     ok: bool
     detail: dict[str, Any] | None = None
+    sequence: int | None = None
+    timestamp: str | None = None
+    attempt_id: str | None = None
+    duration_ms: int = 0
+    args: Any = None
+    error: str | None = None
+    state_before: str | None = None
+    state_after: str | None = None
 
 
 class RuntimeEvent(BaseModel):
     event: str
     detail: dict[str, Any] | None = None
+    sequence: int | None = None
+    timestamp: str | None = None
 
 
 class ToolExecutionResult(BaseModel):

--- a/apps/api/tests/test_agent_trace_types.py
+++ b/apps/api/tests/test_agent_trace_types.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.application.agent.types import (
+    AgentConstraints,
+    AgentResult,
+    RuntimeEvent,
+    ToolEvent,
+)
+
+
+def test_rich_trace_events_round_trip() -> None:
+    tool = ToolEvent(
+        sequence=1,
+        timestamp="2026-08-21T00:00:00.000Z",
+        tool="runtime_tool_execute",
+        attempt_id="run-1:attempt:1",
+        ok=False,
+        duration_ms=12,
+        args={"tool": "scene_blueprint.compile"},
+        error="runtime_tool.capability_denied",
+        state_before="outlined",
+        state_after="outlined",
+    )
+    runtime = RuntimeEvent(
+        sequence=2,
+        timestamp="2026-08-21T00:00:00.010Z",
+        event="sidecar.failed",
+        detail={"reason": "test"},
+    )
+
+    assert ToolEvent.model_validate(tool.model_dump()).model_dump() == tool.model_dump()
+    assert (
+        RuntimeEvent.model_validate(runtime.model_dump()).model_dump()
+        == runtime.model_dump()
+    )
+
+
+def test_agent_result_keeps_legacy_sparse_events_compatible() -> None:
+    result = AgentResult(
+        playbook={},
+        provider="pi",
+        tool_events=[{"tool": "runtime_tool_list", "ok": True}],
+        runtime_events=[{"event": "sidecar.completed"}],
+    )
+
+    assert result.tool_events == [{"tool": "runtime_tool_list", "ok": True}]
+    assert result.runtime_events == [{"event": "sidecar.completed"}]
+
+
+def test_max_tool_events_is_bounded() -> None:
+    assert AgentConstraints().max_tool_events == 512
+    with pytest.raises(ValidationError):
+        AgentConstraints(max_tool_events=31)
+    with pytest.raises(ValidationError):
+        AgentConstraints(max_tool_events=2049)


### PR DESCRIPTION
## Summary

Implements #256 as the first migration slice from #160 without applying PR #161 wholesale.

- adds bounded, redacted tool/runtime traces with lifecycle state transitions;
- records structured `ok=false` tool outcomes as failures, not only thrown exceptions;
- retains live traces for error and timeout responses;
- writes compact trace summaries to `playbook.initial_data`;
- uses timing-safe shared-token comparison and pre-wires the token on assert calls;
- treats blank optional provider env values as unset;
- enriches Agent trace types while keeping legacy sparse events compatible.

## Preserved invariants

- keeps the current SYSTEM_PROMPT and self-repair flow unchanged;
- keeps VisualKind, algorithm range/auxiliary types, PlaybookSkeleton.steps/step_frames, and wide string domains;
- keeps `timeout_ms` clamping and the structured `AgentSelfCheckError.self_check` response;
- does not enable request-scoped inventory or JSON Patch repair from #258/#259;
- sidecar auth remains fail-open when no token is configured.

## Trace bounds

- tool events: configurable through `constraints.max_tool_events`, default 512, valid range 32-2048;
- runtime events: capped at 256;
- arrays: first 50 items; objects: first 100 keys;
- sensitive keys are redacted;
- strings longer than 240 characters are replaced by SHA-256 + length;
- overflow emits a truncation marker.

## Validation

GitHub Actions Check run #474 passed in full:

- lint/type checks;
- API tests;
- Web mobile, player, and full test suites;
- Agent tests;
- MCP tests;
- Web and Agent builds;
- PR coverage and report upload.

Local pre-push checks also passed:

- TypeScript syntax checks for all changed TS files;
- Python `compileall` for changed Python files;
- invariant scan confirming the prompt, repair guidance, and timeout contract remain present.

Closes #256
Related: #160, #258, #259