### PR TITLE
feat(templates): 改参数之后旁白继续说，不再整段哑掉

### DIFF
--- a/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
+++ b/apps/web/src/features/playbook/engine/player/PlaybookPlayer.tsx
@@ -425,7 +425,7 @@ export const PlaybookPlayer: React.FC<PlaybookPlayerProps> = ({
     const step = script.steps[safeStepIndex];
     if (!step) return;
     if (!enableTTS) {
-      recordedRef.current.playStep(step.step_id, step.voiceover_text);
+      recordedRef.current.playStep(step.step_id);
       return;
     }
     if (!ttsRef.current.enabled) return;

--- a/apps/web/src/features/playbook/engine/player/useStaticNarration.test.tsx
+++ b/apps/web/src/features/playbook/engine/player/useStaticNarration.test.tsx
@@ -43,7 +43,7 @@ describe("useStaticNarration", () => {
     const { result } = renderHook(() => useStaticNarration("derivative-tangent"));
     expect(result.current.available).toBe(false);
     expect(result.current.supported).toBe(false);
-    act(() => result.current.playStep("anything", "任何文案"));
+    act(() => result.current.playStep("anything"));
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(window.HTMLMediaElement.prototype.play).not.toHaveBeenCalled();
     vi.unstubAllGlobals();
@@ -54,32 +54,23 @@ describe("useStaticNarration", () => {
     expect(result.current.available).toBe(true);
     expect(result.current.enabled).toBe(true);
 
-    act(() => result.current.playStep(FIRST.step_id, FIRST.text));
+    act(() => result.current.playStep(FIRST.step_id));
     expect(result.current.speaking).toBe(true);
     expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled();
   });
 
-  it("stays silent when a parameter edit has rewritten the step's line", () => {
-    const { result } = renderHook(() => useStaticNarration(CASE));
-    // The slider moved: the live sentence now quotes numbers the recording
-    // knows nothing about.
-    act(() => result.current.playStep(SECOND.step_id, `${SECOND.text}（参数已改）`));
-    expect(window.HTMLMediaElement.prototype.play).not.toHaveBeenCalled();
-    expect(result.current.speaking).toBe(false);
-  });
-
   it("lets a line finish when a parameter edit rebuilds the script under it", () => {
     const { result } = renderHook(() => useStaticNarration(CASE));
-    act(() => result.current.playStep(FIRST.step_id, FIRST.text));
+    act(() => result.current.playStep(FIRST.step_id));
     expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(1);
     const pausesWhileStarting = vi.mocked(window.HTMLMediaElement.prototype.pause).mock
       .calls.length;
 
     // Every slider tick rebuilds the whole script and re-fires the narration
-    // effect. Same step: neither restart the sentence nor cut it off — the
-    // drag used to clip the line mid-word and leave the step silent.
-    act(() => result.current.playStep(FIRST.step_id, `${FIRST.text}（参数已改）`));
-    act(() => result.current.playStep(FIRST.step_id, FIRST.text));
+    // effect. Same step: neither restart the sentence nor cut it off — dragging
+    // a slider used to clip the line mid-word and leave the step silent.
+    act(() => result.current.playStep(FIRST.step_id));
+    act(() => result.current.playStep(FIRST.step_id));
     expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(1);
     expect(window.HTMLMediaElement.prototype.pause).toHaveBeenCalledTimes(
       pausesWhileStarting,
@@ -87,26 +78,19 @@ describe("useStaticNarration", () => {
     expect(result.current.speaking).toBe(true);
   });
 
-  it("still hands the next step its own line, or silence when that one drifted", () => {
+  it("stops the old line and starts the new one on a real step change", () => {
     const { result } = renderHook(() => useStaticNarration(CASE));
-    act(() => result.current.playStep(FIRST.step_id, FIRST.text));
-    expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(1);
-
-    // Moving on is a real step change: the previous line stops, and this one
-    // only speaks if the recording still matches what is on screen.
-    act(() => result.current.playStep(SECOND.step_id, `${SECOND.text}（参数已改）`));
-    expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(1);
-    expect(result.current.speaking).toBe(false);
-
-    act(() => result.current.playStep(SECOND.step_id, SECOND.text));
+    act(() => result.current.playStep(FIRST.step_id));
+    act(() => result.current.playStep(SECOND.step_id));
     expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(2);
+    expect(result.current.speaking).toBe(true);
   });
 
   it("mutes on request and remembers the choice", () => {
     const first = renderHook(() => useStaticNarration(CASE));
     act(() => first.result.current.toggle());
     expect(first.result.current.enabled).toBe(false);
-    act(() => first.result.current.playStep(FIRST.step_id, FIRST.text));
+    act(() => first.result.current.playStep(FIRST.step_id));
     expect(window.HTMLMediaElement.prototype.play).not.toHaveBeenCalled();
     first.unmount();
 
@@ -119,7 +103,7 @@ describe("useStaticNarration", () => {
       new DOMException("blocked", "NotAllowedError"),
     );
     const { result } = renderHook(() => useStaticNarration(CASE));
-    act(() => result.current.playStep(FIRST.step_id, FIRST.text));
+    act(() => result.current.playStep(FIRST.step_id));
     await act(async () => {});
     expect(result.current.speaking).toBe(false);
   });

--- a/apps/web/src/features/playbook/engine/player/useStaticNarration.ts
+++ b/apps/web/src/features/playbook/engine/player/useStaticNarration.ts
@@ -17,9 +17,12 @@ import {
  * without costing anything per view.
  *
  * Narration is parameter-dependent: dragging a slider rewrites the wording of
- * the steps it affects. Each entry therefore carries the exact text it was
- * recorded from, and a step whose live text has drifted stays silent — a
- * sentence quoting numbers that are no longer on screen is worse than none.
+ * the steps it affects, and a fixed recording cannot follow it. The lesson
+ * keeps speaking anyway — a voice that stops the moment a student touches a
+ * slider reads as broken, and the recomputed numbers stay right there in the
+ * subtitle and on the canvas. The cost is that those few steps narrate the
+ * values they were recorded at; recordedNarration.test.ts keeps the recordings
+ * honest for the defaults, which is the state every visitor arrives in.
  */
 
 export interface StaticNarrationChannel {
@@ -29,8 +32,8 @@ export interface StaticNarrationChannel {
   enabled: boolean;
   speaking: boolean;
   toggle: () => void;
-  /** Play a step's recorded line, or stay silent if its text has drifted. */
-  playStep: (stepId: string, text: string) => void;
+  /** Play this step's recorded line, if one was recorded for it. */
+  playStep: (stepId: string) => void;
   stop: () => void;
 }
 
@@ -118,7 +121,7 @@ export function useStaticNarration(caseId?: string): StaticNarrationChannel {
   }, []);
 
   const playStep = useCallback(
-    (stepId: string, text: string) => {
+    (stepId: string) => {
       if (!caseId || !enabledRef.current) return;
       const audio = audioRef.current;
       if (!audio) return;
@@ -132,9 +135,7 @@ export function useStaticNarration(caseId?: string): StaticNarrationChannel {
         return;
       }
       const entry = byStep.get(stepId);
-      if (!entry || entry.text !== text.trim()) {
-        // Either nothing was recorded for this step, or its line has been
-        // rewritten since. Silence beats a stale reading.
+      if (!entry) {
         stop();
         return;
       }

--- a/apps/web/src/pages/Templates/narration/recordedNarration.test.ts
+++ b/apps/web/src/pages/Templates/narration/recordedNarration.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { RECORDED_NARRATION, RECORDED_NARRATION_VOICE } from "./recordedNarration";
+import { PUBLIC_GOLD_TEMPLATES } from "../gold-templates/publicGoldTemplates";
+
+/**
+ * The recordings are made from the default-parameter playbook and then played
+ * back verbatim, so a narration edit that lands without re-running
+ * `apps/api/scripts/generate_template_narration.py` would have every visitor
+ * hearing the old sentence under the new subtitle. Nothing at runtime can
+ * catch that — the drift check lives here instead.
+ */
+describe("recorded template narration", () => {
+  it("matches, line for line, the narration each case ships at its defaults", () => {
+    for (const [caseId, entries] of Object.entries(RECORDED_NARRATION)) {
+      const manifest = PUBLIC_GOLD_TEMPLATES.find((item) => item.caseId === caseId);
+      expect(manifest, `no public case named ${caseId}`).toBeDefined();
+      const script = manifest!.buildPublicPlaybook(manifest!.parameterSchema?.defaults ?? {});
+      const spoken = script.steps.filter((step) => step.voiceover_text.trim());
+
+      expect(entries.map((entry) => entry.step_id)).toEqual(
+        spoken.map((step) => step.step_id),
+      );
+      for (const [index, entry] of entries.entries()) {
+        expect(
+          entry.text,
+          `${caseId}/${entry.step_id} 的录音与当前旁白不符 — 重新运行 `
+            + "apps/api/scripts/generate_template_narration.py",
+        ).toBe(spoken[index].voiceover_text.trim());
+      }
+    }
+  });
+
+  it("names the voice it was recorded with, and files every line by step id", () => {
+    expect(RECORDED_NARRATION_VOICE).toBeTruthy();
+    for (const [caseId, entries] of Object.entries(RECORDED_NARRATION)) {
+      expect(entries.length, caseId).toBeGreaterThan(0);
+      for (const entry of entries) {
+        expect(entry.file).toBe(`${entry.step_id}.mp3`);
+      }
+    }
+  });
+});

--- a/docs/template-previews.md
+++ b/docs/template-previews.md
@@ -28,9 +28,11 @@ Status: Active
 
 静态模板播放器不接 TTS 代理入口，避免继承浏览器里曾保存的远程 TTS 配置并意外请求服务端；Studio 和运营版 BYOK 的既有语音/模型配置不受影响。
 
-旁白改为**预先录好、随前端发布的静态音频**：`apps/api/scripts/generate_template_narration.py` 用与导出视频同一套 `METAVIEW_TTS_*` 配置，把每一步旁白合成到 `apps/web/public/template-narration/<caseId>/<stepId>.mp3`（32 kbps 单声道，按步懒加载），同目录 `manifest.json` 记录每段录制时的原文。播放器侧由 `useStaticNarration` 播放，并与既有「等旁白说完再翻页」的闸门共用同一契约。访客打开模板页即可听到讲解：无需登录、不发 API 请求、不扣减额度——静态运行边界不变（音频与海报一样是静态资源）。
+旁白改为**预先录好、随前端发布的静态音频**：`apps/api/scripts/generate_template_narration.py` 用与导出视频同一套 `METAVIEW_TTS_*` 配置，把每一步旁白合成到 `apps/web/public/template-narration/<caseId>/<stepId>.mp3`（32 kbps 单声道，按步懒加载），并把录音清单生成为 TS 源码 `src/pages/Templates/narration/recordedNarration.ts`——随包发布而非线上拉取，模板页因此仍是零 fetch。播放器侧由 `useStaticNarration` 播放，并与既有「等旁白说完再翻页」的闸门共用同一契约。访客打开模板页即可听到讲解：无需登录、不发 API 请求、不扣减额度——静态运行边界不变（音频与海报一样是静态资源）。
 
-旁白文案随参数实时重算，所以每段录音只对录制时的文案成立：某一步的当前文案与 manifest 记录不一致时（例如拖动了影响该步的滑杆），该步静音，其余步骤照常朗读。改动旁白后需重新运行上述脚本；未生成音频的案例自动保持无声。
+旁白文案随参数实时重算，而录音是固定的，两者只在默认参数下完全一致。取舍是**声音优先**：任何一步都照常播放它的录音，学生拖动滑杆后那一两步会念着录制时的数字（重算后的数字仍显示在字幕和画面上）——旁白一碰滑杆就消失，用起来像坏了。同一步内重入既不重播也不打断，只有真正切换步骤才停旧句、播新句。
+
+录音与默认文案是否一致由 `recordedNarration.test.ts` 在开发期守住：改了旁白却没重新运行生成脚本，测试会直接失败并指出是哪一步。未生成音频的案例自动保持无声。
 
 ## 正式案例
 


### PR DESCRIPTION
线上反馈：「不是，是修改了参数以后所有的声音都没了，切换下一步也没声音。」

## 两层原因

**一、正在念的那句被打断**（[#277](https://github.com/jry21223/MetaView/pull/277) 已修）：参数每动一次脚本就重建，播放器把它当成了换步骤，先 `pause()` 再从头 `play()`。浏览器实测抓到 `pause:logistic-s-curve.mp3@3.3`——念到 3.3 秒被切断。

**二、连续几步静音**（本 PR）：录音是固定的，文案里的数字实时重算，我原先让「文案与录音对不上」的步骤静音。但一次滑杆往往连着影响两三步：

| 案例 | 滑杆 | 受影响步数 |
|---|---|---|
| `logistic-growth` | `r` / `K` | 3/8 |
| `predator-prey` | `r` | 3/9 |
| `island-biogeography` | `P` | **6/9** |

连着几步没声，用起来就是「声音全没了」——这个判断是对的。

## 取舍：声音优先

每一步都照常播它的录音。拖完滑杆的那几步会念着录制时的数字，而**重算后的数字仍然显示在字幕和画面上**。旁白一碰滑杆就消失，比数字对不上更像坏了。

漂移检查移到开发期：新增 `recordedNarration.test.ts` 逐字核对每段录音与该案例默认参数下的文案，改了旁白却没重新运行 `generate_template_narration.py` 会直接失败并指出是哪一步——每位访客到达时都是默认参数，那个状态必须准确。

同一步内重入仍然既不重播也不打断，只有真正切换步骤才停旧句、播新句。

## 验证

浏览器里在第 3 步把 `r` 拖到 0.7，再连走五步：

```
拖动时:   []                                   ← 正在播的那句不受影响
之后五步: play:logistic-inflection.mp3          ← 原先静音
         play:logistic-harvest.mp3
         play:logistic-msy.mp3                 ← 原先静音
         play:logistic-st-matthew.mp3
         play:logistic-skeleton.mp3
```

前端 1344 项测试全绿（含新增的录音一致性守卫与两条播放行为回归测试）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDPoKGH8Q4KKCz99EmACac)_