### PR TITLE
test(eval): 多学科端到端跑通渲染 Pipeline，并记录 5 处缺陷

### DIFF
--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -130,6 +130,15 @@ Workflow you MUST follow:
    学到了什么". Finish with \`finalize_playbook\`; after that, do not call any
    more tools.
 
+Expression grammar (every \`expression*\` argument, in drawing, animation, and
+assert tools alike):
+- Powers use \`^\`, NEVER Python's \`**\` (write \`x^2\`, not \`x**2\`).
+- Function names are plain, with no LaTeX backslashes: \`sin(x)\`, \`cos(t)\`,
+  \`exp(x)\`, \`log(x)\`, \`sqrt(x)\`, \`abs(x)\` — never \`\\sin(x)\`.
+- Multiplication is explicit (\`2*x\`, \`a*sin(x)\`); constants \`pi\` and \`e\`
+  are available. LaTeX belongs ONLY in \`formula_latex\` / \`add_formula\`
+  arguments, never in an expression.
+
 Output discipline:
 - Use the most specific tool available; do not try to write CIR JSON directly.
 - For subject visual scenes, use SceneBlueprint/SkillPack-backed renderer

--- a/apps/agent/src/tools/drawing.ts
+++ b/apps/agent/src/tools/drawing.ts
@@ -117,8 +117,9 @@ export function makeDrawingTools(deps: DrawingToolDeps): AgentTool[] {
       "add_curve_parametric",
       "Add parametric curve",
       "Add a parametric curve ``(x(t), y(t))`` over ``[t_min, t_max]``. " +
-        "Expressions use the same character set MathPlotRenderer accepts " +
-        "(sin/cos/exp/log + parameters).",
+        "Expression grammar: '^' for powers (never '**'), plain function " +
+        "names like sin(t), cos(t), sqrt(t) (no LaTeX backslashes), explicit " +
+        "multiplication (2*t), constants pi and e.",
       Type.Object({
         expression_x: Type.String({ minLength: 1 }),
         expression_y: Type.String({ minLength: 1 }),
@@ -147,7 +148,9 @@ export function makeDrawingTools(deps: DrawingToolDeps): AgentTool[] {
       "Add 1D curve",
       "Add a 1-D function y=f(x). Use this for typical math function plots, " +
         "tangent lines, derivative comparisons, integrals (with shade_from/to " +
-        "set elsewhere).",
+        "set elsewhere). Expression grammar: '^' for powers (never '**'), " +
+        "plain function names like sin(x) (no LaTeX backslashes), explicit " +
+        "multiplication (2*x).",
       Type.Object({
         expression: Type.String({ minLength: 1 }),
         label: Type.String(),

--- a/apps/api/app/application/agent/runtime_tool_hub.py
+++ b/apps/api/app/application/agent/runtime_tool_hub.py
@@ -30,36 +30,53 @@ from app.domain.skills.registry import SkillRegistry, build_default_skill_regist
 ArgModelT = TypeVar("ArgModelT", bound=BaseModel)
 
 ASSET_MANIFEST_ROOT = (
-    Path(__file__).resolve().parents[5]
-    / "apps"
-    / "web"
-    / "public"
-    / "assets"
-    / "metaview-kits"
+    Path(__file__).resolve().parents[5] / "apps" / "web" / "public" / "assets" / "metaview-kits"
+)
+
+
+_PARAM_EXPR_DOC = (
+    "Renderer-grammar expression in t: '^' for powers (not '**'), plain "
+    "function names like sin(t), no LaTeX backslashes."
 )
 
 
 class _OrientationArgs(BaseModel):
-    expression_x: StrictStr = Field(min_length=1)
-    expression_y: StrictStr = Field(min_length=1)
-    t_min: FiniteFloat
-    t_max: FiniteFloat
+    expression_x: StrictStr = Field(
+        min_length=1, description=f"x(t) of the parametric curve. {_PARAM_EXPR_DOC}"
+    )
+    expression_y: StrictStr = Field(
+        min_length=1, description="y(t) of the parametric curve, same grammar."
+    )
+    t_min: FiniteFloat = Field(description="Start of the parameter interval.")
+    t_max: FiniteFloat = Field(description="End of the parameter interval.")
 
 
 class _PassesThroughArgs(BaseModel):
-    expression_x: StrictStr = Field(min_length=1)
-    expression_y: StrictStr = Field(min_length=1)
-    t_min: FiniteFloat
-    t_max: FiniteFloat
-    target_x: FiniteFloat
-    target_y: FiniteFloat
-    tol: FiniteFloat = 1e-2
+    expression_x: StrictStr = Field(
+        min_length=1, description=f"x(t) of the parametric curve. {_PARAM_EXPR_DOC}"
+    )
+    expression_y: StrictStr = Field(
+        min_length=1, description="y(t) of the parametric curve, same grammar."
+    )
+    t_min: FiniteFloat = Field(description="Start of the parameter interval.")
+    t_max: FiniteFloat = Field(description="End of the parameter interval.")
+    target_x: FiniteFloat = Field(description="x coordinate the curve should pass through.")
+    target_y: FiniteFloat = Field(description="y coordinate the curve should pass through.")
+    tol: FiniteFloat = Field(
+        default=1e-2, description="Distance tolerance for the pass-through check."
+    )
 
 
 class _MonotonicArgs(BaseModel):
-    expression: StrictStr = Field(min_length=1)
-    x_min: FiniteFloat
-    x_max: FiniteFloat
+    expression: StrictStr = Field(
+        min_length=1,
+        description=(
+            "Function of x in renderer grammar: '^' for powers (not '**'), "
+            "no LaTeX backslashes."
+        ),
+    )
+    x_min: FiniteFloat = Field(description="Left end of the interval to check.")
+    x_max: FiniteFloat = Field(description="Right end of the interval to check.")
 
 
 class RuntimeToolHub:
@@ -103,8 +120,7 @@ class RuntimeToolHub:
             ToolManifest(
                 name="scene_blueprint.compile",
                 description=(
-                    "Compile a controlled SceneBlueprint into a renderer-ready "
-                    "PlaybookScript."
+                    "Compile a controlled SceneBlueprint into a renderer-ready PlaybookScript."
                 ),
                 args_schema={
                     "type": "object",
@@ -171,7 +187,7 @@ class RuntimeToolHub:
                         "source_code": {"type": ["string", "null"]},
                         "language": {"type": ["string", "null"]},
                         "route_match": {"type": "object"},
-                        "problem_spec": {"type": "object"},
+                        "problem_spec": self._problem_spec_schema(manifest.skill_id),
                     },
                     "required": ["run_id", "prompt"],
                 },
@@ -188,14 +204,25 @@ class RuntimeToolHub:
     def get_tool(self, name: str) -> ToolManifest | None:
         return next((tool for tool in self.list_tools() if tool.name == name), None)
 
+    def _problem_spec_schema(self, skill_id: str) -> dict[str, Any]:
+        """Advertise the pack's real ProblemSpec schema instead of a bare object."""
+        skill = self._skill_registry.get(skill_id)
+        model = getattr(skill, "problem_spec_model", None)
+        if model is None or not (isinstance(model, type) and issubclass(model, BaseModel)):
+            return {"type": "object"}
+        return model.model_json_schema()
+
     async def execute_tool(self, name: str, args: dict[str, Any]) -> ToolExecutionResult:
         if name == "skill.registry.list":
-            return self._ok(name, {
-                "skills": [
-                    manifest.model_dump(mode="json")
-                    for manifest in self._skill_registry.manifests()
-                ]
-            })
+            return self._ok(
+                name,
+                {
+                    "skills": [
+                        manifest.model_dump(mode="json")
+                        for manifest in self._skill_registry.manifests()
+                    ]
+                },
+            )
         if name.startswith("skill.") and name.endswith(".solve"):
             return await self._execute_skill_tool(name, args)
         if name == "playbook.schema.validate":
@@ -205,9 +232,9 @@ class RuntimeToolHub:
         if name == "scene_blueprint.compile":
             return self._compile_scene_blueprint(name, args)
         if name == "animation_tool.list":
-            return self._ok(name, {
-                "tools": [tool.model_dump(mode="json") for tool in list_animation_tools()]
-            })
+            return self._ok(
+                name, {"tools": [tool.model_dump(mode="json") for tool in list_animation_tools()]}
+            )
         if name == "animation_tool.expand":
             result = safe_expand_animation_call(
                 str(args.get("tool", "")),
@@ -253,7 +280,10 @@ class RuntimeToolHub:
         return self._error(
             name,
             "runtime_tool.unknown_tool",
-            f"Unknown runtime tool: {name}",
+            (
+                f"Unknown runtime tool: {name}. Available tools: "
+                f"{', '.join(tool.name for tool in self.list_tools())}"
+            ),
         )
 
     async def _execute_skill_tool(
@@ -264,16 +294,22 @@ class RuntimeToolHub:
         skill_id = name.removeprefix("skill.").removesuffix(".solve")
         skill = self._skill_registry.get(skill_id)
         if skill is None:
+            available = ", ".join(
+                f"skill.{manifest.skill_id}.solve"
+                for manifest in self._skill_registry.manifests()
+            )
             return self._error(
                 name,
                 "runtime_tool.unknown_tool",
-                f"Unknown SkillPack runtime tool: {name}",
+                f"Unknown SkillPack runtime tool: {name}. Available: {available}",
             )
         prompt = str(args.get("prompt", ""))
         route_match = self._coerce_route_match(skill_id, args)
         problem_spec = None
+        provided_spec_invalid = False
         if isinstance(args.get("problem_spec"), dict):
             problem_spec = skill.validate_problem_spec(args["problem_spec"])
+            provided_spec_invalid = problem_spec is None
         if problem_spec is None and route_match.problem_spec:
             problem_spec = skill.validate_problem_spec(route_match.problem_spec)
         if problem_spec is None:
@@ -297,6 +333,22 @@ class RuntimeToolHub:
             problem_spec,
         )
         payload = result.model_dump(mode="json")
+        if not result.handled:
+            if provided_spec_invalid and problem_spec is None:
+                spec_model = getattr(skill, "problem_spec_model", None)
+                expected = spec_model.__name__ if isinstance(spec_model, type) else "problem_spec"
+                payload["fallback_reason"] = "invalid_problem_spec"
+                payload["message"] = (
+                    f"The provided problem_spec did not validate against {expected}; "
+                    f"check the {name} args_schema for the expected fields, or omit "
+                    "problem_spec and pass a prompt the skill can extract from."
+                )
+            else:
+                payload["message"] = (
+                    f"{name} declined this request "
+                    f"(fallback_reason={payload.get('fallback_reason')}): the prompt or "
+                    "problem_spec did not match a supported capability of this skill."
+                )
         if result.playbook_json:
             try:
                 payload["playbook"] = PlaybookScript.model_validate_json(

--- a/apps/api/app/domain/animation_tools/algorithm_tools.py
+++ b/apps/api/app/domain/animation_tools/algorithm_tools.py
@@ -10,20 +10,40 @@ from app.domain.models.playbook import GraphSceneEdge, GraphSceneNode, GraphScen
 
 
 class GraphTraversalEdgeArgs(BaseModel):
-    source: str = Field(min_length=1)
-    target: str = Field(min_length=1)
-    label: str | None = None
-    weight: float | None = None
+    source: str = Field(
+        min_length=1, description="Node id the edge starts from; must appear in `nodes`."
+    )
+    target: str = Field(
+        min_length=1, description="Node id the edge points to; must appear in `nodes`."
+    )
+    label: str | None = Field(
+        default=None, description="Optional edge label drawn at the midpoint."
+    )
+    weight: float | None = Field(
+        default=None, description="Optional edge weight, shown when `weighted` is true."
+    )
 
 
 class AlgorithmGraphTraversalArgs(BaseModel):
-    nodes: list[str] = Field(min_length=1)
-    edges: list[GraphTraversalEdgeArgs] = Field(default_factory=list)
-    active_node_ids: list[str] = Field(default_factory=list)
-    active_edge_ids: list[str] = Field(default_factory=list)
-    directed: bool = False
-    weighted: bool = False
-    caption: str | None = None
+    nodes: list[str] = Field(
+        min_length=1, description="Node ids; each is also used as its display label."
+    )
+    edges: list[GraphTraversalEdgeArgs] = Field(
+        default_factory=list, description="Edges between the declared nodes."
+    )
+    active_node_ids: list[str] = Field(
+        default_factory=list,
+        description="Node ids highlighted as the traversal's current frontier for this step.",
+    )
+    active_edge_ids: list[str] = Field(
+        default_factory=list,
+        description='Edge ids highlighted this step, written as "source->target".',
+    )
+    directed: bool = Field(default=False, description="Draw arrowheads and treat edges as one-way.")
+    weighted: bool = Field(default=False, description="Show edge weights next to edges.")
+    caption: str | None = Field(
+        default=None, description="Optional one-sentence caption rendered as a narration card."
+    )
 
 
 @register("algorithm.graph_traversal", AlgorithmGraphTraversalArgs)

--- a/apps/api/app/domain/animation_tools/biology_tools.py
+++ b/apps/api/app/domain/animation_tools/biology_tools.py
@@ -10,11 +10,35 @@ from app.domain.models.playbook import ChartSeries, StatsChartSceneSnapshot, Tab
 
 
 class BiologyPunnettSquareArgs(BaseModel):
-    parent_a: str = Field(min_length=1)
-    parent_b: str = Field(min_length=1)
-    alleles: list[str] = Field(min_length=1)
-    cells: list[list[str]] = Field(min_length=1)
-    phenotype_counts: dict[str, float] = Field(default_factory=dict)
+    parent_a: str = Field(
+        min_length=1,
+        description="Genotype of the first parent, e.g. 'Aa'; shown as the column-side parent.",
+    )
+    parent_b: str = Field(
+        min_length=1,
+        description="Genotype of the second parent, e.g. 'Aa'; shown as the row-side parent.",
+    )
+    alleles: list[str] = Field(
+        min_length=1,
+        description=(
+            "Gamete labels, e.g. ['A', 'a']. They become the column headers "
+            "and, in order, the row headers."
+        ),
+    )
+    cells: list[list[str]] = Field(
+        min_length=1,
+        description=(
+            "Offspring genotypes as a grid: cells[i][j] is row-gamete i crossed "
+            "with column-gamete j, so the grid is len(alleles) x len(alleles)."
+        ),
+    )
+    phenotype_counts: dict[str, float] = Field(
+        default_factory=dict,
+        description=(
+            "Optional phenotype -> count (or probability) mapping charted "
+            "next to the square."
+        ),
+    )
 
 
 @register("biology.punnett_square", BiologyPunnettSquareArgs)

--- a/apps/api/app/domain/animation_tools/biology_tools.py
+++ b/apps/api/app/domain/animation_tools/biology_tools.py
@@ -64,6 +64,7 @@ def punnett_square(args: dict) -> list[LayerSpec]:
         ],
         x_label="phenotype",
         y_label="count",
+        categories=list(parsed.phenotype_counts.keys()),
         caption="Phenotype count distribution",
     )
     return [

--- a/apps/api/app/domain/animation_tools/chemistry_tools.py
+++ b/apps/api/app/domain/animation_tools/chemistry_tools.py
@@ -16,17 +16,32 @@ from app.domain.models.playbook import TableSceneSnapshot
 
 
 class StoichiometryRowArgs(BaseModel):
-    species: str = Field(min_length=1)
-    coefficient: int = Field(ge=1)
-    mol: float | None = Field(default=None, ge=0)
-    mass: float | None = Field(default=None, ge=0)
-    role: str = Field(min_length=1)
+    species: str = Field(min_length=1, description="Chemical formula of the species, e.g. 'Fe2O3'.")
+    coefficient: int = Field(ge=1, description="Balanced-equation coefficient for this species.")
+    mol: float | None = Field(
+        default=None, ge=0, description="Optional amount of substance in mol."
+    )
+    mass: float | None = Field(default=None, ge=0, description="Optional mass in grams.")
+    role: str = Field(
+        min_length=1,
+        description=(
+            "Free-text role shown in the table, e.g. 'reactant', 'product', "
+            "or 'limiting reactant'."
+        ),
+    )
 
 
 class ChemistryStoichiometryTableArgs(BaseModel):
-    rows: list[StoichiometryRowArgs] = Field(min_length=1)
-    equation_latex: str = Field(min_length=1)
-    caption: str | None = None
+    rows: list[StoichiometryRowArgs] = Field(
+        min_length=1, description="One row per species in the balanced reaction."
+    )
+    equation_latex: str = Field(
+        min_length=1,
+        description="Balanced equation as KaTeX, e.g. '4Fe + 3O_2 \\\\rightarrow 2Fe_2O_3'.",
+    )
+    caption: str | None = Field(
+        default=None, description="Optional one-sentence caption rendered as a narration card."
+    )
 
 
 @register("chemistry.stoichiometry_table", ChemistryStoichiometryTableArgs)

--- a/apps/api/app/domain/animation_tools/math_tools.py
+++ b/apps/api/app/domain/animation_tools/math_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import AliasChoices, BaseModel, Field
 
-from app.domain.animation_tools.registry import register
+from app.domain.animation_tools.registry import EXPRESSION_GRAMMAR_HINT, register
 from app.domain.models.cir import (
     KaTeXOverlaySpec,
     LayerKind,
@@ -18,82 +18,175 @@ from app.domain.models.cir import (
     SceneSegment,
     SceneSpec,
 )
+from app.domain.skills.algebra_core import parse_expression
+from app.domain.skills.algebra_core.parser import expression_to_source
+
+_EXPR_DOC = f"Function of x in renderer grammar. {EXPRESSION_GRAMMAR_HINT}"
+_LATEX_DOC = "Optional KaTeX string shown as a formula overlay (LaTeX allowed here only)."
+_CAPTION_DOC = "Optional one-sentence caption rendered as a narration card."
 
 
 class _PlotBounds(BaseModel):
-    x_min: float = -6.0
-    x_max: float = 6.0
-    y_min: float | None = None
-    y_max: float | None = None
+    x_min: float = Field(default=-6.0, description="Left edge of the visible x range.")
+    x_max: float = Field(default=6.0, description="Right edge of the visible x range.")
+    y_min: float | None = Field(
+        default=None, description="Optional fixed lower y bound (auto when null)."
+    )
+    y_max: float | None = Field(
+        default=None, description="Optional fixed upper y bound (auto when null)."
+    )
 
 
 class MathShowTangentArgs(_PlotBounds):
-    expression: str = Field(min_length=1)
-    x0: float
-    tangent_expression: str = Field(min_length=1)
-    formula_latex: str | None = None
-    caption: str | None = None
+    expression: str = Field(min_length=1, description=_EXPR_DOC)
+    x0: float = Field(description="x value of the tangent point; also drawn as marker_x.")
+    tangent_expression: str | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Optional explicit tangent line as a function of x. Omit it and the "
+            "backend derives the true tangent of `expression` at `x0` symbolically; "
+            "if you do pass it, you are responsible for its correctness."
+        ),
+    )
+    formula_latex: str | None = Field(default=None, description=_LATEX_DOC)
+    caption: str | None = Field(default=None, description=_CAPTION_DOC)
 
 
 class MathShowFunctionArgs(_PlotBounds):
-    expression: str = Field(min_length=1)
-    expression_2: str | None = None
-    formula_latex: str | None = None
-    marker_x: float | None = None
-    shade_from: float | None = None
-    shade_to: float | None = None
+    expression: str = Field(min_length=1, description=_EXPR_DOC)
+    expression_2: str | None = Field(
+        default=None,
+        description=f"Optional second curve g(x) for comparison. {EXPRESSION_GRAMMAR_HINT}",
+    )
+    formula_latex: str | None = Field(default=None, description=_LATEX_DOC)
+    marker_x: float | None = Field(
+        default=None, description="Optional x position highlighted with a marker dot."
+    )
+    shade_from: float | None = Field(
+        default=None, description="Optional left x bound of a shaded interval under the curve."
+    )
+    shade_to: float | None = Field(
+        default=None, description="Optional right x bound of the shaded interval."
+    )
 
 
 class MathShowIntegralAreaArgs(_PlotBounds):
-    expression: str = Field(min_length=1)
-    from_: float = Field(validation_alias=AliasChoices("from_", "from"))
-    to: float
-    formula_latex: str | None = None
+    expression: str = Field(min_length=1, description=_EXPR_DOC)
+    from_: float = Field(
+        validation_alias=AliasChoices("from_", "from"),
+        description="Lower integration bound (JSON key: `from` or `from_`).",
+    )
+    to: float = Field(description="Upper integration bound.")
+    formula_latex: str | None = Field(default=None, description=_LATEX_DOC)
 
 
 class MathShowDerivativeCompareArgs(_PlotBounds):
-    expression: str = Field(min_length=1)
-    derivative_expression: str = Field(min_length=1)
-    formula_latex: str | None = None
-    caption: str | None = None
+    expression: str = Field(min_length=1, description=_EXPR_DOC)
+    derivative_expression: str | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Optional explicit derivative f'(x). Omit it and the backend "
+            "differentiates `expression` symbolically; if you do pass it, you "
+            "are responsible for its correctness."
+        ),
+    )
+    formula_latex: str | None = Field(default=None, description=_LATEX_DOC)
+    caption: str | None = Field(default=None, description=_CAPTION_DOC)
 
 
 class MathShowFunctionTransformArgs(_PlotBounds):
-    base_expression: str = Field(min_length=1)
-    transformed_expression: str = Field(min_length=1)
-    base_label: str = "f(x)"
-    transformed_label: str = "g(x)"
-    formula_latex: str | None = None
-    caption: str | None = None
+    base_expression: str = Field(
+        min_length=1, description=f"Base curve before the transform. {EXPRESSION_GRAMMAR_HINT}"
+    )
+    transformed_expression: str = Field(
+        min_length=1, description="Transformed curve, same grammar as base_expression."
+    )
+    base_label: str = Field(default="f(x)", description="Legend label for the base curve.")
+    transformed_label: str = Field(
+        default="g(x)", description="Legend label for the transformed curve."
+    )
+    formula_latex: str | None = Field(default=None, description=_LATEX_DOC)
+    caption: str | None = Field(default=None, description=_CAPTION_DOC)
 
 
 class MathShowParametricCurveArgs(BaseModel):
-    expression_x: str = Field(min_length=1)
-    expression_y: str = Field(min_length=1)
-    t_min: float
-    t_max: float
-    x_min: float = -5.0
-    x_max: float = 5.0
-    y_min: float = -5.0
-    y_max: float = 5.0
-    formula_latex: str | None = None
-    caption: str | None = None
+    expression_x: str = Field(
+        min_length=1, description=f"x(t) of the parametric curve. {EXPRESSION_GRAMMAR_HINT}"
+    )
+    expression_y: str = Field(
+        min_length=1, description="y(t) of the parametric curve, same grammar as expression_x."
+    )
+    t_min: float = Field(description="Start of the parameter interval (radians for trig curves).")
+    t_max: float = Field(description="End of the parameter interval.")
+    x_min: float = Field(default=-5.0, description="Left edge of the visible x range.")
+    x_max: float = Field(default=5.0, description="Right edge of the visible x range.")
+    y_min: float = Field(default=-5.0, description="Bottom edge of the visible y range.")
+    y_max: float = Field(default=5.0, description="Top edge of the visible y range.")
+    formula_latex: str | None = Field(default=None, description=_LATEX_DOC)
+    caption: str | None = Field(default=None, description=_CAPTION_DOC)
 
 
 class MathShowRegionBoundaryArgs(BaseModel):
-    vertices: list[tuple[float, float]] = Field(min_length=3)
-    label: str | None = None
-    x_min: float = -5.0
-    x_max: float = 5.0
-    y_min: float = -5.0
-    y_max: float = 5.0
-    formula_latex: str | None = None
-    caption: str | None = None
+    vertices: list[tuple[float, float]] = Field(
+        min_length=3,
+        description=(
+            "Polygon vertices as [x, y] pairs in scene coordinates, "
+            "in drawing order (auto-closed)."
+        ),
+    )
+    label: str | None = Field(
+        default=None, description="Optional label for the region and its boundary."
+    )
+    x_min: float = Field(default=-5.0, description="Left edge of the visible x range.")
+    x_max: float = Field(default=5.0, description="Right edge of the visible x range.")
+    y_min: float = Field(default=-5.0, description="Bottom edge of the visible y range.")
+    y_max: float = Field(default=5.0, description="Top edge of the visible y range.")
+    formula_latex: str | None = Field(default=None, description=_LATEX_DOC)
+    caption: str | None = Field(default=None, description=_CAPTION_DOC)
+
+
+def _plot_symbol(parsed_variables: list[str]):
+    import sympy as sp
+
+    # Plot curves are functions of x; fall back to the single parsed variable
+    # so e.g. "t^2" still differentiates, but always emit in terms of x.
+    name = "x" if "x" in parsed_variables or not parsed_variables else parsed_variables[0]
+    return sp.Symbol(name)
+
+
+def _derived_tangent_expression(expression: str, x0: float) -> str:
+    """Compute the tangent line of ``expression`` at ``x0`` in renderer grammar."""
+    import sympy as sp
+
+    expr, parsed = parse_expression(expression)
+    symbol = _plot_symbol(parsed.variables)
+    slope = sp.diff(expr, symbol).subs(symbol, x0)
+    value = expr.subs(symbol, x0)
+    if not (slope.is_number and value.is_number):
+        raise ValueError(
+            f"cannot derive a tangent for {expression!r} at x0={x0}: "
+            "the expression must evaluate to a number there"
+        )
+    tangent = sp.nsimplify(value) + sp.nsimplify(slope) * (sp.Symbol("x") - sp.nsimplify(x0))
+    return expression_to_source(sp.expand(tangent))
+
+
+def _derived_derivative_expression(expression: str) -> str:
+    """Differentiate ``expression`` symbolically, returned in renderer grammar."""
+    import sympy as sp
+
+    expr, parsed = parse_expression(expression)
+    return expression_to_source(sp.diff(expr, _plot_symbol(parsed.variables)))
 
 
 @register("math.show_tangent", MathShowTangentArgs)
 def show_tangent(args: dict) -> list[LayerSpec]:
     parsed = MathShowTangentArgs.model_validate(args)
+    tangent_expression = parsed.tangent_expression or _derived_tangent_expression(
+        parsed.expression, parsed.x0
+    )
     layers = _plot_layers(
         PlotSpec(
             curves=[
@@ -103,7 +196,7 @@ def show_tangent(args: dict) -> list[LayerSpec]:
                     emphasis="primary",
                 ),
                 PlotCurveSpec(
-                    expression=parsed.tangent_expression,
+                    expression=tangent_expression,
                     label=f"切线 (x={parsed.x0})",
                     emphasis="secondary",
                 ),
@@ -124,9 +217,7 @@ def show_tangent(args: dict) -> list[LayerSpec]:
 @register("math.show_function", MathShowFunctionArgs)
 def show_function(args: dict) -> list[LayerSpec]:
     parsed = MathShowFunctionArgs.model_validate(args)
-    curves = [
-        PlotCurveSpec(expression=parsed.expression, label="f(x)", emphasis="primary")
-    ]
+    curves = [PlotCurveSpec(expression=parsed.expression, label="f(x)", emphasis="primary")]
     if parsed.expression_2:
         curves.append(
             PlotCurveSpec(
@@ -178,6 +269,9 @@ def show_integral_area(args: dict) -> list[LayerSpec]:
 @register("math.show_derivative_compare", MathShowDerivativeCompareArgs)
 def show_derivative_compare(args: dict) -> list[LayerSpec]:
     parsed = MathShowDerivativeCompareArgs.model_validate(args)
+    derivative_expression = parsed.derivative_expression or _derived_derivative_expression(
+        parsed.expression
+    )
     return _plot_layers(
         PlotSpec(
             curves=[
@@ -187,7 +281,7 @@ def show_derivative_compare(args: dict) -> list[LayerSpec]:
                     emphasis="primary",
                 ),
                 PlotCurveSpec(
-                    expression=parsed.derivative_expression,
+                    expression=derivative_expression,
                     label="f'(x)",
                     emphasis="accent",
                 ),

--- a/apps/api/app/domain/animation_tools/physics_tools.py
+++ b/apps/api/app/domain/animation_tools/physics_tools.py
@@ -29,32 +29,62 @@ from app.domain.models.playbook import (
 
 
 class ForceVectorArgs(BaseModel):
-    name: str = Field(min_length=1)
-    magnitude: float = Field(gt=0)
-    angle_deg: float
+    name: str = Field(
+        min_length=1, description="Force label drawn next to the arrow, e.g. 'F', 'mg', 'N'."
+    )
+    magnitude: float = Field(
+        gt=0,
+        description="Force magnitude in newtons; arrows are scaled relative to the largest force.",
+    )
+    angle_deg: float = Field(
+        description="Direction in degrees, counterclockwise from the +x axis (0 = right, 90 = up)."
+    )
 
 
 class PhysicsForceDiagramArgs(BaseModel):
-    forces: list[ForceVectorArgs] = Field(min_length=1)
-    x_min: float = -5.0
-    x_max: float = 5.0
-    y_min: float = -5.0
-    y_max: float = 5.0
-    formula_latex: str | None = None
-    caption: str | None = None
+    forces: list[ForceVectorArgs] = Field(
+        min_length=1, description="Forces acting on one body, all drawn from the origin."
+    )
+    x_min: float = Field(default=-5.0, description="Left edge of the scene coordinate range.")
+    x_max: float = Field(default=5.0, description="Right edge of the scene coordinate range.")
+    y_min: float = Field(default=-5.0, description="Bottom edge of the scene coordinate range.")
+    y_max: float = Field(default=5.0, description="Top edge of the scene coordinate range.")
+    formula_latex: str | None = Field(
+        default=None, description="Optional KaTeX formula overlay (LaTeX allowed here only)."
+    )
+    caption: str | None = Field(
+        default=None, description="Optional one-sentence caption rendered as a narration card."
+    )
 
 
 class PhysicsProjectileMotionArgs(BaseModel):
-    v0: float = Field(gt=0)
-    angle_deg: float
-    g: float = Field(default=9.8, gt=0)
-    duration: float | None = Field(default=None, gt=0)
-    x_min: float = 0.0
-    x_max: float | None = None
-    y_min: float = 0.0
-    y_max: float | None = None
-    formula_latex: str | None = None
-    caption: str | None = None
+    v0: float = Field(gt=0, description="Initial speed in m/s.")
+    angle_deg: float = Field(
+        description="Launch angle in degrees above the horizontal (90 = straight up)."
+    )
+    g: float = Field(default=9.8, gt=0, description="Gravitational acceleration in m/s^2.")
+    duration: float | None = Field(
+        default=None,
+        gt=0,
+        description="Optional flight time in seconds; defaults to the full time until landing.",
+    )
+    x_min: float = Field(default=0.0, description="Left edge of the world x range in meters.")
+    x_max: float | None = Field(
+        default=None,
+        description="Optional right edge in meters; auto-fit to the trajectory when null.",
+    )
+    y_min: float = Field(
+        default=0.0, description="Bottom edge of the world y range in meters (ground level)."
+    )
+    y_max: float | None = Field(
+        default=None, description="Optional top edge in meters; auto-fit to the peak when null."
+    )
+    formula_latex: str | None = Field(
+        default=None, description="Optional KaTeX formula overlay (LaTeX allowed here only)."
+    )
+    caption: str | None = Field(
+        default=None, description="Optional one-sentence caption rendered as a narration card."
+    )
 
 
 @register("physics.force_diagram", PhysicsForceDiagramArgs)

--- a/apps/api/app/domain/animation_tools/registry.py
+++ b/apps/api/app/domain/animation_tools/registry.py
@@ -14,8 +14,23 @@ from pydantic import BaseModel, Field, ValidationError
 
 from app.domain.animation_tools.types import AnimationTool
 from app.domain.models.cir import CirDocument, LayerSpec
+from app.domain.services.safe_math_expr import (
+    SafeMathExpressionError,
+    compile_safe_math_expression,
+)
 
 logger = logging.getLogger(__name__)
+
+# Renderer expression grammar, restated wherever an agent can get it wrong.
+EXPRESSION_GRAMMAR_HINT = (
+    "MetaView expressions use '^' for powers (not Python '**'), plain function "
+    "names such as sin(x), cos(x), sqrt(x), abs(x) (no LaTeX backslashes), "
+    "explicit multiplication like 2*x, and the constants pi and e."
+)
+
+# Args-model field names that must parse under the renderer expression grammar.
+_EXPRESSION_FIELD_PREFIX = "expression"
+_EXPRESSION_FIELD_SUFFIX = "_expression"
 
 _REGISTRY: dict[str, AnimationTool] = {}
 _TOOL_ARGS_MODELS: dict[str, type[BaseModel]] = {}
@@ -25,7 +40,11 @@ _TOOL_DESCRIPTIONS: dict[str, str] = {
     "chemistry.stoichiometry_table": (
         "Build stoichiometry table layers for balanced reaction quantities."
     ),
-    "math.show_derivative_compare": "Compare a function and its derivative on shared plot layers.",
+    "math.show_derivative_compare": (
+        "Compare a function and its derivative on shared plot layers. Pass only "
+        "`expression` and the backend differentiates it symbolically; "
+        "`derivative_expression` overrides that at the caller's own risk."
+    ),
     "math.show_function": (
         "Build function plot layers with optional comparison, marker, or shaded interval."
     ),
@@ -33,7 +52,12 @@ _TOOL_DESCRIPTIONS: dict[str, str] = {
     "math.show_integral_area": "Show area under a function between two bounds.",
     "math.show_parametric_curve": "Show a parametric curve in a math scene.",
     "math.show_region_boundary": "Show a polygonal region boundary in a math scene.",
-    "math.show_tangent": "Show a function and tangent line at a selected x value.",
+    "math.show_tangent": (
+        "Show a function and its tangent line at x0 with a marker at the tangent "
+        "point. Pass only `expression` and `x0` and the backend derives the true "
+        "tangent symbolically; `tangent_expression` overrides that at the "
+        "caller's own risk."
+    ),
     "physics.force_diagram": "Build force-vector scene layers for a body.",
     "physics.projectile_motion": (
         "Build projectile trajectory layers from initial velocity and angle."
@@ -46,6 +70,7 @@ _TOOL_DESCRIPTIONS: dict[str, str] = {
 AnimationToolIssueCode = Literal[
     "animation_tool.unknown_tool",
     "animation_tool.invalid_args",
+    "animation_tool.invalid_expression",
     "animation_tool.exception",
 ]
 
@@ -122,6 +147,52 @@ def _description_from_name(name: str) -> str:
     return f"{domain.title()} animation tool for {phrase}."
 
 
+def _format_validation_error(exc: ValidationError) -> str:
+    """Render every error with its field path so callers can self-correct."""
+    parts = []
+    for error in exc.errors():
+        loc = ".".join(str(item) for item in error.get("loc", ())) or "args"
+        parts.append(f"{loc}: {error.get('msg')}")
+    return "; ".join(parts)
+
+
+def _expression_issues(
+    tool: str,
+    args: dict,
+    path: str,
+) -> list[AnimationToolIssue]:
+    """Fail fast on expression fields the renderer grammar cannot parse.
+
+    The canonical quality gate would reject these anyway, but only after the
+    whole Playbook is assembled — far from the tool call that caused it.
+    """
+    issues: list[AnimationToolIssue] = []
+    for field, value in args.items():
+        if not isinstance(value, str) or not value.strip():
+            continue
+        if not (
+            field == _EXPRESSION_FIELD_PREFIX
+            or field.startswith(f"{_EXPRESSION_FIELD_PREFIX}_")
+            or field.endswith(_EXPRESSION_FIELD_SUFFIX)
+        ):
+            continue
+        try:
+            compile_safe_math_expression(value)
+        except SafeMathExpressionError as exc:
+            issues.append(
+                AnimationToolIssue(
+                    code="animation_tool.invalid_expression",
+                    tool=tool,
+                    path=path,
+                    message=(
+                        f"Invalid expression for animation tool {tool} at {field}: "
+                        f"{exc}. {EXPRESSION_GRAMMAR_HINT}"
+                    ),
+                )
+            )
+    return issues
+
+
 def safe_expand_animation_call(
     tool: str,
     args: dict,
@@ -139,10 +210,17 @@ def safe_expand_animation_call(
             code="animation_tool.unknown_tool",
             tool=tool,
             path=path,
-            message=f"Unknown animation tool: {tool}",
+            message=(
+                f"Unknown animation tool: {tool}. Available tools: {', '.join(sorted(_REGISTRY))}"
+            ),
         )
         logger.warning("%s at %s", issue.message, path)
         return AnimationToolExpansionResult(issues=[issue])
+    expression_issues = _expression_issues(tool, args, path)
+    if expression_issues:
+        for issue in expression_issues:
+            logger.warning("%s", issue.message)
+        return AnimationToolExpansionResult(issues=expression_issues)
     try:
         return AnimationToolExpansionResult(layers=fn(args))
     except ValidationError as exc:
@@ -150,7 +228,7 @@ def safe_expand_animation_call(
             code="animation_tool.invalid_args",
             tool=tool,
             path=path,
-            message=f"Invalid args for animation tool {tool}: {exc.errors()[0].get('msg')}",
+            message=f"Invalid args for animation tool {tool}: {_format_validation_error(exc)}",
         )
         logger.warning("%s", issue.message)
         return AnimationToolExpansionResult(issues=[issue])

--- a/apps/api/app/domain/animation_tools/stats_tools.py
+++ b/apps/api/app/domain/animation_tools/stats_tools.py
@@ -12,19 +12,38 @@ from app.domain.models.playbook import ChartPoint, ChartSeries, StatsChartSceneS
 
 
 class StatsChartSeriesArgs(BaseModel):
-    label: str = Field(min_length=1)
-    values: list[float] = Field(default_factory=list)
-    points: list[ChartPoint] = Field(default_factory=list)
-    emphasis: str = "primary"
+    label: str = Field(min_length=1, description="Series name shown in the legend.")
+    values: list[float] = Field(
+        default_factory=list,
+        description=(
+            "y values plotted at indices 0..n-1; use `points` instead for "
+            "explicit x positions."
+        ),
+    )
+    points: list[ChartPoint] = Field(
+        default_factory=list,
+        description="Explicit {x, y} points; takes precedence over `values` when non-empty.",
+    )
+    emphasis: str = Field(
+        default="primary", description="Series color role: primary, secondary, or accent."
+    )
 
 
 class StatsDistributionChartArgs(BaseModel):
-    chart_type: Literal["line", "bar", "histogram", "distribution", "box"]
-    series: list[StatsChartSeriesArgs] = Field(min_length=1)
-    x_label: str = "x"
-    y_label: str = "y"
-    formula_latex: str | None = None
-    caption: str | None = None
+    chart_type: Literal["line", "bar", "histogram", "distribution", "box"] = Field(
+        description="Chart family; bar/histogram draw one bar per value, line connects the points."
+    )
+    series: list[StatsChartSeriesArgs] = Field(
+        min_length=1, description="One or more data series drawn on shared axes."
+    )
+    x_label: str = Field(default="x", description="x-axis title.")
+    y_label: str = Field(default="y", description="y-axis title.")
+    formula_latex: str | None = Field(
+        default=None, description="Optional KaTeX formula overlay (LaTeX allowed here only)."
+    )
+    caption: str | None = Field(
+        default=None, description="Optional one-sentence caption rendered as a narration card."
+    )
 
 
 @register("stats.distribution_chart", StatsDistributionChartArgs)

--- a/apps/api/app/domain/animation_tools/stats_tools.py
+++ b/apps/api/app/domain/animation_tools/stats_tools.py
@@ -38,6 +38,13 @@ class StatsDistributionChartArgs(BaseModel):
     )
     x_label: str = Field(default="x", description="x-axis title.")
     y_label: str = Field(default="y", description="y-axis title.")
+    categories: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Category names for bar/histogram charts, one per series value; "
+            "when set the renderer labels each bar instead of a numeric axis."
+        ),
+    )
     formula_latex: str | None = Field(
         default=None, description="Optional KaTeX formula overlay (LaTeX allowed here only)."
     )
@@ -62,6 +69,7 @@ def distribution_chart(args: dict) -> list[LayerSpec]:
         ],
         x_label=parsed.x_label,
         y_label=parsed.y_label,
+        categories=parsed.categories,
         formula_latex=parsed.formula_latex,
         caption=parsed.caption,
     )

--- a/apps/api/app/domain/models/playbook.py
+++ b/apps/api/app/domain/models/playbook.py
@@ -411,6 +411,10 @@ class StatsChartSceneSnapshot(BaseModel):
     series: list[ChartSeries] = Field(default_factory=list)
     x_label: str = "x"
     y_label: str = "y"
+    # Category names for bar/histogram charts, one per series value; when set
+    # the renderer lays bars out categorically and labels each bar instead of
+    # showing a meaningless numeric index axis (issue #285).
+    categories: list[str] = Field(default_factory=list)
     current_index: int | None = None
     formula_latex: str | None = None
     caption: str | None = None

--- a/apps/api/app/domain/models/playbook.py
+++ b/apps/api/app/domain/models/playbook.py
@@ -393,9 +393,9 @@ class CodeTraceSceneSnapshot(BaseModel):
 
 
 class ChartPoint(BaseModel):
-    x: float
-    y: float
-    label: str | None = None
+    x: float = Field(description="Horizontal position of the point in chart coordinates.")
+    y: float = Field(description="Vertical position of the point in chart coordinates.")
+    label: str | None = Field(default=None, description="Optional label for this point.")
 
 
 class ChartSeries(BaseModel):

--- a/apps/api/app/domain/skills/algorithm_graph_core/playbook_adapter.py
+++ b/apps/api/app/domain/skills/algorithm_graph_core/playbook_adapter.py
@@ -168,16 +168,35 @@ def _graph_asset_id(kind: str) -> str | None:
 
 
 def _graph_visual_state(solution: GraphAlgorithmSolution) -> GraphVisualState:
-    if solution.kind == "bfs" and solution.table_rows:
+    # Every kind's process table keeps cumulative state per row, so the first
+    # row always yields a non-empty visited/frontier state. Leaving these
+    # lists empty for non-BFS kinds used to trip the quality gate's
+    # algorithm.state_missing check on DFS (issue #284).
+    if solution.table_rows:
         row = solution.table_rows[0]
         current = row[0]
-        visited = _split_state_cell(row[1] if len(row) > 1 else "")
-        enqueued = _split_state_cell(row[2] if len(row) > 2 else "")
-        queue = _split_state_cell(row[3] if len(row) > 3 else "")
+        if solution.kind == "bfs":
+            visited = _split_state_cell(row[1] if len(row) > 1 else "")
+            enqueued = _split_state_cell(row[2] if len(row) > 2 else "")
+            queue = _split_state_cell(row[3] if len(row) > 3 else "")
+        elif solution.kind == "dfs":
+            # columns: 当前节点 / 深度 / 已访问顺序
+            visited = _split_state_cell(row[2] if len(row) > 2 else "")
+            enqueued = visited
+            queue = []
+        elif solution.kind == "dijkstra":
+            # columns: 确定节点 / 最短距离 / 候选堆
+            visited = [current]
+            queue = _split_state_cell(row[2] if len(row) > 2 else "")
+            enqueued = queue
+        else:  # topological_sort — columns: 取出节点 / 拓扑序 / 释放节点
+            visited = _split_state_cell(row[1] if len(row) > 1 else "")
+            queue = _split_state_cell(row[2] if len(row) > 2 else "")
+            enqueued = queue
         return {
             "current_node_id": current,
             "active_node_ids": [current],
-            "visited_node_ids": visited,
+            "visited_node_ids": visited or [current],
             "queue_node_ids": queue,
             "active_edge_ids": _edge_ids_from_current(solution, current, enqueued),
         }
@@ -186,7 +205,7 @@ def _graph_visual_state(solution: GraphAlgorithmSolution) -> GraphVisualState:
     return {
         "current_node_id": active_nodes[0] if active_nodes else None,
         "active_node_ids": active_nodes,
-        "visited_node_ids": [],
+        "visited_node_ids": list(active_nodes[:1]),
         "queue_node_ids": [],
         "active_edge_ids": _active_edge_ids(solution, active_nodes),
     }

--- a/apps/api/app/domain/skills/algorithm_graph_core/skill_pack.py
+++ b/apps/api/app/domain/skills/algorithm_graph_core/skill_pack.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 class AlgorithmGraphCoreSkillPack:
     manifest = ALGORITHM_GRAPH_CORE_MANIFEST
+    problem_spec_model = AlgorithmGraphProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_algorithm_graph(request.prompt)

--- a/apps/api/app/domain/skills/base.py
+++ b/apps/api/app/domain/skills/base.py
@@ -71,6 +71,9 @@ class SkillExecutionResult(BaseModel):
 
 class SkillPack(Protocol):
     manifest: SkillManifest
+    # ProblemSpec model advertised to agents (runtime tool args_schema); the
+    # same model validate_problem_spec accepts.
+    problem_spec_model: type[BaseModel]
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         ...

--- a/apps/api/app/domain/skills/biology_genetics/playbook_adapter.py
+++ b/apps/api/app/domain/skills/biology_genetics/playbook_adapter.py
@@ -95,6 +95,7 @@ def _snapshots(
         ],
         x_label="表现型",
         y_label="概率",
+        categories=[label for label, _value in solution.chart_values],
         formula_latex=solution.formula_latex,
         caption="柱高表示每类表现型的精确概率。",
     )

--- a/apps/api/app/domain/skills/biology_genetics/skill_pack.py
+++ b/apps/api/app/domain/skills/biology_genetics/skill_pack.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 class BiologyGeneticsSkillPack:
     manifest = BIOLOGY_GENETICS_MANIFEST
+    problem_spec_model = BiologyGeneticsProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_biology_genetics(request.prompt)

--- a/apps/api/app/domain/skills/calculus_core/playbook_adapter.py
+++ b/apps/api/app/domain/skills/calculus_core/playbook_adapter.py
@@ -39,42 +39,28 @@ def _build_derivative(spec: CalculusCoreProblemSpec) -> PlaybookScript:
     expr, parsed = parse_expression(spec.expression)
     symbol = sp.Symbol(spec.variable)
     derivative = sp.simplify(sp.diff(expr, symbol))
-    if spec.point is not None:
-        return _build_derivative_tangent(spec, expr, parsed.latex, symbol, derivative)
-    snapshots = [
-        MathFormulaSnapshot(
-            formula_latex=rf"f({spec.variable})={parsed.latex}", caption="把输入解析为单变量函数。"
-        ),
-        MathFormulaSnapshot(
-            formula_latex=rf"f'({spec.variable})=\frac{{d}}{{d{spec.variable}}}\left({parsed.latex}\right)",
-            caption="导数表示瞬时变化率。",
-        ),
-        MathFormulaSnapshot(
-            formula_latex=rf"f'({spec.variable})={sp.latex(derivative)}",
-            caption="使用确定性符号求导。",
-        ),
-        MathPlotSnapshot(
-            curves=[
-                MathPlotCurve(
-                    expression=expression_to_source(expr), label="f(x)", emphasis="secondary"
-                ),
-                MathPlotCurve(
-                    expression=expression_to_source(derivative), label="f'(x)", emphasis="accent"
-                ),
-            ],
-            x_min=-5,
-            x_max=5,
-            formula_latex=rf"f'({spec.variable})={sp.latex(derivative)}",
-        ),
-        IterationTraceSceneSnapshot(
-            iterations=_sample_derivative(expr, derivative, symbol),
-            metric_name="slope",
-            current_index=2,
-            formula_latex=rf"f'({spec.variable})={sp.latex(derivative)}",
-            caption="用几个采样点对比函数值和导数斜率。",
-        ),
-    ]
-    return _script(spec, "单变量导数", snapshots)
+    # A derivative lesson always teaches through the secant→tangent arc (the
+    # LessonPlan demands tangent/secant/target_point visuals even without an
+    # explicit point); without one we pick a well-defined demonstration point.
+    if spec.point is None:
+        spec = spec.model_copy(update={"point": _default_tangent_point(expr, derivative, symbol)})
+    return _build_derivative_tangent(spec, expr, parsed.latex, symbol, derivative)
+
+
+def _default_tangent_point(
+    expr: sp.Expr,
+    derivative: sp.Expr,
+    symbol: sp.Symbol,
+) -> float | int:
+    for candidate in (1, sp.Rational(1, 2), 2, -1, 0):
+        try:
+            value = expr.subs(symbol, candidate)
+            slope = derivative.subs(symbol, candidate)
+        except Exception:  # noqa: BLE001
+            continue
+        if value.is_real and slope.is_real and value.is_finite and slope.is_finite:
+            return int(candidate) if candidate == int(candidate) else float(candidate)
+    return 1
 
 
 def _build_derivative_tangent(
@@ -189,8 +175,17 @@ def _build_derivative_tangent(
                 f"因此该点的切线斜率也等于 {_display(tangent_slope)}。"
             ),
         ),
+        MathFormulaSnapshot(
+            formula_latex=rf"f'({spec.variable})={sp.latex(derivative)}",
+            caption="切线斜率随目标点移动，就得到整条导函数。",
+        ),
     ]
-    return _script(spec, "导数的几何意义", snapshots)
+    answer_text = (
+        f"所以 d/d{spec.variable} ({expression_to_source(expr)}) = "
+        f"{expression_to_source(derivative)}；在 {spec.variable}={_display(point)} 处，"
+        f"切线斜率为 {_display(tangent_slope)}。"
+    )
+    return _script(spec, "导数的几何意义", snapshots, answer_text=answer_text)
 
 
 def _secant_line(
@@ -207,7 +202,10 @@ def _secant_line(
 
 
 def _display(value: sp.Expr) -> str:
-    return sp.sstr(sp.simplify(value))
+    simplified = sp.simplify(value)
+    if getattr(simplified, "is_Float", False):
+        return str(round(float(simplified), 4))
+    return sp.sstr(simplified)
 
 
 def _build_integral(spec: CalculusCoreProblemSpec) -> PlaybookScript:
@@ -248,9 +246,16 @@ def _build_integral(spec: CalculusCoreProblemSpec) -> PlaybookScript:
             formula_latex=rf"面积={sp.latex(value)}",
             caption="用分割采样展示面积累积直觉。",
         ),
-        MathFormulaSnapshot(formula_latex=rf"\boxed{{{sp.latex(value)}}}", caption="最终结果。"),
+        MathFormulaSnapshot(
+            formula_latex=rf"{integral_latex}=\boxed{{{sp.latex(value)}}}",
+            caption="阴影区域的面积就是这个定积分的值。",
+        ),
     ]
-    return _script(spec, "定积分面积", snapshots)
+    answer_text = (
+        f"所以 int_{_display(lower)}^{_display(upper)} {expression_to_source(expr)} "
+        f"d{spec.variable} = {_display(value)}，曲线下这块面积等于 {_display(value)}。"
+    )
+    return _script(spec, "定积分面积", snapshots, answer_text=answer_text)
 
 
 def _build_limit(spec: CalculusCoreProblemSpec) -> PlaybookScript:
@@ -286,9 +291,16 @@ def _build_limit(spec: CalculusCoreProblemSpec) -> PlaybookScript:
             formula_latex=rf"{limit_latex}={sp.latex(value)}",
             caption="符号极限给出最终值。",
         ),
-        MathFormulaSnapshot(formula_latex=rf"\boxed{{{sp.latex(value)}}}", caption="整理答案。"),
+        MathFormulaSnapshot(
+            formula_latex=rf"{limit_latex}=\boxed{{{sp.latex(value)}}}",
+            caption="两侧取样与符号计算给出同一个极限值。",
+        ),
     ]
-    return _script(spec, "单变量极限", snapshots)
+    answer_text = (
+        f"所以 lim {spec.variable}->{_display(point)} {expression_to_source(expr)} "
+        f"= {_display(value)}，极限等于 {_display(value)}。"
+    )
+    return _script(spec, "单变量极限", snapshots, answer_text=answer_text)
 
 
 def _build_series(spec: CalculusCoreProblemSpec) -> PlaybookScript:
@@ -331,18 +343,29 @@ def _build_series(spec: CalculusCoreProblemSpec) -> PlaybookScript:
         ),
         MathFormulaSnapshot(formula_latex=sp.latex(series), caption="最终近似多项式。"),
     ]
-    return _script(spec, "泰勒展开", snapshots)
+    answer_text = (
+        f"所以 {expression_to_source(expr)} 在该点的泰勒多项式为 "
+        f"{expression_to_source(series)}。"
+    )
+    return _script(spec, "泰勒展开", snapshots, answer_text=answer_text)
 
 
 def _script(
     spec: CalculusCoreProblemSpec,
     title: str,
     snapshots: list[MathFormulaSnapshot | MathPlotSnapshot | IterationTraceSceneSnapshot],
+    *,
+    answer_text: str | None = None,
 ) -> PlaybookScript:
     steps: list[MetaStep] = []
     frame_cursor = 0
-    for index, snapshot in enumerate(snapshots[:6]):
+    kept = snapshots[:6]
+    for index, snapshot in enumerate(kept):
         voiceover_text = getattr(snapshot, "caption", None) or "执行微积分步骤。"
+        if answer_text and index == len(kept) - 1:
+            # The final step must state the requested conclusion in narration —
+            # a \boxed{} formula alone never answers the prompt (issue #283).
+            voiceover_text = f"{voiceover_text} {answer_text}".strip()
         frame_cursor += max(_STEP_FRAMES, estimate_step_frames(voiceover_text, _FPS))
         steps.append(
             MetaStep(
@@ -368,19 +391,6 @@ def _script(
         initial_data={},
     )
 
-
-def _sample_derivative(
-    expr: sp.Expr, derivative: sp.Expr, symbol: sp.Symbol
-) -> list[IterationTraceItem]:
-    items: list[IterationTraceItem] = []
-    for index, x_value in enumerate([-2, -1, 0, 1, 2]):
-        slope = sp.N(derivative.subs(symbol, x_value), 5)
-        items.append(
-            IterationTraceItem(
-                index=index, value=f"x={x_value}", error=float(slope), label=f"斜率 {slope}"
-            )
-        )
-    return items
 
 
 def _riemann_samples(

--- a/apps/api/app/domain/skills/calculus_core/skill_pack.py
+++ b/apps/api/app/domain/skills/calculus_core/skill_pack.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 class CalculusCoreSkillPack:
     manifest = CALCULUS_CORE_MANIFEST
+    problem_spec_model = CalculusCoreProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_calculus_core(request.prompt)

--- a/apps/api/app/domain/skills/chemistry_stoichiometry/playbook_adapter.py
+++ b/apps/api/app/domain/skills/chemistry_stoichiometry/playbook_adapter.py
@@ -81,6 +81,7 @@ def _snapshots(
             ],
             x_label="反应物",
             y_label="n/系数",
+            categories=[label for label, _value in solution.chart_values],
             formula_latex=r"\min(n_i/\nu_i)",
             caption="柱子越短，越先耗尽，是限量反应物。",
         )

--- a/apps/api/app/domain/skills/chemistry_stoichiometry/skill_pack.py
+++ b/apps/api/app/domain/skills/chemistry_stoichiometry/skill_pack.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 class ChemistryStoichiometrySkillPack:
     manifest = CHEMISTRY_STOICHIOMETRY_MANIFEST
+    problem_spec_model = ChemistryStoichiometryProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_chemistry_stoichiometry(request.prompt)

--- a/apps/api/app/domain/skills/conic_sections/skill_pack.py
+++ b/apps/api/app/domain/skills/conic_sections/skill_pack.py
@@ -18,6 +18,7 @@ from app.domain.skills.conic_sections.spec_extractor import try_extract_ellipse_
 
 class ConicSectionsSkillPack:
     manifest = CONIC_SECTIONS_MANIFEST
+    problem_spec_model = ConicEllipseFocusProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_ellipse_focus_definition(request.prompt)

--- a/apps/api/app/domain/skills/conic_sections/spec_extractor.py
+++ b/apps/api/app/domain/skills/conic_sections/spec_extractor.py
@@ -20,8 +20,13 @@ def try_extract_ellipse_focus_definition(prompt: str) -> ConicEllipseFocusProble
         return None
     a_match = _A_RE.search(text)
     b_match = _B_RE.search(text)
-    if a_match is None or b_match is None:
+    if (a_match is None) != (b_match is None):
+        # Half-specified axes are ambiguous; let another skill or path claim it.
         return None
+    if a_match is None and b_match is None:
+        # A pure focus-definition demo names no axes (the manifest's own second
+        # example); use a classic demonstration ellipse. See issue #282.
+        return ConicEllipseFocusProblemSpec(original_prompt=prompt, a=5.0, b=3.0)
     try:
         return ConicEllipseFocusProblemSpec(
             original_prompt=prompt,

--- a/apps/api/app/domain/skills/elementary_algebra/skill_pack.py
+++ b/apps/api/app/domain/skills/elementary_algebra/skill_pack.py
@@ -30,6 +30,7 @@ _TASK_CAPABILITY_IDS = {
 
 class ElementaryAlgebraSkillPack:
     manifest = ELEMENTARY_ALGEBRA_MANIFEST
+    problem_spec_model = ElementaryAlgebraProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_elementary_algebra(request.prompt)

--- a/apps/api/app/domain/skills/geography_climate/playbook_adapter.py
+++ b/apps/api/app/domain/skills/geography_climate/playbook_adapter.py
@@ -99,6 +99,7 @@ def _snapshots(
         ],
         x_label="月份/站点",
         y_label="温度或降水",
+        categories=[label for label, _value in solution.chart_values],
         formula_latex=solution.formula_latex,
         caption="用月序列或站点柱形图显示气候常年值。",
     )

--- a/apps/api/app/domain/skills/geography_climate/skill_pack.py
+++ b/apps/api/app/domain/skills/geography_climate/skill_pack.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 class GeographyClimateSkillPack:
     manifest = GEOGRAPHY_CLIMATE_MANIFEST
+    problem_spec_model = GeographyClimateProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_geography_climate(request.prompt)

--- a/apps/api/app/domain/skills/geography_earth/skill_pack.py
+++ b/apps/api/app/domain/skills/geography_earth/skill_pack.py
@@ -23,6 +23,7 @@ _EAST_ASIA_TERMS = ("东亚", "中国", "西太平洋", "western pacific", "east
 
 class GeographyEarthSkillPack:
     manifest = GEOGRAPHY_EARTH_MANIFEST
+    problem_spec_model = GeographyEarthProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_geography_earth(request.prompt)

--- a/apps/api/app/domain/skills/linear_algebra/skill_pack.py
+++ b/apps/api/app/domain/skills/linear_algebra/skill_pack.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 class LinearAlgebraSkillPack:
     manifest = LINEAR_ALGEBRA_MANIFEST
+    problem_spec_model = LinearAlgebraProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_linear_algebra(request.prompt)

--- a/apps/api/app/domain/skills/linear_algebra/spec_extractor.py
+++ b/apps/api/app/domain/skills/linear_algebra/spec_extractor.py
@@ -26,6 +26,12 @@ def try_extract_linear_algebra(prompt: str) -> LinearAlgebraProblemSpec | None:
             matrix=matrix,
         )
 
+    # Graph-edge notation like "A->B=2" is not a linear equation; without this
+    # guard a Dijkstra prompt reads as a solvable system and outranks the
+    # algorithm skill pack. See issue #282.
+    if "->" in normalized:
+        return None
+
     if any(keyword in normalized.lower() for keyword in _SYSTEM_KEYWORDS) or _looks_like_system(
         normalized
     ):

--- a/apps/api/app/domain/skills/physics_mechanics/mechanics_kernel.py
+++ b/apps/api/app/domain/skills/physics_mechanics/mechanics_kernel.py
@@ -162,7 +162,11 @@ def _solve_incline(spec: PhysicsMechanicsProblemSpec) -> PhysicsMechanicsSolutio
             PhysicsMechanicsStep("重力分解", r"mg\sin\theta", "沿斜面分力提供下滑加速度。"),
             PhysicsMechanicsStep("忽略摩擦", r"a=g\sin\theta", "质量约掉，结果只由角度和 g 决定。"),
         ],
-        values={"acceleration": value},
+        values={
+            "acceleration": value,
+            # The motion-scene adapter draws the ramp at the real angle.
+            "angle_deg": _mechanics_value(Decimal(str(angle)), "°"),
+        },
         answer_latex=rf"a=g\sin\theta={_fmt(acceleration)}\,\text{{m/s}}^2",
         answer_text=f"沿斜面下滑加速度 {value.display}。",
         checks={"frictionless": True},

--- a/apps/api/app/domain/skills/physics_mechanics/playbook_adapter.py
+++ b/apps/api/app/domain/skills/physics_mechanics/playbook_adapter.py
@@ -112,6 +112,11 @@ def _projectile_force_snapshot(solution: PhysicsMechanicsSolution) -> PhysicsFor
 
 
 def _motion_snapshot(solution: PhysicsMechanicsSolution) -> MotionSceneSnapshot:
+    if solution.kind == "incline_force":
+        return _incline_motion_snapshot(solution)
+    # The direction label lives at the arrow tip, not on the segment itself:
+    # a segment label sits at the midpoint, exactly where the animated body's
+    # own label passes, and the two collide mid-step (issue #286).
     objects = [
         MotionSegmentObject(
             id="axis",
@@ -120,9 +125,9 @@ def _motion_snapshot(solution: PhysicsMechanicsSolution) -> MotionSceneSnapshot:
             x2=4,
             y2=0,
             arrow=True,
-            label="运动方向",
             style="muted",
         ),
+        MotionTextObject(id="axis-label", x=3.4, y=0.55, text="运动方向", style="label"),
         MotionPointObject(id="body", x=-3.2, y=0, r=0.16, label="物体", style="primary"),
         MotionSegmentObject(
             id="velocity",
@@ -210,6 +215,109 @@ def _motion_snapshot(solution: PhysicsMechanicsSolution) -> MotionSceneSnapshot:
                 easing="easeInOut",
             ),
         ]
+    return MotionSceneSnapshot(
+        viewport=MotionSceneViewport(
+            width=960,
+            height=540,
+            world=MotionSceneWorld(xMin=-4.5, xMax=4.5, yMin=-3.0, yMax=3.0),
+        ),
+        objects=objects,
+        tracks=tracks,
+        camera=MotionCameraTrack(
+            keyframes=[
+                MotionCameraKeyframe(t=0, x=0, y=0, zoom=1),
+                MotionCameraKeyframe(t=1, x=0, y=0, zoom=1),
+            ],
+            easing="linear",
+        ),
+    )
+
+
+def _incline_motion_snapshot(solution: PhysicsMechanicsSolution) -> MotionSceneSnapshot:
+    """Draw the ramp at the real incline angle with the body sliding down it.
+
+    The generic horizontal scene used to be reused verbatim here, so the
+    narration said 沿斜面下滑 while the picture showed level motion (#286).
+    """
+    import math
+
+    angle_value = solution.values.get("angle_deg")
+    angle_deg = angle_value.numeric if angle_value is not None else 30.0
+    angle = math.radians(max(5.0, min(80.0, angle_deg)))
+    base = (3.8, -2.2)
+    ramp_length = min(6.5, 7.6 / math.cos(angle), 4.6 / math.sin(angle))
+    top = (base[0] - ramp_length * math.cos(angle), base[1] + ramp_length * math.sin(angle))
+    # Down-slope unit direction, and the outward normal used to float the
+    # velocity arrow above the surface, clear of the body's path.
+    down = (math.cos(angle), -math.sin(angle))
+    normal = (math.sin(angle), math.cos(angle))
+    start = (top[0] + 0.4 * down[0], top[1] + 0.4 * down[1])
+    end = (base[0] - 0.6 * down[0], base[1] - 0.6 * down[1])
+    velocity_start = (start[0] + 0.35 * normal[0], start[1] + 0.35 * normal[1])
+    velocity_end = (velocity_start[0] + 1.8 * down[0], velocity_start[1] + 1.8 * down[1])
+    objects = [
+        MotionSegmentObject(id="ground", x1=-4.2, y1=base[1], x2=4.2, y2=base[1], style="muted"),
+        MotionSegmentObject(
+            id="ramp",
+            x1=round(top[0], 3),
+            y1=round(top[1], 3),
+            x2=base[0],
+            y2=base[1],
+            style="secondary",
+        ),
+        MotionTextObject(
+            id="angle-label",
+            x=base[0] - 1.5,
+            y=base[1] + 0.3,
+            text=f"θ={angle_deg:g}°",
+            style="label",
+        ),
+        MotionPointObject(
+            id="body",
+            x=round(start[0], 3),
+            y=round(start[1], 3),
+            r=0.16,
+            label="物体",
+            style="primary",
+        ),
+        MotionSegmentObject(
+            id="velocity",
+            x1=round(velocity_start[0], 3),
+            y1=round(velocity_start[1], 3),
+            x2=round(velocity_end[0], 3),
+            y2=round(velocity_end[1], 3),
+            arrow=True,
+            label="v",
+            style="accent",
+        ),
+        MotionTextObject(id="summary", x=-3.7, y=2.2, text=solution.answer_text, style="caption"),
+    ]
+    tracks = [
+        MotionTrack(
+            target="body",
+            property="x",
+            keyframes=[
+                MotionKeyframe(t=0, value=round(start[0], 3)),
+                MotionKeyframe(t=1, value=round(end[0], 3)),
+            ],
+            easing="easeInOut",
+        ),
+        MotionTrack(
+            target="body",
+            property="y",
+            keyframes=[
+                MotionKeyframe(t=0, value=round(start[1], 3)),
+                MotionKeyframe(t=1, value=round(end[1], 3)),
+            ],
+            easing="easeInOut",
+        ),
+        MotionTrack(
+            target="velocity",
+            property="drawProgress",
+            keyframes=[MotionKeyframe(t=0, value=0), MotionKeyframe(t=1, value=1)],
+            easing="linear",
+        ),
+    ]
     return MotionSceneSnapshot(
         viewport=MotionSceneViewport(
             width=960,

--- a/apps/api/app/domain/skills/physics_mechanics/skill_pack.py
+++ b/apps/api/app/domain/skills/physics_mechanics/skill_pack.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 class PhysicsMechanicsSkillPack:
     manifest = PHYSICS_MECHANICS_MANIFEST
+    problem_spec_model = PhysicsMechanicsProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_physics_mechanics(request.prompt)

--- a/apps/api/app/domain/skills/probability_statistics_core/playbook_adapter.py
+++ b/apps/api/app/domain/skills/probability_statistics_core/playbook_adapter.py
@@ -75,6 +75,11 @@ def _snapshots(
         ],
         x_label="项目",
         y_label="数值/概率",
+        categories=(
+            [label for label, _value in solution.chart_values]
+            if solution.kind != "z_score_normal_cdf"
+            else []
+        ),
         formula_latex=solution.formula_latex,
         caption="用图形比较关键数值的大小。",
     )

--- a/apps/api/app/domain/skills/probability_statistics_core/skill_pack.py
+++ b/apps/api/app/domain/skills/probability_statistics_core/skill_pack.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 class ProbabilityStatisticsCoreSkillPack:
     manifest = PROBABILITY_STATISTICS_CORE_MANIFEST
+    problem_spec_model = ProbabilityStatisticsProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_probability_statistics(request.prompt)

--- a/apps/api/app/domain/skills/probability_statistics_core/spec_extractor.py
+++ b/apps/api/app/domain/skills/probability_statistics_core/spec_extractor.py
@@ -59,19 +59,28 @@ def _extract_descriptive(text: str) -> ProbabilityStatisticsProblemSpec | None:
     if not data:
         return None
     query: list[str] = []
+    lower = text.lower()
     for needle, key in (
         ("均值", "mean"),
         ("平均", "mean"),
+        ("mean", "mean"),
         ("中位数", "median"),
+        ("median", "median"),
         ("众数", "mode"),
+        ("mode", "mode"),
         ("极差", "range"),
         ("方差", "variance"),
+        ("variance", "variance"),
         ("标准差", "std"),
     ):
-        if needle in text and key not in query:
+        if (needle in text or needle in lower) and key not in query:
             query.append(key)
+    # A bare number list is not a statistics request: without at least one
+    # descriptive-statistics keyword this extractor must not claim the prompt
+    # (an eigenvalue prompt like "求 A=[[1,2],[3,4]] 的特征值" also contains a
+    # bracketed number list). See issue #282.
     if not query:
-        query = ["mean", "median", "mode", "range"]
+        return None
     scope = "population" if "总体" in text else "sample" if "样本" in text else None
     assumptions: list[str] = []
     if scope is None and {"variance", "std"} & set(query):

--- a/apps/api/app/domain/skills/probability_statistics_core/statistics_kernel.py
+++ b/apps/api/app/domain/skills/probability_statistics_core/statistics_kernel.py
@@ -23,6 +23,16 @@ class ProbabilityStatisticsSolution:
     assumptions: list[str] = field(default_factory=list)
 
 
+_DESCRIPTIVE_LABELS = {
+    "mean": "均值",
+    "median": "中位数",
+    "mode": "众数",
+    "range": "极差",
+    "variance": "方差",
+    "std": "标准差",
+}
+
+
 def solve_probability_statistics(
     spec: ProbabilityStatisticsProblemSpec,
 ) -> ProbabilityStatisticsSolution:
@@ -74,7 +84,12 @@ def _solve_descriptive(spec: ProbabilityStatisticsProblemSpec) -> ProbabilitySta
         table_rows=rows,
         chart_values=[(str(index + 1), float(value)) for index, value in enumerate(spec.data)],
         formula_latex=r"\bar{x}=\frac{\sum x_i}{n}",
-        answer_text="；".join(f"{key}={_display(value)}" for key, value in results.items()),
+        # Bilingual labels so the final narration shares tokens with the
+        # (usually Chinese) prompt — "mean=5" alone never answers 「求均值」.
+        answer_text="；".join(
+            f"{_DESCRIPTIVE_LABELS.get(key, key)} {key}={_display(value)}"
+            for key, value in results.items()
+        ),
         data=spec.data,
         assumptions=spec.assumptions,
     )

--- a/apps/api/app/domain/skills/quadratic_transform/skill_pack.py
+++ b/apps/api/app/domain/skills/quadratic_transform/skill_pack.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 class QuadraticTransformSkillPack:
     manifest = QUADRATIC_TRANSFORM_MANIFEST
+    problem_spec_model = QuadraticTransformProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = try_extract_quadratic_transform(request.prompt)

--- a/apps/api/app/domain/skills/solid_geometry/skill_pack.py
+++ b/apps/api/app/domain/skills/solid_geometry/skill_pack.py
@@ -28,6 +28,7 @@ _SUPPORTED_QUERY_KINDS = frozenset({"line_plane_angle", "volume"})
 
 class SolidGeometrySkillPack:
     manifest = SOLID_GEOMETRY_MANIFEST
+    problem_spec_model = SolidGeometryProblemSpec
 
     def heuristic_match(self, request: SkillRouteInput) -> SkillRouteMatch | None:
         spec = extract_solid_geometry_spec(request.prompt)

--- a/apps/api/tests/test_animation_tools.py
+++ b/apps/api/tests/test_animation_tools.py
@@ -454,3 +454,123 @@ class TestRegistry:
                 _REGISTRY.pop("test.raise_base_exception", None)
             else:
                 _REGISTRY["test.raise_base_exception"] = original
+
+
+class TestErrorEchoAndFailFast:
+    """Issues #279/#280: field paths in errors and fail-fast expression checks."""
+
+    def test_unknown_tool_lists_available_tools(self):
+        result = safe_expand_animation_call("math.show_tangent_line", {})
+
+        assert result.issues[0].code == "animation_tool.unknown_tool"
+        assert "math.show_tangent" in result.issues[0].message
+
+    def test_invalid_args_message_names_every_missing_field(self):
+        result = safe_expand_animation_call("math.show_parametric_curve", {})
+
+        assert result.issues[0].code == "animation_tool.invalid_args"
+        message = result.issues[0].message
+        for field in ("expression_x", "expression_y", "t_min", "t_max"):
+            assert field in message
+
+    def test_invalid_args_message_names_nested_field_path(self):
+        result = safe_expand_animation_call(
+            "physics.force_diagram",
+            {"forces": [{"name": "重力", "magnitude": "9.8牛", "angle_deg": -90}]},
+        )
+
+        assert result.issues[0].code == "animation_tool.invalid_args"
+        assert "forces.0.magnitude" in result.issues[0].message
+
+    @pytest.mark.parametrize("bad_expression", ["x**2", "\\sin(x)"])
+    def test_python_or_latex_expression_fails_fast(self, bad_expression):
+        result = safe_expand_animation_call(
+            "math.show_function", {"expression": bad_expression}
+        )
+
+        assert result.layers == []
+        assert result.issues[0].code == "animation_tool.invalid_expression"
+        assert "expression" in result.issues[0].message
+        assert "'^'" in result.issues[0].message
+
+    def test_caret_grammar_still_expands(self):
+        result = safe_expand_animation_call(
+            "math.show_function", {"expression": "x^2*sin(x)"}
+        )
+
+        assert result.issues == []
+        assert result.layers[0].kind == LayerKind.MATH_PLOT
+
+    def test_formula_latex_is_not_expression_checked(self):
+        result = safe_expand_animation_call(
+            "math.show_function",
+            {"expression": "x^2", "formula_latex": "\\int_0^1 x^2 dx"},
+        )
+
+        assert result.issues == []
+
+
+class TestDerivedTangentAndDerivative:
+    """Issue #281: omit tangent/derivative expressions and get the true ones."""
+
+    def test_show_tangent_derives_true_tangent_when_omitted(self):
+        layers = expand_animation_call(
+            "math.show_tangent", {"expression": "x^2", "x0": 2}
+        )
+
+        tangent = layers[0].plot.curves[1].expression
+        from app.domain.services.safe_math_expr import compile_safe_math_expression
+
+        fn = compile_safe_math_expression(tangent)
+        # Tangent of x^2 at x0=2 is 4x - 4.
+        for x in (-1.0, 0.0, 2.0, 3.5):
+            assert fn({"x": x}) == pytest.approx(4 * x - 4)
+
+    def test_show_tangent_keeps_explicit_tangent_expression(self):
+        layers = expand_animation_call(
+            "math.show_tangent",
+            {"expression": "x^2", "x0": 2, "tangent_expression": "4*x - 4"},
+        )
+
+        assert layers[0].plot.curves[1].expression == "4*x - 4"
+
+    def test_show_derivative_compare_derives_derivative_when_omitted(self):
+        layers = expand_animation_call(
+            "math.show_derivative_compare", {"expression": "x^3"}
+        )
+
+        derivative = layers[0].plot.curves[1].expression
+        from app.domain.services.safe_math_expr import compile_safe_math_expression
+
+        fn = compile_safe_math_expression(derivative)
+        for x in (-2.0, 0.5, 3.0):
+            assert fn({"x": x}) == pytest.approx(3 * x * x)
+
+    def test_every_tool_documents_every_arg_field(self):
+        for tool in list_animation_tools():
+            properties = tool.args_schema.get("properties", {})
+            defs = tool.args_schema.get("$defs", {})
+            for name, prop in properties.items():
+                assert _schema_field_documented(prop, defs), (
+                    f"{tool.name}.{name} has no description"
+                )
+            for def_name, definition in defs.items():
+                for name, prop in definition.get("properties", {}).items():
+                    assert _schema_field_documented(prop, defs), (
+                        f"{tool.name} ${def_name}.{name} has no description"
+                    )
+
+
+def _schema_field_documented(prop: dict, defs: dict) -> bool:
+    if prop.get("description"):
+        return True
+    ref = prop.get("$ref", "")
+    if ref.startswith("#/$defs/"):
+        return True  # nested model documented via its own properties
+    items = prop.get("items")
+    if isinstance(items, dict) and items.get("$ref", "").startswith("#/$defs/"):
+        return True
+    for variant in prop.get("anyOf", []) or []:
+        if isinstance(variant, dict) and variant.get("description"):
+            return True
+    return False

--- a/apps/api/tests/test_coverage_resolver.py
+++ b/apps/api/tests/test_coverage_resolver.py
@@ -310,13 +310,26 @@ def test_generic_override_never_forces_a_registered_skill() -> None:
 def test_binary_search_dataset_cannot_become_statistics_specialized() -> None:
     registry = build_default_skill_registry()
     prompt = "用二分查找在 [2,4,7,11,18,25,31] 中查找 18"
-    false_match = registry.heuristic_match(SkillRouteInput(prompt=prompt))
-    assert false_match is not None
-    assert false_match.skill_id == "probability_statistics_core"
 
+    # Since issue #282 the statistics extractor no longer claims a bare number
+    # list, so the false match is gone at the source.
+    false_match = registry.heuristic_match(SkillRouteInput(prompt=prompt))
+    assert false_match is None or false_match.skill_id != "probability_statistics_core"
+
+    # The resolver's downstream defense must still hold if a mis-route ever
+    # reappears: a statistics claim on an algorithm prompt degrades to
+    # experimental with an explicit domain mismatch.
+    forged_match = SkillRouteMatch(
+        skill_id="probability_statistics_core",
+        domain="math",
+        confidence=0.9,
+        capability_id="probability_statistics_core.descriptive_statistics",
+        reason="forged false positive for downstream-defense coverage",
+        problem_spec=None,
+    )
     decision = DefaultCoverageResolver(registry).resolve(
         prompt=prompt,
-        route_match=false_match,
+        route_match=forged_match,
     )
 
     assert decision.mode == "experimental"

--- a/apps/api/tests/test_math_skill_catalog_v1.py
+++ b/apps/api/tests/test_math_skill_catalog_v1.py
@@ -74,7 +74,7 @@ def test_algebra_core_solves_equation_and_system_matrix() -> None:
     [
         (ElementaryAlgebraSkillPack(), "解方程 2x+3=11", "elementary_algebra", "table_scene"),
         (LinearAlgebraSkillPack(), "求 A=[[1,2],[3,4]] 的特征值", "linear_algebra", "matrix_scene"),
-        (CalculusCoreSkillPack(), "求 d/dx (x^2 sin x)", "calculus_core", "iteration_trace_scene"),
+        (CalculusCoreSkillPack(), "求 d/dx (x^2 sin x)", "calculus_core", "math_plot"),
     ],
 )
 @pytest.mark.asyncio

--- a/apps/api/tests/test_router_agent.py
+++ b/apps/api/tests/test_router_agent.py
@@ -134,7 +134,7 @@ def test_animation_tool_list_requires_shared_token(monkeypatch: pytest.MonkeyPat
     assert ok.status_code == 200
     tools = ok.json()["tools"]
     tangent = next(tool for tool in tools if tool["name"] == "math.show_tangent")
-    assert tangent["description"] == "Show a function and tangent line at a selected x value."
+    assert tangent["description"].startswith("Show a function and its tangent line at x0")
     assert tangent["args_schema"]["properties"]["expression"]["minLength"] == 1
 
 
@@ -172,7 +172,7 @@ def test_animation_tool_expand_returns_layers_with_issues_empty(
         headers={"X-MetaView-Agent-Token": "secret"},
         json={
             "tool": "math.show_function",
-            "args": {"expression": "x**2", "x_min": -2, "x_max": 2},
+            "args": {"expression": "x^2", "x_min": -2, "x_max": 2},
         },
     )
 
@@ -232,7 +232,7 @@ def test_runtime_tool_execute_returns_structured_result(
         headers={"X-MetaView-Agent-Token": "secret"},
         json={
             "tool": "geometry.assert_monotonic",
-            "args": {"expression": "x**2", "x_min": 0.1, "x_max": 2.0},
+            "args": {"expression": "x^2", "x_min": 0.1, "x_max": 2.0},
         },
     )
 

--- a/apps/api/tests/test_runtime_tool_hub.py
+++ b/apps/api/tests/test_runtime_tool_hub.py
@@ -483,3 +483,71 @@ async def test_runtime_tool_hub_executes_skill_pack_tool() -> None:
     assert result.result["handled"] is True
     assert result.result["playbook"]["title"] == "Fake Skill"
     assert result.result["review_actions"] == ["skill:fake_skill"]
+
+
+@pytest.mark.anyio
+async def test_skill_solve_reports_invalid_problem_spec_instead_of_unsupported() -> None:
+    """Issue #279: a mis-shaped problem_spec must not read as 'capability unsupported'."""
+    hub = RuntimeToolHub()
+
+    result = await hub.execute_tool(
+        "skill.calculus_core.solve",
+        {
+            "run_id": "run-echo",
+            "prompt": "",
+            "problem_spec": {"task": "derivative", "expression": "x**2"},
+        },
+    )
+
+    assert result.ok is True
+    assert result.result["handled"] is False
+    assert result.result["fallback_reason"] == "invalid_problem_spec"
+    assert "CalculusCoreProblemSpec" in result.result["message"]
+
+
+@pytest.mark.anyio
+async def test_skill_solve_declined_prompt_carries_message() -> None:
+    hub = RuntimeToolHub()
+
+    result = await hub.execute_tool(
+        "skill.calculus_core.solve",
+        {"run_id": "run-echo", "prompt": "写一首关于秋天的诗"},
+    )
+
+    assert result.ok is True
+    assert result.result["handled"] is False
+    assert "declined" in result.result["message"]
+
+
+@pytest.mark.anyio
+async def test_unknown_runtime_tool_error_lists_available_tools() -> None:
+    hub = RuntimeToolHub()
+
+    result = await hub.execute_tool("skill.calculus.solve", {})
+
+    assert result.ok is False
+    assert "skill.calculus_core.solve" in result.error["message"]
+
+
+def test_skill_solve_args_schema_exports_real_problem_spec() -> None:
+    """Issue #281: problem_spec must not be advertised as an opaque object."""
+    hub = RuntimeToolHub()
+
+    tool = hub.get_tool("skill.calculus_core.solve")
+    spec_schema = tool.args_schema["properties"]["problem_spec"]
+
+    assert spec_schema.get("title") == "CalculusCoreProblemSpec"
+    task = spec_schema["properties"]["task"]
+    assert "derivative" in task.get("enum", [])
+
+
+def test_geometry_assert_args_document_every_field() -> None:
+    hub = RuntimeToolHub()
+    for name in (
+        "geometry.assert_orientation",
+        "geometry.assert_passes_through",
+        "geometry.assert_monotonic",
+    ):
+        schema = hub.get_tool(name).args_schema
+        for field, prop in schema["properties"].items():
+            assert prop.get("description"), f"{name}.{field} has no description"

--- a/apps/api/tests/test_skill_pack_pipeline.py
+++ b/apps/api/tests/test_skill_pack_pipeline.py
@@ -353,7 +353,10 @@ async def test_derivative_tangent_prompt_produces_required_visual_evidence() -> 
     }
     assert {"curve", "secant", "tangent"} <= curve_roles
     assert any(snapshot.get("marker_x") == 1 for snapshot in math_plots)
-    assert "切线斜率也等于 2" in playbook["steps"][-1]["voiceover_text"]
+    final_voiceover = playbook["steps"][-1]["voiceover_text"]
+    # Since #283 the final step states the full requested conclusion.
+    assert "切线斜率为 2" in final_voiceover
+    assert "d/dx" in final_voiceover
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_skill_routing_manifest_examples.py
+++ b/apps/api/tests/test_skill_routing_manifest_examples.py
@@ -1,0 +1,60 @@
+"""Every SkillPack manifest example must route back to its own skill.
+
+Issue #282: constant per-skill confidences let a greedy extractor steal
+another skill's documented example (an eigenvalue prompt claimed by the
+statistics pack; a Dijkstra prompt claimed as a linear system and then
+rejected as unsupported). This suite turns the invariant into data-driven
+regression coverage over all manifests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.domain.skills.base import SkillRouteInput
+from app.domain.skills.registry import build_default_skill_registry
+
+_REGISTRY = build_default_skill_registry()
+
+_CASES = [
+    pytest.param(skill.manifest.skill_id, example, id=f"{capability.capability_id}:{example}")
+    for skill in _REGISTRY.all()
+    for capability in skill.manifest.capabilities
+    for example in capability.examples
+]
+
+
+@pytest.mark.parametrize(("skill_id", "example"), _CASES)
+def test_manifest_example_routes_to_its_own_skill(skill_id: str, example: str) -> None:
+    match = _REGISTRY.heuristic_match(
+        SkillRouteInput(prompt=example, source_code=None, language=None)
+    )
+
+    assert match is not None, f"no skill claimed the manifest example {example!r}"
+    assert match.skill_id == skill_id, (
+        f"{example!r} routed to {match.skill_id!r} instead of {skill_id!r} "
+        f"(confidence {match.confidence})"
+    )
+
+
+def test_eigen_prompt_not_claimed_by_statistics() -> None:
+    match = _REGISTRY.heuristic_match(
+        SkillRouteInput(prompt="求 A=[[1,2],[3,4]] 的特征值", source_code=None, language=None)
+    )
+
+    assert match is not None
+    assert match.skill_id == "linear_algebra"
+    assert match.capability_id == "linear_algebra.eigen_basic"
+
+
+def test_dijkstra_prompt_not_claimed_as_linear_system() -> None:
+    match = _REGISTRY.heuristic_match(
+        SkillRouteInput(
+            prompt="解释 Dijkstra：A->B=2, B->C=1，求 A 到 C 最短路",
+            source_code=None,
+            language=None,
+        )
+    )
+
+    assert match is not None
+    assert match.skill_id == "algorithm_graph_core"

--- a/apps/web/src/features/playbook/engine/renderers/AdvancedMathRenderers.test.tsx
+++ b/apps/web/src/features/playbook/engine/renderers/AdvancedMathRenderers.test.tsx
@@ -106,6 +106,38 @@ describe("advanced math renderers", () => {
     }
   });
 
+  it("labels categorical bars with category names and axis titles (issue #285)", () => {
+    const markup = render({
+      kind: "stats_chart_scene",
+      chart_type: "bar",
+      series: [{ label: "表现型概率", values: [0.75, 0.25], emphasis: "accent" }],
+      x_label: "表现型",
+      y_label: "概率",
+      categories: ["显性", "隐性"],
+    });
+
+    expect(markup).toContain("显性");
+    expect(markup).toContain("隐性");
+    expect(markup).toContain("表现型");
+    expect(markup).toContain("概率");
+    // Categorical mode replaces the numeric index axis under the bars.
+    expect(markup).not.toContain(">0.5<");
+  });
+
+  it("keeps numeric-axis bar charts working without categories", () => {
+    const markup = render({
+      kind: "stats_chart_scene",
+      chart_type: "bar",
+      series: [{ label: "counts", values: [3, 5, 2] }],
+      x_label: "index",
+      y_label: "count",
+    });
+
+    expect(markup).toContain("advanced-math-renderer");
+    expect(markup).toContain("index");
+    expect(markup).toContain("count");
+  });
+
   it("projects compact graph coordinates into the viewport", () => {
     const markup = render({
       kind: "graph_scene",

--- a/apps/web/src/features/playbook/engine/renderers/AdvancedMathRenderers.tsx
+++ b/apps/web/src/features/playbook/engine/renderers/AdvancedMathRenderers.tsx
@@ -329,45 +329,149 @@ function chartBounds(series: ChartSeries[]): { xMin: number; xMax: number; yMin:
   };
 }
 
+function AxisTitles({ theme, xLabel, yLabel }: { theme: ThemeName; xLabel?: string; yLabel?: string }) {
+  const colors = PALETTE[theme];
+  return (
+    <>
+      {xLabel ? (
+        <text x={(PLOT.left + SVG_W - PLOT.right) / 2} y={SVG_H - 6} fill={colors.muted} fontSize={13} textAnchor="middle">
+          {xLabel}
+        </text>
+      ) : null}
+      {yLabel ? (
+        <text
+          x={8}
+          y={(PLOT.top + SVG_H - PLOT.bottom) / 2}
+          fill={colors.muted}
+          fontSize={13}
+          textAnchor="middle"
+          transform={`rotate(-90 8 ${(PLOT.top + SVG_H - PLOT.bottom) / 2})`}
+        >
+          {yLabel}
+        </text>
+      ) : null}
+    </>
+  );
+}
+
+function CategoricalBars({
+  series,
+  categories,
+  reveal,
+  theme,
+}: {
+  series: ChartSeries[];
+  categories: string[];
+  reveal: number;
+  theme: ThemeName;
+}) {
+  const colors = PALETTE[theme];
+  const slotCount = Math.max(categories.length, ...series.map((s) => chartPoints(s).length), 1);
+  const plotW = SVG_W - PLOT.left - PLOT.right;
+  const slotW = plotW / slotCount;
+  const values = series.flatMap((s) => chartPoints(s).map((p) => p.y));
+  const yMin = Math.min(0, ...values);
+  // Headroom so the tallest bar never touches the plot ceiling.
+  const yMax = Math.max(1, ...values) * 1.12;
+  const yTicks = [yMin, (yMin + yMax) / 2, yMax];
+  const groupW = Math.min(slotW * 0.6, 96);
+  const barW = Math.max(8, groupW / series.length);
+  return (
+    <>
+      <rect x={PLOT.left} y={PLOT.top} width={plotW} height={SVG_H - PLOT.top - PLOT.bottom} fill="transparent" stroke={colors.line} />
+      {yTicks.map((tick) => (
+        <g key={`y-${tick}`}>
+          <line x1={PLOT.left} x2={SVG_W - PLOT.right} y1={sy(tick, yMin, yMax)} y2={sy(tick, yMin, yMax)} stroke={colors.grid} />
+          <text x={44} y={sy(tick, yMin, yMax) + 4} fill={colors.muted} fontSize={12} textAnchor="end">{tick.toFixed(1)}</text>
+        </g>
+      ))}
+      {series.map((oneSeries, seriesIndex) => {
+        const color = oneSeries.emphasis === "accent" ? colors.accent : oneSeries.emphasis === "secondary" ? colors.secondary : colors.primary;
+        return chartPoints(oneSeries).map((point, index) => {
+          const slotCenter = PLOT.left + (index + 0.5) * slotW;
+          const x = slotCenter - groupW / 2 + seriesIndex * barW;
+          return (
+            <rect
+              key={`${oneSeries.label}-${index}`}
+              x={x}
+              y={sy(point.y * reveal, yMin, yMax)}
+              width={barW}
+              height={Math.max(0, sy(0, yMin, yMax) - sy(point.y * reveal, yMin, yMax))}
+              fill={color}
+              opacity={0.78}
+              rx={4}
+            />
+          );
+        });
+      })}
+      {categories.map((category, index) => (
+        <text
+          key={`cat-${index}`}
+          x={PLOT.left + (index + 0.5) * slotW}
+          y={SVG_H - 25}
+          fill={colors.ink}
+          fontSize={13}
+          textAnchor="middle"
+        >
+          {category}
+        </text>
+      ))}
+    </>
+  );
+}
+
 export const StatsChartSceneRenderer: React.FC<RendererProps> = ({ step, frame, stepStartFrame, theme }) => {
   const snap = step.snapshot as StatsChartSceneSnapshot;
   const colors = PALETTE[theme];
   const bounds = chartBounds(snap.series ?? []);
   const reveal = progressOpacity(frame, stepStartFrame, 4);
+  const chartType = snap.chart_type ?? "line";
+  const barLike = chartType === "bar" || chartType === "histogram";
+  const categories = snap.categories ?? [];
+  const categorical = barLike && categories.length > 0;
+  const plotLeft = PLOT.left;
+  const plotRight = SVG_W - PLOT.right;
   return (
     <Shell title={step.title} caption={snap.caption} formula={snap.formula_latex} theme={theme}>
       <svg viewBox={`0 0 ${SVG_W} ${SVG_H}`} width="100%" height="100%">
-        <AxisFrame theme={theme} {...bounds} />
-        {(snap.series ?? []).map((series, seriesIndex) => {
-          const pts = chartPoints(series);
-          const color = series.emphasis === "accent" ? colors.accent : series.emphasis === "secondary" ? colors.secondary : colors.primary;
-          if ((snap.chart_type ?? "line") === "bar" || (snap.chart_type ?? "line") === "histogram") {
-            const barW = Math.max(8, (SVG_W - PLOT.left - PLOT.right) / Math.max(pts.length * 1.8, 1));
-            return pts.map((point, index) => (
-              <rect
-                key={`${series.label}-${index}`}
-                x={sx(point.x, bounds.xMin, bounds.xMax) - barW / 2}
-                y={sy(point.y * reveal, bounds.yMin, bounds.yMax)}
-                width={barW}
-                height={Math.max(0, sy(0, bounds.yMin, bounds.yMax) - sy(point.y * reveal, bounds.yMin, bounds.yMax))}
-                fill={color}
-                opacity={0.78}
-                rx={4}
-              />
-            ));
-          }
-          return (
-            <polyline
-              key={series.label || seriesIndex}
-              points={pointsPath(pts.slice(0, Math.max(1, Math.ceil(pts.length * reveal))).map((p) => [p.x, p.y]), bounds.xMin, bounds.xMax, bounds.yMin, bounds.yMax)}
-              fill="none"
-              stroke={color}
-              strokeWidth={4}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          );
-        })}
+        {categorical ? (
+          <CategoricalBars series={snap.series ?? []} categories={categories} reveal={reveal} theme={theme} />
+        ) : (
+          <>
+            <AxisFrame theme={theme} {...bounds} />
+            {(snap.series ?? []).map((series, seriesIndex) => {
+              const pts = chartPoints(series);
+              const color = series.emphasis === "accent" ? colors.accent : series.emphasis === "secondary" ? colors.secondary : colors.primary;
+              if (barLike) {
+                const barW = Math.max(8, (SVG_W - PLOT.left - PLOT.right) / Math.max(pts.length * 1.8, 1));
+                return pts.map((point, index) => (
+                  <rect
+                    key={`${series.label}-${index}`}
+                    x={Math.min(Math.max(sx(point.x, bounds.xMin, bounds.xMax) - barW / 2, plotLeft), plotRight - barW)}
+                    y={sy(point.y * reveal, bounds.yMin, bounds.yMax)}
+                    width={barW}
+                    height={Math.max(0, sy(0, bounds.yMin, bounds.yMax) - sy(point.y * reveal, bounds.yMin, bounds.yMax))}
+                    fill={color}
+                    opacity={0.78}
+                    rx={4}
+                  />
+                ));
+              }
+              return (
+                <polyline
+                  key={series.label || seriesIndex}
+                  points={pointsPath(pts.slice(0, Math.max(1, Math.ceil(pts.length * reveal))).map((p) => [p.x, p.y]), bounds.xMin, bounds.xMax, bounds.yMin, bounds.yMax)}
+                  fill="none"
+                  stroke={color}
+                  strokeWidth={4}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              );
+            })}
+          </>
+        )}
+        <AxisTitles theme={theme} xLabel={snap.x_label} yLabel={snap.y_label} />
       </svg>
     </Shell>
   );

--- a/apps/web/src/features/playbook/engine/types.ts
+++ b/apps/web/src/features/playbook/engine/types.ts
@@ -397,6 +397,9 @@ export interface StatsChartSceneSnapshot {
   series: ChartSeries[];
   x_label?: string;
   y_label?: string;
+  /** Category names for bar/histogram charts, one per series value; enables
+   *  categorical layout with per-bar labels instead of a numeric index axis. */
+  categories?: string[];
   current_index?: number | null;
   formula_latex?: string | null;
   caption?: string | null;

--- a/docs/worklogs/render-pipeline-e2e-2026-09.md
+++ b/docs/worklogs/render-pipeline-e2e-2026-09.md
@@ -1,0 +1,104 @@
+# 渲染 Pipeline 多学科端到端验证（2026-09）
+
+对 `main`（`7e37509`）的完整渲染链路做了一次跨学科端到端验证：
+`POST /api/v1/pipeline` → CoverageDecision → LessonPlan → PlaybookScript →
+canonical QualityReport → DirectorScript → Remotion 静帧 → MP4 导出。
+
+复现命令见 [`scripts/e2e_render_pipeline.py`](../../scripts/e2e_render_pipeline.py)。
+
+## 运行方式
+
+- Edition `self`，`METAVIEW_GENERATION_MODE=single`，`METAVIEW_ROUTER_MODE=heuristic`。
+- 无 LLM 凭据。25 条用例全部命中 deterministic SkillPack 或 capability 拒绝路径，
+  `generator_path` 均为 `skill_pack` / `capability_resolution`，**没有一条走 mock provider**，
+  因此结论反映的是真实确定性生成链路，而不是 mock 桩。
+- 提示词直接取自各 SkillPack manifest 里声明的 capability `examples`。
+- 生产写入限流 `10/minute` 保持开启，驱动脚本用退避而不是关限流。
+
+## 结果
+
+| 学科 | 通过 / 用例 |
+|---|---|
+| math | 5 / 9 |
+| algorithm | 2 / 4 |
+| physics | 2 / 2 |
+| chemistry | 4 / 4 |
+| biology | 3 / 3 |
+| geography | 3 / 3 |
+| 合计 | **18 / 25** |
+
+18 条成功用例全部渲染出静帧（68 张 PNG），DirectorScript 均带 beats。
+BFS 用例的 MP4 导出验证通过：1920×1080、30fps、1122 帧、37.46s、h264。
+
+## 发现
+
+### 1. SkillPack 路由被抢占，两条 manifest 自带示例无法到达自己的 Skill
+
+`SkillRegistry.heuristic_match` 取最大 confidence，而各 Skill 的 confidence 是常量：
+
+- `求 A=[[1,2],[3,4]] 的特征值` → `probability_statistics_core` (0.90)
+  压过 `linear_algebra` (0.87)。这是 `linear_algebra` manifest 自己的
+  `eigen_basic` 示例；统计包的列联表正则 `(\[\s*\[.*?\]\s*\])` 会认领任意二维方括号，
+  即使提示词里有「特征值」。
+- `解释 Dijkstra：A->B=2, B->C=1，求 A 到 C 最短路` → `linear_algebra` (0.87)
+  压过 `algorithm_graph_core` (0.86)，随后 CoverageResolver 判为 `unsupported`
+  并直接拒绝生成。这是 `algorithm_graph_core` manifest 自己的 `dijkstra` 示例。
+
+常量 confidence 没有表达「关键词命中强度」，谁的常量大谁赢。
+
+### 2. `calculus_core` 三个 capability 全部被质量门拦下
+
+`derivative` / `integral_area` / `limit_1var` 均以 `step.does_not_answer_prompt`
+（ERROR）+ `quality.repair_unavailable` 失败，即整个微积分包目前产不出可用讲解。
+
+根因在 [`calculus_core/playbook_adapter.py`](../../apps/api/app/domain/skills/calculus_core/playbook_adapter.py)
+的 `_script()`：步骤 `voiceover_text` 直接取 snapshot 的 `caption`，末步 caption 是
+「最终结果。」「整理答案。」这类占位语，标题取自固定数组 `[..., "总结"]`。
+真正的答案只存在于 `MathFormulaSnapshot.formula_latex` 的 `\boxed{...}` 里，
+而质量门的 `_check_final_step_answers_prompt` 只对 `title + voiceover_text` 取 token，
+永远看不到公式，于是 prompt token 与末步 token 交集恒为空。
+
+`derivative` 还额外缺 LessonPlan 声明的 required fact `tangent` 与 visual roles
+`secant` / `tangent` / `target_point`。
+
+质量门的判定是对的——末步确实没说出答案；缺陷在适配器。
+
+### 3. `algorithm_graph_core` 只为 BFS 填充遍历状态
+
+[`playbook_adapter.py`](../../apps/api/app/domain/skills/algorithm_graph_core/playbook_adapter.py)
+的 `_graph_visual_state()` 只在 `solution.kind == "bfs"` 时填 `visited_node_ids` /
+`queue_node_ids`，其余算法走兜底分支，两者都是 `[]`。
+质量门 `_snapshot_has_graph_traversal_state` 要求 `graph_scene` 有非空 `visited_node_ids`，
+所以 DFS 被 `algorithm.state_missing` 拦下。
+
+拓扑排序侥幸通过只是因为它的提示词不含「遍历」标记，走了更宽松的
+`_snapshot_has_algorithm_state` 分支——同一个缺陷在两条用例上判定不一致。
+
+### 4. `stats_chart_scene` 柱状图丢掉分类轴（跨学科）
+
+[`AdvancedMathRenderers.tsx`](../../apps/web/src/features/playbook/engine/renderers/AdvancedMathRenderers.tsx)
+的 `StatsChartSceneRenderer` 从未读取 `snap.x_label` / `snap.y_label`，
+契约里声明了也不会渲染；柱子按数值索引落在连续轴上。
+
+结果是分类数据被画成数值轴：
+- biology-monohybrid：`x_label="表现型"`、`y_label="概率"`，画面上 x 轴刻度是 `0.0 / 0.5 / 1.0`，
+  看不出哪根柱子是显性、哪根是隐性。
+- geography-climate-compare：两个站点的对比同样退化成 `0.0 / 0.5 / 1.0`。
+
+另外末柱以 `xMax` 为中心绘制，有一半溢出绘图区右边界。
+
+### 5. 物理 `motion_scene` 忽略斜面几何，且动画中标签相撞
+
+`斜面倾角 30°…` 与 `水平拉力…` 两条提示词生成的 `motion_scene` snapshot
+除 summary 文案外**逐字节相同**：都是 `y=0` 的水平轴、`y=0` 的物体、水平速度矢量。
+倾角没有进入场景，画面在讲「沿斜面下滑」时显示的是水平运动。
+
+同一场景里 `axis` 的标签「运动方向」固定在线段中点，`body` 沿 `x` 轨道动画穿过中点，
+两个标签在步骤中后段重叠成不可读的字形。这正是 `make visual-check` 想守住的
+annotation-collision 不变量，但它出现在新生成的内容上，而不是已冻结的 fixture。
+
+## 未覆盖
+
+- `code` 学科：没有确定性 SkillPack，需要真实 LLM 凭据，本次未验证。
+- `agent` 模式、Follow-up 与版本恢复、带音轨导出（beta）未验证。
+- 真实生产部署不可达（沙箱网络策略拒绝 `metaview.top`），本次验证对象是 `main` 分支代码。

--- a/docs/worklogs/render-pipeline-e2e-2026-09.md
+++ b/docs/worklogs/render-pipeline-e2e-2026-09.md
@@ -277,3 +277,24 @@ SYSTEM_PROMPT 的工作流纪律本身写得不错（LessonPlan 绑定、断言�
    `handled: false` 时回显期望 spec 与失败原因，`ok` 不再恒为 true。
 5. 表达式语法契约写进 SYSTEM_PROMPT 与各 SKILL.md。
 6. 统一 `tool`/`name` 与 `expression*` 命名，schema 里去掉 `run_id`、`from_` 泄漏。
+
+## 修复落地（2026-09-01）
+
+以上发现已拆为 issue #279–#287 并在同一分支实现（#287 为需要产品决策的
+编排 epic，未实现）：
+
+| Issue | 内容 | 验证 |
+|---|---|---|
+| #279 | 工具报错拼全字段路径；solve 失败区分 invalid_problem_spec | pytest 回显断言 |
+| #280 | expand 边界表达式 fail-fast；语法契约进 SYSTEM_PROMPT/SKILL.md | `x**2`/`\sin` 立即报错 |
+| #281 | 199 个参数字段补描述；show_tangent 缺省自动求切线；solve 导出真 spec schema | schema 全量断言 |
+| #282 | 统计包不再认领裸数字列表；`->` 不再当方程；conic 焦点定义兜底 | manifest 57 例全量路由回归 |
+| #283 | calculus 末步陈述答案；导数默认进切线弧；统计答案加中文标签 | 真实 pipeline 4 例 succeeded |
+| #284 | dfs/dijkstra/topo 从过程表填遍历状态 | DFS/Dijkstra E2E succeeded |
+| #285 | stats_chart_scene 增 categories，渲染分类名与轴标题，末柱不溢出 | 渲染截图核对 |
+| #286 | 斜面按真实倾角作画；方向标签移出运动路径 | 渲染截图核对 |
+
+复验：第一轮 E2E 的 7 条失败用例（3 条 calculus、DFS、Dijkstra、特征值、
+描述统计）全部经真实 pipeline 转为 succeeded；biology/geography 柱状图与
+两条物理场景重渲染确认视觉修复。`code` 学科与 agent 模式仍未覆盖（无 LLM
+凭据），#287 待决策。

--- a/docs/worklogs/render-pipeline-e2e-2026-09.md
+++ b/docs/worklogs/render-pipeline-e2e-2026-09.md
@@ -102,3 +102,88 @@ annotation-collision 不变量，但它出现在新生成的内容上，而不�
 - `code` 学科：没有确定性 SkillPack，需要真实 LLM 凭据，本次未验证。
 - `agent` 模式、Follow-up 与版本恢复、带音轨导出（beta）未验证。
 - 真实生产部署不可达（沙箱网络策略拒绝 `metaview.top`），本次验证对象是 `main` 分支代码。
+
+## 追加诊断：为什么生成质量和 Gold Template 差这么远
+
+上面五条是症状。把「模板」和「生成内容」放在同一把尺子下量，根因是**编排短路**，
+不是 renderer。
+
+### 快照词汇表对比
+
+| snapshot kind | Gold Template（人工编写） | Pipeline 生成（69 步） |
+|---|---|---|
+| `math_plot` | 12 | **0** |
+| `math_scene` | 11 | **0** |
+| `physics_force_scene` | 4 | **0** |
+| `algorithm_bars` / `algorithm_array` | 5 | **0** |
+| `phase_portrait_scene` | 2 | 0 |
+| `code_trace_scene` | 1 | 0 |
+| `math_formula` | 2（5%） | **32（46%）** |
+| `table_scene` | 0 | **18（26%）** |
+| 交互控件 | 56 | **0** |
+
+renderer registry 注册了 28 个 renderer，生成内容只用到 6 个，其中 72% 是
+公式卡加表格。chemistry 有 `reaction_scene` / `molecule_2d_scene` 却在画表格，
+biology 有 `bio_cell_scene` / `bio_process_scene` 却在画表格，geography 有
+`geo_map_scene` 却在画表格。
+
+### 不是 renderer 的问题
+
+模板和生成内容走的是同一套 renderer、同一条 Remotion 出口。模板好看是因为喂给
+renderer 的是富数据（`math_scene` 的几何对象、`math_plot` 的多曲线与 marker）。
+28 个 renderer 本身工作正常——本次 18 条成功用例全部渲染出静帧，MP4 导出也通过。
+
+### 工具是「暴露了但够不着」
+
+`GET /api/v1/agent/animation-tools` 暴露了 13 个动画工具，其中
+`math.show_tangent` / `math.show_derivative_compare` / `math.show_integral_area`
+正是导数模板需要的能力。实测调用：
+
+```
+POST /api/v1/agent/animation-tools/expand
+{"tool":"math.show_tangent","args":{"expression":"x^2*sin(x)","x0":1.0,
+ "tangent_expression":"2.22*(x-1)+0.841","x_min":-6,"x_max":6}}
+```
+
+返回一个 `math_plot` layer：原函数曲线（primary）+ 切线（secondary，标注「切线 (x=1.0)」）
++ `marker_x=1.0`，外加一个 `narration_card`。`issues` 为空。
+这正好满足 calculus LessonPlan 要求的 `secant` / `tangent` / `target_point` 三个
+visual role——也就是发现 2 里被判定「缺失」的那三个。
+
+工具能用，但它只挂在 agent 路径上，而 agent 路径在这些提示词上根本不会执行。
+
+### 短路点
+
+[`run_pipeline.py:243`](../../apps/api/app/application/use_cases/run_pipeline.py)（single 模式）：
+
+```python
+if route_match is not None and route_context.coverage_decision.mode == "specialized":
+    handled = await self._try_execute_skill(...)
+    if handled:
+        return          # ← LLM / 动画工具永远到不了
+await self._execute_single(...)
+```
+
+agent 模式同样受限，`can_execute_skill` 的判据一模一样：
+
+```python
+can_execute_skill=lambda ctx: (... and ctx.coverage_decision.mode == "specialized")
+```
+
+于是对这 13 个 SkillPack 覆盖的学科，**两种生成模式下 agent 与 13 个动画工具都被绕过**，
+输出质量的上限就是确定性 adapter 的快照词汇表：34 个 `MathFormulaSnapshot` +
+13 个 `TableSceneSnapshot`，13 个包加起来只有 1 个 `MathSceneSnapshot`。
+
+确定性 SkillPack 保证了「算得对」（本次化学配平、遗传比例、高斯消元结果都正确），
+但同时封死了「讲得好」的通道。发现 2 的「末步不陈述答案」正是这个上限的直接表现：
+adapter 只会把答案塞进 `\boxed{}` 公式卡。
+
+### 修的方向
+
+问题在优先级，不在缺工具。三条路，代价递增：
+
+1. SkillPack 保留 solve（算得对），把 render 交给动画工具——adapter 输出
+   `math_plot` / `math_scene` 而不是公式卡。改动集中在各 `playbook_adapter.py`。
+2. 让 `specialized` 覆盖走「skill 出数据 + agent 出画面」，而不是 skill 独占并 return。
+3. 给 adapter 补 `parameter_controls`，否则 README 承诺的参数互动轨道在生成内容上
+   始终是空的。

--- a/docs/worklogs/render-pipeline-e2e-2026-09.md
+++ b/docs/worklogs/render-pipeline-e2e-2026-09.md
@@ -187,3 +187,93 @@ adapter 只会把答案塞进 `\boxed{}` 公式卡。
 2. 让 `specialized` 覆盖走「skill 出数据 + agent 出画面」，而不是 skill 独占并 return。
 3. 给 adapter 补 `parameter_controls`，否则 README 承诺的参数互动轨道在生成内容上
    始终是空的。
+
+## 追加审计：agent 工具面（描述、schema、报错回显）
+
+用「一个只能看到工具名 + description + args_schema 的 LLM」的标准，把
+`/api/v1/agent/animation-tools`、`/api/v1/agent/runtime-tools`、geometry asserts
+和 sidecar Drawing 工具过了一遍，全部为实测结果。
+
+### T1. 参数字段描述覆盖率为 0
+
+13 个动画工具 101 个参数字段、22 个 runtime 工具 98 个参数字段，
+**199 个字段没有一个带 `description`**。单位、表达式语法、枚举含义、
+`alleles` 与 `cells` 的布局关系、`role` 的合法取值，agent 全靠猜。
+Pydantic 的 `Field(description=...)` 会自动进 json schema，属于纯增量修复。
+
+### T2. 描述不准确 / 埋雷
+
+- `math.show_tangent` 的描述是 "Show a function and tangent line at a selected
+  x value"，但 required 里有 `tangent_expression`——**切线要调用方自己算**，
+  描述只字未提；且服务端不校验它是不是真切线：给 `x^2` 在 `x0=1` 配上
+  `100*x-500`，返回 `issues: []`。`show_derivative_compare` 的
+  `derivative_expression` 同理。错误画面就是这样带着「成功」标记流下去的。
+- `skill.*.solve` 的 description 直接复用 manifest 一句话（"Deterministic
+  single-variable calculus explanations."），`problem_spec` 在 schema 里是
+  `{"type": "object"}` 黑箱——真实的 `CalculusCoreProblemSpec` 有 9 个字段和
+  `task` Literal 枚举，agent 无从得知。
+- sidecar `add_curve_parametric` 的语法说明是循环引用："Expressions use the
+  same character set MathPlotRenderer accepts"——模型读不到 MathPlotRenderer。
+
+### T3. 报错回显丢关键信息
+
+- [`animation_tools/registry.py:153`](../../apps/api/app/domain/animation_tools/registry.py)
+  只取 `exc.errors()[0].get("msg")`：**丢字段路径、丢其余所有错误**。实测缺
+  `tangent_expression` 时回显是 `Invalid args ...: Field required`——不说缺哪个；
+  `forces[0].magnitude` 传字符串时回显 `Input should be a valid number`——不说哪个字段。
+- `skill.calculus_core.solve` 传错 args 形状时返回
+  `{"ok": true, "handled": false, "fallback_reason": "unsupported_calculus_core"}`：
+  成功标志位为 true，理由撒谎（不是能力不支持，是 args 不对），没有任何
+  「期望的 spec 长这样」提示。schema 广告的 `required: ["run_id","prompt"]`
+  实际也不执行——不传照样跑。
+- `animation_tool.unknown_tool` 不回可用工具列表或最近似名。
+- 对照组：geometry assert 走 FastAPI 原生 422，带全部 `loc`，反而是可用的。
+
+### T4. 校验时机太晚（fail-late 而非 fail-fast）
+
+表达式语法后端前端是一致的（都收 `x^2`/`sin(x)`，都拒 `x**2`/`\sin(x)`，
+`safe_math_expr.py` 与 `mathExpr.ts` 实测无漂移）——但这套校验**不在工具边界上跑**：
+
+- `animation-tools/expand` 对 `\sin(x)`、`x**2` 一律 `issues: []` 放行；
+  错误要等整份 Playbook 进 canonical gate 才爆（`math.expression_invalid`），
+  报错已经和当初那次工具调用脱钩，agent 只能整轮重来。
+- Drawing 路径同样只在 `finalize_playbook` 后的 self-check 里验表达式：
+  第 3 步埋的雷，画完 14 步才响。
+
+而 LLM 默认吐 Python（`**`）或 LaTeX（`\sin`）语法；`^` 才是本仓库的方言，
+这条方言在 SYSTEM_PROMPT、8 份 SKILL.md、35 个工具描述里**一处都没写**
+（唯一一处是 T2 那句循环引用）。
+
+### T5. 命名不一致
+
+list 返回 `name` 字段，`expand`/`execute` 请求体却要 `tool`（我第一次就猜成
+`tool_id`）；动画工具用 `expression`，geometry assert 用
+`expression_x/expression_y/t_min`；`math.show_integral_area` 的 `from_`
+（Python 关键字规避 + alias "from"）直接泄漏进 schema；`skill.*.solve` 要求
+agent 提供 `run_id` 这种 harness 内部字段。
+
+### T6. 暴露形态：两跳 + free-form JSON
+
+sidecar 只给 LLM 两个动画工具：`animation_tool_list` 和
+`animation_tool_expand(tool, args: Record<string, unknown>)`。13 个工具不是
+一等 function-calling 工具，args 在模型侧没有 schema 约束——每个参数错误都
+变成一次运行时往返，而往返的报错又丢路径（T3）。模型必须先 list、再从返回
+文本里自行解析 json schema、再盲填 free-form args。
+
+### 好的一面
+
+SYSTEM_PROMPT 的工作流纪律本身写得不错（LessonPlan 绑定、断言前置、
+参数控件规则、禁止发明字段）；表达式语法前后端无漂移；geometry assert 的
+422 回显完整。问题集中在工具边界的描述与回显，不在工作流设计。
+
+### 修复优先级
+
+1. `registry.py:153`：拼接全部 `exc.errors()` 的 `loc + msg`（一行级改动，收益最大）。
+2. `expand` 边界上对所有表达式字段跑 `compile_safe_math_expression`，
+   报错附语法提示（「用 `^` 表示幂，不支持 `**` 与 LaTeX 反斜杠」）。
+3. 给 199 个参数字段补 `Field(description=...)`；`show_tangent` 要么在描述里
+   写明「切线表达式需调用方计算」，要么后端用 sympy 自己算（能力现成）。
+4. `skill.*.solve` 用 `model_json_schema()` 导出真实 ProblemSpec；
+   `handled: false` 时回显期望 spec 与失败原因，`ok` 不再恒为 true。
+5. 表达式语法契约写进 SYSTEM_PROMPT 与各 SKILL.md。
+6. 统一 `tool`/`name` 与 `expression*` 命名，schema 里去掉 `run_id`、`from_` 泄漏。

--- a/scripts/e2e_render_pipeline.py
+++ b/scripts/e2e_render_pipeline.py
@@ -1,0 +1,175 @@
+"""Multi-discipline end-to-end check of the rendering pipeline.
+
+Drives a running MetaView API through the full contract chain for one prompt
+per capability -- ``POST /api/v1/pipeline`` -> CoverageDecision -> LessonPlan ->
+PlaybookScript -> canonical QualityReport -> DirectorScript -- and writes each
+run plus a machine-readable summary under ``eval/reports/`` (git-ignored).
+
+The prompts are the capability examples declared by the deterministic
+SkillPack manifests, so a failure here means a shipped capability cannot
+produce a lesson for its own documented example.
+
+Usage:
+    .venv/bin/python scripts/e2e_render_pipeline.py [--api http://127.0.0.1:8000]
+
+Rendering the resulting Playbooks is a separate step; feed the files written to
+``eval/reports/e2e/playbooks/`` to ``apps/web/scripts/render-shots.mjs``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+import time
+
+import httpx
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_OUT = REPO_ROOT / "eval" / "reports" / "e2e"
+
+# (case_id, discipline, prompt) -- prompts are SkillPack manifest examples.
+CASES: list[tuple[str, str, str]] = [
+    ("math-calculus-derivative", "math", "求 d/dx (x^2 sin x)"),
+    ("math-calculus-integral", "math", "解释 int_0^1 x^2 dx 的面积"),
+    ("math-calculus-limit", "math", "求 lim x->0 sin(x)/x"),
+    ("math-elementary-algebra", "math", "解方程 2x+3=11"),
+    ("math-quadratic-factor", "math", "因式分解 x^2-5x+6"),
+    ("math-linear-eigen", "math", "求 A=[[1,2],[3,4]] 的特征值"),
+    ("math-linear-gauss", "math", "对 [[1,2,3],[3,4,7]] 做高斯消元"),
+    ("math-stats-descriptive", "math", "总体数据 [2,4,4,4,5,5,7,9]，求均值、中位数、众数和极差"),
+    ("math-stats-binomial", "math", "二项分布 n=5, p=0.2, k=2，求概率"),
+    ("algorithm-bfs", "algorithm", "用 BFS 遍历图 A-B, A-C, B-D，从 A 开始"),
+    ("algorithm-dfs", "algorithm", "用 DFS 遍历图 A-B, A-C, B-D，从 A 开始"),
+    ("algorithm-dijkstra", "algorithm", "解释 Dijkstra：A->B=2, B->C=1，求 A 到 C 最短路"),
+    ("algorithm-toposort", "algorithm", "对有向图 A->B, A->C, B->D 做拓扑排序"),
+    ("physics-newton-second", "physics", "质量 2kg 的物体受到 10N 水平拉力，忽略摩擦，求加速度"),
+    ("physics-incline", "physics", "斜面倾角 30°，物体质量 1kg，忽略摩擦，求沿斜面下滑的加速度"),
+    ("chemistry-balance", "chemistry", "配平 Fe + O2 -> Fe2O3"),
+    ("chemistry-molar-mass", "chemistry", "求 H2O 的摩尔质量"),
+    ("chemistry-limiting", "chemistry", "10g H2 与 80g O2 反应生成水，判断限量反应物并求理论产量"),
+    ("chemistry-concentration", "chemistry", "0.5mol NaOH 溶于 1L 水，求物质的量浓度"),
+    ("biology-monohybrid", "biology", "A 对 a 显性，亲本 Aa x Aa，求基因型比例和表现型比例"),
+    ("biology-testcross", "biology", "A 对 a 显性，亲本 Aa x aa，做 test cross 并画 Punnett 表"),
+    ("biology-dihybrid", "biology", "A 对 a 显性，B 对 b 显性，亲本 AaBb x AaBb，求表现型比例"),
+    ("geography-climate-normals", "geography", "离线教学站点 EDU_TEMPERATE 的气候常年值摘要"),
+    ("geography-climate-compare", "geography", "比较 EDU_TEMPERATE 和 EDU_ARID 的年均温和年降水"),
+    ("geography-climate-anomaly", "geography", "EDU_TEMPERATE 7月观测气温 28C，求距平"),
+]
+
+
+def submit(client: httpx.Client, api: str, prompt: str) -> str:
+    """Submit one run, backing off on the API's production write rate limit."""
+    for _ in range(12):
+        response = client.post(f"{api}/api/v1/pipeline", json={"prompt": prompt}, timeout=60)
+        if response.status_code == 429:
+            time.sleep(15.0)
+            continue
+        response.raise_for_status()
+        return response.json()["run_id"]
+    raise RuntimeError("still rate-limited after 12 submit attempts")
+
+
+def poll(client: httpx.Client, api: str, run_id: str, timeout: float = 300.0) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = client.get(f"{api}/api/v1/runs/{run_id}", timeout=60)
+        response.raise_for_status()
+        data = response.json()
+        if data["status"] in {"succeeded", "failed"}:
+            return data
+        time.sleep(1.5)
+    raise TimeoutError(f"run {run_id} did not settle within {timeout}s")
+
+
+def summarize(case_id: str, discipline: str, prompt: str, run_id: str, data: dict) -> dict:
+    coverage = data.get("coverage_decision") or {}
+    report = data.get("quality_report") or {}
+    playbook = data.get("playbook") or {}
+    director = data.get("director") or {}
+    steps = playbook.get("steps") or []
+    issues = report.get("issues") or []
+    return {
+        "case_id": case_id,
+        "discipline": discipline,
+        "prompt": prompt,
+        "run_id": run_id,
+        "status": data["status"],
+        "coverage_mode": coverage.get("mode"),
+        "matched_skill_ids": coverage.get("matched_skill_ids"),
+        "generator_path": report.get("generator_path"),
+        "quality_status": report.get("status"),
+        "issue_codes": [issue.get("code") for issue in issues],
+        "step_count": len(steps),
+        "snapshot_kinds": sorted(
+            {(step.get("snapshot") or {}).get("kind") for step in steps} - {None}
+        ),
+        # DirectorScript carries "beats", not "shots".
+        "director_beat_count": len(director.get("beats") or []),
+        "error": data.get("error"),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api", default="http://127.0.0.1:8000")
+    parser.add_argument("--out", type=pathlib.Path, default=DEFAULT_OUT)
+    args = parser.parse_args()
+
+    runs_dir = args.out / "runs"
+    playbooks_dir = args.out / "playbooks"
+    directors_dir = args.out / "directors"
+    for directory in (runs_dir, playbooks_dir, directors_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict] = []
+    with httpx.Client() as client:
+        for case_id, discipline, prompt in CASES:
+            try:
+                run_id = submit(client, args.api, prompt)
+                data = poll(client, args.api, run_id)
+            except Exception as exc:  # noqa: BLE001
+                rows.append(
+                    {
+                        "case_id": case_id,
+                        "discipline": discipline,
+                        "prompt": prompt,
+                        "status": "driver_error",
+                        "error": repr(exc),
+                    }
+                )
+                print(f"[{case_id:28}] DRIVER ERROR {exc}", flush=True)
+                continue
+
+            (runs_dir / f"{case_id}.json").write_text(
+                json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+            if data.get("playbook"):
+                (playbooks_dir / f"{case_id}.json").write_text(
+                    json.dumps(data["playbook"], ensure_ascii=False), encoding="utf-8"
+                )
+            if data.get("director"):
+                (directors_dir / f"{case_id}.json").write_text(
+                    json.dumps(data["director"], ensure_ascii=False), encoding="utf-8"
+                )
+
+            row = summarize(case_id, discipline, prompt, run_id, data)
+            rows.append(row)
+            print(
+                f"[{case_id:28}] {row['status']:9} gate={row['quality_status']} "
+                f"path={row['generator_path']} coverage={row['coverage_mode']} "
+                f"steps={row['step_count']} beats={row['director_beat_count']}",
+                flush=True,
+            )
+
+    (args.out / "summary.json").write_text(
+        json.dumps(rows, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    succeeded = sum(1 for row in rows if row.get("status") == "succeeded")
+    print(f"\n{succeeded}/{len(rows)} succeeded -- report: {args.out / 'summary.json'}")
+    return 0 if succeeded == len(rows) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/metaview-agent/generic/SKILL.md
+++ b/skills/metaview-agent/generic/SKILL.md
@@ -35,3 +35,12 @@ Use this skill for every Codex agent generation in MetaView.
   current reasoning step.
 - Do not invent unsupported renderers, HTML, SVG-only scenes, Manim, iframe
   rendering, or server-side video output.
+
+## Expression Grammar
+
+Every `expression*` argument across drawing, animation, and assert tools uses
+one grammar: `^` for powers (never Python's `**`), plain function names such as
+`sin(x)`, `cos(t)`, `exp(x)`, `log(x)`, `sqrt(x)`, `abs(x)` (no LaTeX
+backslashes), explicit multiplication like `2*x`, and the constants `pi` and
+`e`. LaTeX belongs only in `formula_latex` arguments. An expression that
+violates this grammar renders as a blank curve, so fix it at authoring time.

--- a/skills/metaview-agent/math/SKILL.md
+++ b/skills/metaview-agent/math/SKILL.md
@@ -48,3 +48,12 @@ math explanations that were not fully handled by deterministic SkillPacks.
   transforms, frame counts, arbitrary JSON Patch operations, or unverified
   discriminant/intersection results. Do not copy public template scripts or
   embed hidden benchmark answers.
+
+## Expression Grammar
+
+All curve and validator expressions use the renderer grammar: `^` for powers
+(never `**`), plain function names (`sin(x)`, not `\sin(x)`), explicit
+multiplication (`2*x`), constants `pi` and `e`. LaTeX is only valid inside
+`formula_latex` / `add_formula`. Prefer omitting `tangent_expression` /
+`derivative_expression` in `math.show_tangent` / `math.show_derivative_compare`
+— the backend derives the true tangent/derivative symbolically.


### PR DESCRIPTION
新增 scripts/e2e_render_pipeline.py：用各 SkillPack manifest 自带的 capability
示例作为提示词，驱动真实 API 走完 CoverageDecision → LessonPlan → PlaybookScript
→ canonical QualityReport → DirectorScript，产物写入 git-ignored 的 eval/reports/。
保留生产写入限流，用退避而不是关限流。

对 main 跑了 25 条用例覆盖 math / algorithm / physics / chemistry / biology /
geography 六个学科，18 条通过并渲染出静帧，BFS 用例导出 1080p30 MP4 验证通过。
docs/worklogs/ 记录 7 条失败与 2 处视觉缺陷的根因：SkillPack 常量 confidence
导致路由抢占、calculus_core 末步不陈述答案、graph core 只为 BFS 填遍历状态、
stats_chart_scene 丢弃分类轴、physics motion_scene 忽略斜面几何且标签相撞。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P85BczZXd32Lja527VWUot