### PR TITLE
fix(templates): 拖动滑杆不再把旁白拦腰掐断

### DIFF
--- a/apps/web/src/features/playbook/engine/player/useStaticNarration.test.tsx
+++ b/apps/web/src/features/playbook/engine/player/useStaticNarration.test.tsx
@@ -68,6 +68,40 @@ describe("useStaticNarration", () => {
     expect(result.current.speaking).toBe(false);
   });
 
+  it("lets a line finish when a parameter edit rebuilds the script under it", () => {
+    const { result } = renderHook(() => useStaticNarration(CASE));
+    act(() => result.current.playStep(FIRST.step_id, FIRST.text));
+    expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(1);
+    const pausesWhileStarting = vi.mocked(window.HTMLMediaElement.prototype.pause).mock
+      .calls.length;
+
+    // Every slider tick rebuilds the whole script and re-fires the narration
+    // effect. Same step: neither restart the sentence nor cut it off — the
+    // drag used to clip the line mid-word and leave the step silent.
+    act(() => result.current.playStep(FIRST.step_id, `${FIRST.text}（参数已改）`));
+    act(() => result.current.playStep(FIRST.step_id, FIRST.text));
+    expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(1);
+    expect(window.HTMLMediaElement.prototype.pause).toHaveBeenCalledTimes(
+      pausesWhileStarting,
+    );
+    expect(result.current.speaking).toBe(true);
+  });
+
+  it("still hands the next step its own line, or silence when that one drifted", () => {
+    const { result } = renderHook(() => useStaticNarration(CASE));
+    act(() => result.current.playStep(FIRST.step_id, FIRST.text));
+    expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(1);
+
+    // Moving on is a real step change: the previous line stops, and this one
+    // only speaks if the recording still matches what is on screen.
+    act(() => result.current.playStep(SECOND.step_id, `${SECOND.text}（参数已改）`));
+    expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(1);
+    expect(result.current.speaking).toBe(false);
+
+    act(() => result.current.playStep(SECOND.step_id, SECOND.text));
+    expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(2);
+  });
+
   it("mutes on request and remembers the choice", () => {
     const first = renderHook(() => useStaticNarration(CASE));
     act(() => first.result.current.toggle());

--- a/apps/web/src/features/playbook/engine/player/useStaticNarration.ts
+++ b/apps/web/src/features/playbook/engine/player/useStaticNarration.ts
@@ -76,6 +76,8 @@ export function useStaticNarration(caseId?: string): StaticNarrationChannel {
   );
   const [speaking, setSpeaking] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  /** Which step's line the element is currently carrying, playing or done. */
+  const playingStepRef = useRef<string | null>(null);
   const enabledRef = useRef(enabled);
   useLayoutEffect(() => {
     enabledRef.current = enabled;
@@ -108,6 +110,7 @@ export function useStaticNarration(caseId?: string): StaticNarrationChannel {
   }, [caseId]);
 
   const stop = useCallback(() => {
+    playingStepRef.current = null;
     const audio = audioRef.current;
     if (!audio) return;
     audio.pause();
@@ -119,6 +122,15 @@ export function useStaticNarration(caseId?: string): StaticNarrationChannel {
       if (!caseId || !enabledRef.current) return;
       const audio = audioRef.current;
       if (!audio) return;
+      if (playingStepRef.current === stepId) {
+        // A parameter edit rebuilds the whole script on every slider tick, and
+        // the narration effect re-fires with it. That is not a step change:
+        // restarting the line would stutter it, and cutting it off would clip
+        // a sentence mid-word — which is what dragging a slider used to do.
+        // The line the viewer is already hearing plays out; only the *next*
+        // step consults the recording again.
+        return;
+      }
       const entry = byStep.get(stepId);
       if (!entry || entry.text !== text.trim()) {
         // Either nothing was recorded for this step, or its line has been
@@ -129,6 +141,7 @@ export function useStaticNarration(caseId?: string): StaticNarrationChannel {
       audio.pause();
       audio.src = `${PUBLIC_DIR}/${caseId}/${entry.file}`;
       audio.currentTime = 0;
+      playingStepRef.current = stepId;
       setSpeaking(true);
       void audio.play().catch(() => {
         // Autoplay policies reject sound before the first gesture; the next


### PR DESCRIPTION
线上反馈：「可以，但调整参数后就没声音了。」

## 原因

参数每动一次，整份 `PlaybookScript` 就会重建，播放器的朗读 effect 也跟着重跑。上一版的 `useStaticNarration` 把每一次重跑都当成「换步骤」处理——先 `pause()`，再把 `src` 换掉、`currentTime = 0`、重新 `play()`。

浏览器实测（`logistic-growth` 第 3 步，拖一下 `r`）：

```
拖动前: play:logistic-s-curve.mp3@0.0
拖动后: pause:logistic-s-curve.mp3@3.3     ← 正念到 3.3 秒被掐断
```

而且这一步的文案本来就随 `r` 改写，按「文案漂移即静音」的规则，之后也不会再出声——从使用者角度看就是「一动参数，声音没了」。

## 修法

改为按**步骤**判断，而不是按脚本对象判断：

- 同一步内重入：既不重播、也不打断，正在听的那句念完；
- 真正切到下一步：停掉上一句，再按录音与当前文案是否一致，决定播放或静音。

参数改写的那一两步仍然静音——念屏幕上已经不存在的数字比不念更糟——但不再殃及正在播放的句子。实测各案例受影响的步骤是 1–3 步（`island-biogeography` 拖物种池 `P` 最多 6 步），并非整讲失声。

## 验证

- 浏览器连拖五次滑杆：`logistic-s-curve.mp3` 仍在播放（8.1/23.1 秒），全程无 `pause`、无重播。
- 前端 1343 项测试全绿，含两条新增回归测试：同一步重入不重播不打断、换步骤仍各按各的文案决定播或静音。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDPoKGH8Q4KKCz99EmACac)_