### PR TITLE
fix(skills): manifest 示例 55/55 过质量门，斜抛公式修正，题面表达式不再进 Python eval

### DIFF
--- a/apps/api/app/domain/skills/algebra_core/__init__.py
+++ b/apps/api/app/domain/skills/algebra_core/__init__.py
@@ -5,11 +5,13 @@ from app.domain.skills.algebra_core.models import (
     ParsedExpression,
 )
 from app.domain.skills.algebra_core.parser import (
+    UnsafeExpressionError,
     expression_to_source,
     extract_expression_after,
     parse_equation,
     parse_equation_list,
     parse_expression,
+    parse_number,
 )
 from app.domain.skills.algebra_core.solving import (
     equation_degree,
@@ -25,6 +27,7 @@ __all__ = [
     "AlgebraStep",
     "AlgebraSystem",
     "ParsedExpression",
+    "UnsafeExpressionError",
     "equation_degree",
     "equation_to_latex",
     "expression_to_source",
@@ -32,6 +35,7 @@ __all__ = [
     "parse_equation",
     "parse_equation_list",
     "parse_expression",
+    "parse_number",
     "solve_equation",
     "solve_inequality",
     "system_to_matrix",

--- a/apps/api/app/domain/skills/algebra_core/parser.py
+++ b/apps/api/app/domain/skills/algebra_core/parser.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import ast
 import re
 from collections.abc import Iterable
+from tokenize import TokenError
+from typing import Any, Final
 
 import sympy as sp
 from sympy.parsing.sympy_parser import (
     convert_xor,
+    eval_expr,
     implicit_multiplication_application,
-    parse_expr,
     standard_transformations,
+    stringify_expr,
 )
 
 from app.domain.skills.algebra_core.models import AlgebraEquation, AlgebraSystem, ParsedExpression
@@ -18,6 +22,190 @@ _TRANSFORMATIONS = standard_transformations + (
     implicit_multiplication_application,
     convert_xor,
 )
+
+
+class UnsafeExpressionError(ValueError):
+    """Raised when prompt-derived text falls outside the sandboxed algebra grammar."""
+
+
+# SymPy's ``parse_expr`` is ``eval`` on the transformed source: ``x.__class__``
+# survives tokenisation as ``Symbol('x').__class__`` and runs. The text we parse
+# comes from user prompts (routing runs before any auth in the self edition)
+# and from agent tool calls (``skill.<id>.solve`` accepts a free-form
+# ``problem_spec``), so it is treated exactly like ``geometry_validators`` treats
+# its inputs: the transformed code must pass an AST allowlist before evaluation.
+_MAX_SOURCE_CHARS: Final = 512
+_MAX_AST_NODES: Final = 160
+_SYMBOL_NAME_RE: Final = re.compile(r"[A-Za-z][A-Za-z0-9_]{0,15}")
+_NUMBER_TEXT_RE: Final = re.compile(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?")
+_FRACTION_TEXT_RE: Final = re.compile(r"(?P<num>[-+]?\d+)/(?P<den>\d+)")
+
+_FUNCTIONS: Final[dict[str, Any]] = {
+    "sin": sp.sin,
+    "cos": sp.cos,
+    "tan": sp.tan,
+    "cot": sp.cot,
+    "sec": sp.sec,
+    "csc": sp.csc,
+    "asin": sp.asin,
+    "acos": sp.acos,
+    "atan": sp.atan,
+    "acot": sp.acot,
+    "sinh": sp.sinh,
+    "cosh": sp.cosh,
+    "tanh": sp.tanh,
+    "asinh": sp.asinh,
+    "acosh": sp.acosh,
+    "atanh": sp.atanh,
+    "exp": sp.exp,
+    "log": sp.log,
+    "ln": sp.log,
+    "sqrt": sp.sqrt,
+    "cbrt": sp.cbrt,
+    "root": sp.root,
+    "Abs": sp.Abs,
+    "abs": sp.Abs,
+    "floor": sp.floor,
+    "ceiling": sp.ceiling,
+    "ceil": sp.ceiling,
+    "factorial": sp.factorial,
+    "binomial": sp.binomial,
+    "Max": sp.Max,
+    "Min": sp.Min,
+    "max": sp.Max,
+    "min": sp.Min,
+    "sign": sp.sign,
+}
+_CONSTANTS: Final[dict[str, Any]] = {"pi": sp.pi, "E": sp.E}
+# The tokens SymPy's own transformations emit for literals and free names.
+_CONSTRUCTORS: Final[dict[str, Any]] = {
+    "Symbol": sp.Symbol,
+    "Integer": sp.Integer,
+    "Float": sp.Float,
+    "Rational": sp.Rational,
+}
+_NAMESPACE: Final[dict[str, Any]] = {**_FUNCTIONS, **_CONSTANTS, **_CONSTRUCTORS}
+_ALLOWED_OPERATORS: Final = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.USub, ast.UAdd)
+
+
+class _AlgebraGuard(ast.NodeVisitor):
+    """Allowlist walker over the code ``stringify_expr`` produced.
+
+    Accepts arithmetic over numeric literals, ``Symbol('name')`` for free
+    variables, the constants above and direct calls to the math functions
+    above. Attribute access, subscripts, lambdas, comparisons, strings outside
+    a constructor and every other name are rejected before ``eval`` runs.
+    """
+
+    def __init__(self) -> None:
+        self._nodes = 0
+
+    def _count(self) -> None:
+        self._nodes += 1
+        if self._nodes > _MAX_AST_NODES:
+            raise UnsafeExpressionError("expression is too complex")
+
+    def generic_visit(self, node: ast.AST) -> None:
+        self._count()
+        allowed = (ast.Expression, ast.BinOp, ast.UnaryOp, ast.Load, *_ALLOWED_OPERATORS)
+        if not isinstance(node, allowed):
+            raise UnsafeExpressionError(f"unsupported syntax: {node.__class__.__name__}")
+        super().generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        self._count()
+        if not isinstance(node.func, ast.Name):
+            raise UnsafeExpressionError(
+                "only direct calls to whitelisted math functions are allowed"
+            )
+        if node.keywords:
+            raise UnsafeExpressionError("keyword arguments are not supported")
+        name = node.func.id
+        if name in _CONSTRUCTORS:
+            self._check_constructor(name, node.args)
+            return
+        if name not in _FUNCTIONS:
+            raise UnsafeExpressionError(f"unknown function: {name}")
+        for arg in node.args:
+            self.visit(arg)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        self._count()
+        if node.id not in _CONSTANTS:
+            raise UnsafeExpressionError(f"unknown name: {node.id}")
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        self._count()
+        if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
+            raise UnsafeExpressionError("only numeric constants are supported")
+
+    def _check_constructor(self, name: str, args: list[ast.expr]) -> None:
+        if name == "Symbol":
+            if (
+                len(args) != 1
+                or not isinstance(args[0], ast.Constant)
+                or not isinstance(args[0].value, str)
+                or not _SYMBOL_NAME_RE.fullmatch(args[0].value)
+                or "__" in args[0].value
+            ):
+                raise UnsafeExpressionError("unsupported symbol name")
+            self._count()
+            return
+        if not 1 <= len(args) <= 2:
+            raise UnsafeExpressionError(f"{name} expects one or two numeric arguments")
+        for arg in args:
+            self._check_numeric_literal(arg)
+
+    def _check_numeric_literal(self, node: ast.expr) -> None:
+        self._count()
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.USub, ast.UAdd)):
+            self._check_numeric_literal(node.operand)
+            return
+        if isinstance(node, ast.Constant):
+            value = node.value
+            if isinstance(value, bool):
+                raise UnsafeExpressionError("only numeric constants are supported")
+            if isinstance(value, (int, float)):
+                return
+            if isinstance(value, str) and _NUMBER_TEXT_RE.fullmatch(value):
+                return
+            raise UnsafeExpressionError("only numeric constants are supported")
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in {"Integer", "Rational", "Float"}
+        ):
+            self._check_constructor(node.func.id, node.args)
+            return
+        raise UnsafeExpressionError("only numeric constants are supported")
+
+
+def parse_number(value: int | float | str) -> sp.Expr:
+    """Turn a numeric literal from a ProblemSpec into a SymPy number without ``eval``.
+
+    Spec fields such as ``point``/``lower``/``upper`` or matrix entries may be
+    strings (regex captures, or free-form agent input); only plain decimal,
+    scientific and ``p/q`` forms are accepted.
+    """
+    if isinstance(value, bool):
+        raise UnsafeExpressionError("boolean is not a number")
+    if isinstance(value, int):
+        return sp.Integer(value)
+    if isinstance(value, float):
+        return sp.Float(value)
+    if not isinstance(value, str):
+        raise UnsafeExpressionError(f"unsupported numeric literal type: {type(value).__name__}")
+    text = value.strip()
+    fraction = _FRACTION_TEXT_RE.fullmatch(text)
+    if fraction is not None:
+        return sp.Rational(int(fraction.group("num")), int(fraction.group("den")))
+    if not _NUMBER_TEXT_RE.fullmatch(text):
+        raise UnsafeExpressionError(f"unsupported numeric literal: {value!r}")
+    if any(marker in text for marker in (".", "e", "E")):
+        return sp.Float(text)
+    return sp.Integer(int(text))
+
+
 _RELATION_RE = re.compile(r"(?P<lhs>.+?)(?P<rel><=|>=|=|<|>)(?P<rhs>.+)")
 _EXPR_TOKEN_RE = re.compile(r"[A-Za-z0-9_+\-*/().^]+")
 _LATEX_FRAC_RE = re.compile(r"\\frac\{([^{}]+)\}\{([^{}]+)\}")
@@ -108,11 +296,26 @@ def _normalize_expression_source(raw: str) -> str:
 
 
 def _parse_sympy(source: str) -> sp.Expr:
-    return parse_expr(
-        source,
-        transformations=_TRANSFORMATIONS,
-        evaluate=True,
-    )
+    if not source.strip() or len(source) > _MAX_SOURCE_CHARS:
+        raise UnsafeExpressionError("expression is empty or too long")
+    # A fresh namespace per parse: ``eval`` writes ``__builtins__`` into its
+    # globals, and the empty override keeps builtins out of reach even if the
+    # guard were ever bypassed.
+    global_dict: dict[str, Any] = {**_NAMESPACE, "__builtins__": {}}
+    local_dict: dict[str, Any] = {}
+    try:
+        code = stringify_expr(source, local_dict, global_dict, _TRANSFORMATIONS)
+        tree = ast.parse(code, mode="eval")
+    except (TokenError, SyntaxError, ValueError) as exc:
+        raise UnsafeExpressionError(f"cannot parse expression: {source!r}") from exc
+    _AlgebraGuard().visit(tree)
+    try:
+        expr = eval_expr(code, local_dict, global_dict)
+    except (TypeError, ValueError, ZeroDivisionError, AttributeError, sp.SympifyError) as exc:
+        raise UnsafeExpressionError(f"cannot evaluate expression: {source!r}") from exc
+    if not isinstance(expr, sp.Expr):
+        raise UnsafeExpressionError("expression did not produce a SymPy expression")
+    return expr
 
 
 def _relation_latex(lhs: sp.Expr, relation: str, rhs: sp.Expr) -> str:

--- a/apps/api/app/domain/skills/calculus_core/playbook_adapter.py
+++ b/apps/api/app/domain/skills/calculus_core/playbook_adapter.py
@@ -15,7 +15,7 @@ from app.domain.models.playbook import (
 )
 from app.domain.models.topic import TopicDomain
 from app.domain.services.playbook_quality import estimate_step_frames
-from app.domain.skills.algebra_core import expression_to_source, parse_expression
+from app.domain.skills.algebra_core import expression_to_source, parse_expression, parse_number
 from app.domain.skills.calculus_core.problem_spec import CalculusCoreProblemSpec
 
 _FPS = 30
@@ -70,7 +70,7 @@ def _build_derivative_tangent(
     symbol: sp.Symbol,
     derivative: sp.Expr,
 ) -> PlaybookScript:
-    point = sp.sympify(spec.point)
+    point = parse_number(spec.point)
     point_value = sp.simplify(expr.subs(symbol, point))
     tangent_slope = sp.simplify(derivative.subs(symbol, point))
     tangent_line = sp.expand(tangent_slope * (symbol - point) + point_value)
@@ -211,8 +211,8 @@ def _display(value: sp.Expr) -> str:
 def _build_integral(spec: CalculusCoreProblemSpec) -> PlaybookScript:
     expr, parsed = parse_expression(spec.expression)
     symbol = sp.Symbol(spec.variable)
-    lower = sp.sympify(spec.lower)
-    upper = sp.sympify(spec.upper)
+    lower = parse_number(spec.lower)
+    upper = parse_number(spec.upper)
     value = sp.simplify(sp.integrate(expr, (symbol, lower, upper)))
     integral_latex = (
         rf"\int_{{{sp.latex(lower)}}}^{{{sp.latex(upper)}}} "
@@ -261,7 +261,7 @@ def _build_integral(spec: CalculusCoreProblemSpec) -> PlaybookScript:
 def _build_limit(spec: CalculusCoreProblemSpec) -> PlaybookScript:
     expr, parsed = parse_expression(spec.expression)
     symbol = sp.Symbol(spec.variable)
-    point = sp.sympify(spec.point)
+    point = parse_number(spec.point)
     value = sp.simplify(sp.limit(expr, symbol, point))
     limit_latex = rf"\lim_{{{spec.variable}\to {sp.latex(point)}}} {parsed.latex}"
     snapshots = [
@@ -306,7 +306,7 @@ def _build_limit(spec: CalculusCoreProblemSpec) -> PlaybookScript:
 def _build_series(spec: CalculusCoreProblemSpec) -> PlaybookScript:
     expr, parsed = parse_expression(spec.expression)
     symbol = sp.Symbol(spec.variable)
-    point = sp.sympify(spec.point or 0)
+    point = parse_number(spec.point if spec.point is not None else 0)
     series = sp.series(expr, symbol, point, spec.order).removeO()
     snapshots = [
         MathFormulaSnapshot(

--- a/apps/api/app/domain/skills/elementary_algebra/playbook_adapter.py
+++ b/apps/api/app/domain/skills/elementary_algebra/playbook_adapter.py
@@ -18,6 +18,7 @@ from app.domain.skills.algebra_core import (
     solve_equation,
     solve_inequality,
 )
+from app.domain.skills.algebra_core.models import AlgebraEquation
 from app.domain.skills.elementary_algebra.problem_spec import ElementaryAlgebraProblemSpec
 
 _FPS = 30
@@ -47,7 +48,8 @@ def build_elementary_algebra_playbook(
                 caption="不等式的解用区间或逻辑条件表示。",
             )
         )
-        return _script(spec, "一元不等式", snapshots)
+        answer_text = f"所以不等式 {_relation_source(equation)} 的解集为 {_plain(result)}。"
+        return _script(spec, "一元不等式", snapshots, answer_text=answer_text)
 
     solutions, core_steps = solve_equation(equation, spec.variable)
     snapshots: list[MathFormulaSnapshot | TableSceneSnapshot] = [
@@ -72,7 +74,11 @@ def build_elementary_algebra_playbook(
         )
     )
     title = "一元一次方程" if spec.task == "linear_equation" else "一元二次方程"
-    return _script(spec, title, snapshots)
+    answer_text = (
+        f"所以方程 {_relation_source(equation)} 的解为 "
+        f"{_solutions_spoken(spec.variable, solutions)}。"
+    )
+    return _script(spec, title, snapshots, answer_text=answer_text)
 
 
 def _build_factor_playbook(spec: ElementaryAlgebraProblemSpec) -> PlaybookScript:
@@ -105,13 +111,16 @@ def _build_factor_playbook(spec: ElementaryAlgebraProblemSpec) -> PlaybookScript
             caption="最终输出保持为规范化因式乘积。",
         ),
     ]
-    return _script(spec, "多项式因式分解", snapshots)
+    answer_text = f"所以 {parsed.source} 因式分解的结果为 {_plain(factored)}。"
+    return _script(spec, "多项式因式分解", snapshots, answer_text=answer_text)
 
 
 def _script(
     spec: ElementaryAlgebraProblemSpec,
     title: str,
     snapshots: list[MathFormulaSnapshot | TableSceneSnapshot],
+    *,
+    answer_text: str | None = None,
 ) -> PlaybookScript:
     steps: list[MetaStep] = []
     captions = [
@@ -124,9 +133,15 @@ def _script(
     while len(snapshots) < 5:
         snapshots.append(snapshots[-1])
     frame_cursor = 0
-    for index, snapshot in enumerate(snapshots[:6]):
+    kept = snapshots[:6]
+    for index, snapshot in enumerate(kept):
         label = captions[index] if index < len(captions) else "补充说明"
         voiceover_text = _voiceover(label, snapshot)
+        if answer_text and index == len(kept) - 1:
+            # The final step must state the requested result in the prompt's
+            # own terms — a solution that only lives in the table never answers
+            # the question (same defect class as issue #283).
+            voiceover_text = f"{voiceover_text} {answer_text}".strip()
         frame_cursor += max(_STEP_FRAMES, estimate_step_frames(voiceover_text, _FPS))
         steps.append(
             MetaStep(
@@ -162,6 +177,21 @@ def _solutions_text(solutions: list[sp.Expr]) -> str:
     if not solutions:
         return "无解"
     return ", ".join(sp.latex(solution) for solution in solutions)
+
+
+def _solutions_spoken(variable: str, solutions: list[sp.Expr]) -> str:
+    if not solutions:
+        return "无解"
+    return "，".join(f"{variable}={_plain(solution)}" for solution in solutions)
+
+
+def _relation_source(equation: AlgebraEquation) -> str:
+    return f"{equation.lhs_source}{equation.relation}{equation.rhs_source}"
+
+
+def _plain(expr: sp.Basic) -> str:
+    # Narration reads the renderer dialect (``x^2``), not Python's ``**``.
+    return sp.sstr(expr).replace("**", "^")
 
 
 def _roots_latex(variable: str, roots: list[sp.Expr]) -> str:

--- a/apps/api/app/domain/skills/linear_algebra/playbook_adapter.py
+++ b/apps/api/app/domain/skills/linear_algebra/playbook_adapter.py
@@ -13,6 +13,7 @@ from app.domain.models.playbook import (
 )
 from app.domain.models.topic import TopicDomain
 from app.domain.services.playbook_quality import estimate_step_frames
+from app.domain.skills.algebra_core import parse_number
 from app.domain.skills.linear_algebra.problem_spec import LinearAlgebraProblemSpec
 
 _FPS = 30
@@ -23,7 +24,9 @@ def build_linear_algebra_playbook(
     run_id: str,  # noqa: ARG001
     spec: LinearAlgebraProblemSpec,
 ) -> PlaybookScript:
-    matrix = sp.Matrix(spec.matrix)
+    # ``sp.Matrix`` sympifies string entries (that is ``eval``); a spec that
+    # arrives from an agent tool call may carry strings, so parse literals only.
+    matrix = sp.Matrix([[parse_number(value) for value in row] for row in spec.matrix])
     if spec.task == "solve_system":
         return _build_solve_system(spec, matrix)
     if spec.task == "eigen_basic":
@@ -34,7 +37,7 @@ def build_linear_algebra_playbook(
 
 
 def _build_solve_system(spec: LinearAlgebraProblemSpec, matrix: sp.Matrix) -> PlaybookScript:
-    rhs = sp.Matrix(spec.rhs or [])
+    rhs = sp.Matrix([parse_number(value) for value in (spec.rhs or [])])
     augmented = matrix.row_join(rhs) if rhs.rows == matrix.rows else matrix
     rref, pivots = augmented.rref()
     variables = spec.variable_names or [f"x_{i + 1}" for i in range(matrix.cols)]

--- a/apps/api/app/domain/skills/physics_mechanics/mechanics_kernel.py
+++ b/apps/api/app/domain/skills/physics_mechanics/mechanics_kernel.py
@@ -101,6 +101,9 @@ def _solve_projectile(spec: PhysicsMechanicsProblemSpec) -> PhysicsMechanicsSolu
             f"落地时间 {values['time'].display}，"
             f"水平位移 {values['horizontal_range'].display}。{_PROJECTILE_MECHANISM}"
         )
+        vertical_latex = r"y=h-\frac{1}{2}gt^2"
+        vertical_caption = "竖直方向由重力产生加速度 g，从高度 h 落到地面的时间由它决定。"
+        horizontal_latex = "x=v_xt"
     else:
         speed = float(_value(spec, "initial_speed"))
         angle = math.radians(float(_value(spec, "angle_deg")))
@@ -119,6 +122,13 @@ def _solve_projectile(spec: PhysicsMechanicsProblemSpec) -> PhysicsMechanicsSolu
             f"最大高度 {values['max_height'].display}，"
             f"射程 {values['range'].display}。{_PROJECTILE_MECHANISM}"
         )
+        # An angled launch starts from the ground with an upward velocity
+        # component; the horizontal-launch formula y=h-½gt² does not apply.
+        vertical_latex = r"y=v_0\sin\theta\,t-\frac{1}{2}gt^2"
+        vertical_caption = (
+            "竖直方向先减速上升再加速下落，由重力产生加速度 g，决定最大高度与飞行时间。"
+        )
+        horizontal_latex = r"x=v_0\cos\theta\,t"
     return PhysicsMechanicsSolution(
         kind=spec.kind,
         steps=[
@@ -127,14 +137,10 @@ def _solve_projectile(spec: PhysicsMechanicsProblemSpec) -> PhysicsMechanicsSolu
                 "x,y",
                 "水平与竖直方向独立处理：水平方向不受力、保持匀速，竖直方向只受重力、匀加速。",
             ),
-            PhysicsMechanicsStep(
-                "竖直方向",
-                r"y=h-\frac{1}{2}gt^2",
-                "竖直方向由重力产生加速度 g，决定飞行时间。",
-            ),
+            PhysicsMechanicsStep("竖直方向", vertical_latex, vertical_caption),
             PhysicsMechanicsStep(
                 "水平方向",
-                "x=v_xt",
+                horizontal_latex,
                 "水平方向匀速运动给出位移，两个分运动合成抛物线轨迹。",
             ),
         ],

--- a/apps/api/app/domain/skills/physics_mechanics/mechanics_kernel.py
+++ b/apps/api/app/domain/skills/physics_mechanics/mechanics_kernel.py
@@ -77,6 +77,11 @@ def _solve_uniform(spec: PhysicsMechanicsProblemSpec) -> PhysicsMechanicsSolutio
     )
 
 
+# The projectile LessonPlan requires evidence for the gravity and parabolic
+# facts; the narration has to say them, a number table never does.
+_PROJECTILE_MECHANISM = "水平速度保持不变，竖直方向由重力加速，两个分运动合成抛物线轨迹。"
+
+
 def _solve_projectile(spec: PhysicsMechanicsProblemSpec) -> PhysicsMechanicsSolution:
     g = _value(spec, "g")
     if "height" in spec.values:
@@ -94,7 +99,7 @@ def _solve_projectile(spec: PhysicsMechanicsProblemSpec) -> PhysicsMechanicsSolu
         )
         text = (
             f"落地时间 {values['time'].display}，"
-            f"水平位移 {values['horizontal_range'].display}。"
+            f"水平位移 {values['horizontal_range'].display}。{_PROJECTILE_MECHANISM}"
         )
     else:
         speed = float(_value(spec, "initial_speed"))
@@ -110,13 +115,28 @@ def _solve_projectile(spec: PhysicsMechanicsProblemSpec) -> PhysicsMechanicsSolu
             rf"H=\frac{{v_0^2\sin^2\theta}}{{2g}}={_fmt(max_height)}\,\text{{m}},\quad "
             rf"R=\frac{{v_0^2\sin 2\theta}}{{g}}={_fmt(horizontal_range)}\,\text{{m}}"
         )
-        text = f"最大高度 {values['max_height'].display}，射程 {values['range'].display}。"
+        text = (
+            f"最大高度 {values['max_height'].display}，"
+            f"射程 {values['range'].display}。{_PROJECTILE_MECHANISM}"
+        )
     return PhysicsMechanicsSolution(
         kind=spec.kind,
         steps=[
-            PhysicsMechanicsStep("分解运动", "x,y", "水平与竖直方向独立处理。"),
-            PhysicsMechanicsStep("竖直方向", r"y=h-\frac{1}{2}gt^2", "竖直运动决定飞行时间。"),
-            PhysicsMechanicsStep("水平方向", "x=v_xt", "水平方向匀速运动给出位移。"),
+            PhysicsMechanicsStep(
+                "分解运动",
+                "x,y",
+                "水平与竖直方向独立处理：水平方向不受力、保持匀速，竖直方向只受重力、匀加速。",
+            ),
+            PhysicsMechanicsStep(
+                "竖直方向",
+                r"y=h-\frac{1}{2}gt^2",
+                "竖直方向由重力产生加速度 g，决定飞行时间。",
+            ),
+            PhysicsMechanicsStep(
+                "水平方向",
+                "x=v_xt",
+                "水平方向匀速运动给出位移，两个分运动合成抛物线轨迹。",
+            ),
         ],
         values=values,
         answer_latex=answer_latex,

--- a/apps/api/app/domain/skills/probability_statistics_core/statistics_kernel.py
+++ b/apps/api/app/domain/skills/probability_statistics_core/statistics_kernel.py
@@ -169,13 +169,29 @@ def _solve_contingency(spec: ProbabilityStatisticsProblemSpec) -> ProbabilitySta
         for index, row in enumerate(spec.table)
     ]
     rows.append(["column_total", *[_display(value) for value in column_totals], _display(total)])
+    row_text = "、".join(_display(value) for value in row_totals)
+    column_text = "、".join(_display(value) for value in column_totals)
     return ProbabilityStatisticsSolution(
         kind=spec.kind,
-        results={"total": _clean_decimal(total)},
+        results={
+            **{
+                f"row_{index + 1}_total": _clean_decimal(value)
+                for index, value in enumerate(row_totals)
+            },
+            **{
+                f"column_{index + 1}_total": _clean_decimal(value)
+                for index, value in enumerate(column_totals)
+            },
+            "total": _clean_decimal(total),
+        },
         table_rows=rows,
         chart_values=[(f"row {index + 1}", float(value)) for index, value in enumerate(row_totals)],
         formula_latex=r"\text{total}=\sum_i\sum_j n_{ij}",
-        answer_text=f"总数={_display(total)}",
+        # The prompt asks for 行列合计; the narration has to say those words
+        # (and the totals), not just the grand total (issue #283 class).
+        answer_text=(
+            f"各行合计 {row_text}；各列合计 {column_text}；总数 total={_display(total)}"
+        ),
         assumptions=spec.assumptions,
     )
 

--- a/apps/api/app/domain/skills/solid_geometry/playbook_adapter.py
+++ b/apps/api/app/domain/skills/solid_geometry/playbook_adapter.py
@@ -205,10 +205,26 @@ def _voiceover(
     if not is_final:
         return narration
     if solution.query_kind == "line_plane_angle":
-        return f"{narration} 因此目标直线与底面所成的角（线面角）为 {solution.answer_latex}。"
+        # Restate the question in the prompt's own words (body, line, plane,
+        # 夹角) so the final step visibly answers it; the earlier generic
+        # "目标直线与底面" wording shared no token with the prompt (#283 class).
+        line = "".join(solution.target_line or ())
+        plane = "".join(solution.target_face or solution.target_plane or ())
+        body = _BODY_NAMES.get(solution.body, "几何体")
+        return (
+            f"{narration} 所以{body}中直线 {line} 与平面 {plane} 的夹角，"
+            f"也就是线面角，为 {solution.answer_latex}。"
+        )
     if solution.query_kind == "volume":
         return f"{narration} 因此立体的体积为 {solution.answer_latex}。"
     return narration
+
+
+_BODY_NAMES = {
+    "cube": "正方体",
+    "cuboid": "长方体",
+    "regular_quad_pyramid": "正四棱锥",
+}
 
 
 def _title_for(solution: SolidGeometrySolution, prompt: str) -> str:

--- a/apps/api/tests/test_algebra_core_parser_guard.py
+++ b/apps/api/tests/test_algebra_core_parser_guard.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import pytest
+import sympy as sp
+import sympy.parsing.sympy_parser as sympy_parser
+
+from app.domain.skills.algebra_core import (
+    UnsafeExpressionError,
+    parse_equation,
+    parse_expression,
+    parse_number,
+)
+from app.domain.skills.algebra_core import parser as algebra_parser
+from app.domain.skills.base import SkillRouteInput
+from app.domain.skills.calculus_core.playbook_adapter import build_calculus_core_playbook
+from app.domain.skills.calculus_core.spec_extractor import try_extract_calculus_core
+from app.domain.skills.elementary_algebra.spec_extractor import try_extract_elementary_algebra
+from app.domain.skills.linear_algebra.playbook_adapter import build_linear_algebra_playbook
+from app.domain.skills.linear_algebra.skill_pack import LinearAlgebraSkillPack
+
+# ``parse_expr`` is ``eval`` over transformed source. The text that reaches it
+# comes from user prompts (routing runs before any auth in the self edition)
+# and from agent tool calls with a free-form ``problem_spec``. The guard must
+# reject anything outside plain algebra *before* ``eval`` — the same posture
+# ``geometry_validators`` already takes (``test_rejects_attribute_access``).
+
+_X, _Y, _R = sp.symbols("x y r")
+
+_HOSTILE_SOURCES = [
+    "x.__class__.__name__",
+    "(1).__class__.__base__.__subclasses__()",
+    "x.__class__.__init__.__globals__",
+    "__import__('os').system('id')",
+    "sin.__globals__",
+    "N(x)",
+    "Lambda(x, x)",
+    "lambda: 1",
+    "x[0]",
+    "[x]",
+    "x if 1 else 2",
+    "open('/etc/passwd')",
+    "sin",  # a bare function object is not an expression
+]
+
+
+@pytest.fixture
+def eval_tap(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record every code string the algebra parser hands to ``eval``."""
+    calls: list[str] = []
+    original = algebra_parser.eval_expr
+
+    def tap(code: str, local_dict: dict, global_dict: dict):
+        calls.append(code)
+        return original(code, local_dict, global_dict)
+
+    monkeypatch.setattr(algebra_parser, "eval_expr", tap)
+    return calls
+
+
+@pytest.fixture
+def sympy_eval_tap(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record ``eval`` calls made by SymPy itself (``sympify`` on strings)."""
+    calls: list[str] = []
+    original = sympy_parser.eval_expr
+
+    def tap(code: str, local_dict: dict, global_dict: dict):
+        calls.append(code)
+        return original(code, local_dict, global_dict)
+
+    monkeypatch.setattr(sympy_parser, "eval_expr", tap)
+    return calls
+
+
+@pytest.mark.parametrize("source", _HOSTILE_SOURCES)
+def test_hostile_source_is_rejected_before_eval(source: str, eval_tap: list[str]) -> None:
+    with pytest.raises(UnsafeExpressionError):
+        parse_expression(source)
+    assert eval_tap == []
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("2x+3", 2 * _X + 3),
+        ("x^2-5x+6", _X**2 - 5 * _X + 6),
+        ("sin(x)*2", 2 * sp.sin(_X)),
+        ("0.5x", sp.Float("0.5") * _X),
+        ("3/4", sp.Rational(3, 4)),
+        ("sqrt(2)+pi*r^2", sp.sqrt(2) + sp.pi * _R**2),
+        ("5!", sp.Integer(120)),
+        ("2x+3y", 2 * _X + 3 * _Y),
+        ("-x+1", 1 - _X),
+        ("abs(x)", sp.Abs(_X)),
+        ("(x+1)(x-1)", (_X + 1) * (_X - 1)),
+        ("ln(x)/x", sp.log(_X) / _X),
+    ],
+)
+def test_benign_algebra_still_parses(source: str, expected: sp.Expr, eval_tap: list[str]) -> None:
+    expr, parsed = parse_expression(source)
+    assert sp.simplify(expr - expected) == 0
+    assert parsed.source
+    assert len(eval_tap) == 1
+
+
+def test_sympy_globals_are_plain_symbols_now(eval_tap: list[str]) -> None:
+    # ``from sympy import *`` used to leak the singleton registry, infinity,
+    # the numeric evaluator and friends into user text; only pi and E stay
+    # special. Unknown multi-letter names get SymPy's usual implicit split.
+    assert parse_expression("S")[0] == sp.Symbol("S")
+    assert parse_expression("oo")[0] == sp.Symbol("o") ** 2
+    assert parse_expression("E+1")[0] == sp.E + 1
+
+
+def test_sympy_callables_outside_the_allowlist_are_never_invoked(eval_tap: list[str]) -> None:
+    # ``preview`` shells out to LaTeX; under the restricted namespace it is not
+    # a callable any more, just letters multiplied together like ``2ab``.
+    expr, _ = parse_expression("preview(x)")
+    assert expr.is_Mul
+    assert sp.Symbol("x") in expr.free_symbols
+    assert all("preview" not in code for code in eval_tap)
+
+
+def test_equation_with_attribute_chain_is_rejected(eval_tap: list[str]) -> None:
+    with pytest.raises(ValueError):
+        parse_equation("x.__class__.__name__=1")
+    assert eval_tap == []
+
+
+def test_elementary_algebra_prompt_never_reaches_eval(eval_tap: list[str]) -> None:
+    # The routing path: heuristic_match -> extractor -> parse_equation.
+    assert try_extract_elementary_algebra("解方程 x.__class__.__name__=1") is None
+    assert eval_tap == []
+    assert try_extract_elementary_algebra("解方程 2x+3=11") is not None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (2, sp.Integer(2)),
+        (1.5, sp.Float(1.5)),
+        ("1.5", sp.Float("1.5")),
+        ("-3", sp.Integer(-3)),
+        ("1/2", sp.Rational(1, 2)),
+        ("2e3", sp.Float("2e3")),
+    ],
+)
+def test_parse_number_accepts_numeric_literals(value: object, expected: sp.Expr) -> None:
+    assert parse_number(value) == expected  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["x.__class__", "__import__('os')", "1+1", "", "nan", "pi", True, None],
+)
+def test_parse_number_rejects_anything_but_literals(value: object) -> None:
+    with pytest.raises(ValueError):
+        parse_number(value)  # type: ignore[arg-type]
+
+
+def test_calculus_spec_numeric_fields_are_not_evaluated(eval_tap: list[str]) -> None:
+    spec = try_extract_calculus_core("求 lim_{x->0} sin(x)/x")
+    assert spec is not None
+    # An agent-supplied spec skips the regex that produced ``point``.
+    hostile = spec.model_copy(update={"point": "__import__('os').system('id')"})
+    with pytest.raises(ValueError):
+        build_calculus_core_playbook("guard", hostile)
+    assert all("__import__" not in code for code in eval_tap)
+
+
+def test_linear_algebra_matrix_entries_are_not_sympified(sympy_eval_tap: list[str]) -> None:
+    skill = LinearAlgebraSkillPack()
+    match = skill.heuristic_match(SkillRouteInput(prompt="求 A=[[1,2],[3,4]] 的特征值"))
+    assert match is not None
+    spec = skill.validate_problem_spec(match.problem_spec or {})
+    assert spec is not None
+    hostile = spec.model_copy(update={"matrix": [["__import__('os').system('id')", 2], [3, 4]]})
+    with pytest.raises(ValueError):
+        build_linear_algebra_playbook("guard", hostile)
+    assert all("__import__" not in code for code in sympy_eval_tap)

--- a/apps/api/tests/test_physics_mechanics_skill.py
+++ b/apps/api/tests/test_physics_mechanics_skill.py
@@ -171,3 +171,33 @@ async def test_physics_mechanics_pipeline_path_does_not_call_llm() -> None:
     playbook = json.loads(repo.updates[-1]["playbook_json"])
     assert playbook["domain"] == "physics"
     assert any(step["snapshot"]["kind"] == "math_formula" for step in playbook["steps"])
+
+
+@pytest.mark.parametrize(
+    ("prompt", "vertical_marker", "horizontal_marker"),
+    [
+        ("一个物体以 10m/s 水平抛出，高度 20m，求落地时间和水平位移", r"y=h-\frac{1}{2}gt^2", "x=v_xt"),
+        ("以 20m/s、30° 斜向上抛出，求最大高度和射程", r"y=v_0\sin\theta\,t-\frac{1}{2}gt^2", r"x=v_0\cos\theta\,t"),
+    ],
+)
+def test_projectile_step_formulas_follow_the_launch_kind(
+    prompt: str, vertical_marker: str, horizontal_marker: str
+) -> None:
+    # The angled launch used to reuse the horizontal-launch formula y=h-½gt²
+    # on its formula card; each branch now states its own equations of motion,
+    # and both narrate the gravity / parabola facts the LessonPlan requires.
+    skill = PhysicsMechanicsSkillPack()
+    match = skill.heuristic_match(SkillRouteInput(prompt=prompt))
+    assert match is not None
+    spec = skill.validate_problem_spec(match.problem_spec or {})
+    assert spec is not None
+
+    solution = solve_mechanics(spec)
+    titles = [step.title for step in solution.steps]
+    vertical = solution.steps[titles.index("竖直方向")]
+    horizontal = solution.steps[titles.index("水平方向")]
+    assert vertical.formula_latex == vertical_marker
+    assert horizontal.formula_latex == horizontal_marker
+    assert "重力" in vertical.caption
+    assert "抛物线" in horizontal.caption
+    assert "重力" in solution.answer_text and "抛物线" in solution.answer_text

--- a/apps/api/tests/test_skill_pack_manifest_examples_gate.py
+++ b/apps/api/tests/test_skill_pack_manifest_examples_gate.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+
+from app.application.services.lesson_planner import build_rule_based_lesson_plan
+from app.domain.models.playbook import PlaybookScript
+from app.domain.models.review import PlaybookIssueSeverity
+from app.domain.models.route_decision import RouteDecision
+from app.domain.services.playbook_quality import quality_gate_playbook
+from app.domain.skills.base import SkillExecutionContext, SkillRouteInput
+from app.domain.skills.registry import build_default_skill_registry
+
+# Every capability example a SkillPack advertises in its manifest must come
+# out of that pack and pass the canonical gate the pipeline applies to it —
+# the same LessonPlan, the same specialized coverage. The 2026-09 e2e run found
+# 7/25 of these failing (#282–#286) and a later sweep found 5 more (末步不陈述
+# 答案 in elementary_algebra / solid_geometry / contingency_table, missing
+# gravity + parabolic facts in physics projectile); this keeps the whole set
+# green instead of one pack at a time.
+
+
+def _manifest_examples() -> list[pytest.param]:
+    registry = build_default_skill_registry()
+    cases: list[pytest.param] = []
+    for manifest in registry.manifests():
+        for capability in manifest.capabilities:
+            if not capability.supported:
+                continue
+            for example in capability.examples:
+                cases.append(
+                    pytest.param(
+                        manifest.skill_id,
+                        example,
+                        id=f"{capability.capability_id}:{example[:24]}",
+                    )
+                )
+    return cases
+
+
+@pytest.mark.parametrize(("skill_id", "prompt"), _manifest_examples())
+@pytest.mark.asyncio
+async def test_manifest_example_passes_canonical_gate(skill_id: str, prompt: str) -> None:
+    registry = build_default_skill_registry()
+    skill = registry.get(skill_id)
+    assert skill is not None
+
+    match = skill.heuristic_match(SkillRouteInput(prompt=prompt))
+    assert match is not None, f"{skill_id} does not match its own example: {prompt}"
+    spec = skill.validate_problem_spec(match.problem_spec or {})
+    assert spec is not None
+
+    result = await skill.execute(
+        SkillExecutionContext(run_id="manifest-examples-gate", prompt=prompt, route_match=match),
+        spec,
+    )
+    assert result.handled is True, result.fallback_reason
+    playbook = PlaybookScript.model_validate_json(result.playbook_json)
+
+    lesson_plan = build_rule_based_lesson_plan(
+        prompt=prompt,
+        domain=skill.manifest.domain,
+        route_decision=RouteDecision(
+            destination="deterministic_skill",
+            domain=skill.manifest.domain,
+            skill_id=skill_id,
+            confidence=match.confidence,
+            reason=match.reason,
+            matched_capability=match.capability_id,
+            problem_spec=match.problem_spec,
+        ),
+    )
+    report = quality_gate_playbook(
+        playbook,
+        prompt,
+        generator_path="skill_pack",
+        coverage_mode="specialized",
+        lesson_plan=lesson_plan,
+    )
+
+    errors = [issue for issue in report.issues if issue.severity == PlaybookIssueSeverity.ERROR]
+    assert not errors, [f"{issue.code} at {issue.path}: {issue.message}" for issue in errors]

--- a/docs/worklogs/render-pipeline-e2e-2026-09.md
+++ b/docs/worklogs/render-pipeline-e2e-2026-09.md
@@ -329,3 +329,30 @@ LessonPlan、`specialized` 覆盖），任何 ERROR 即失败。
 ```bash
 cd apps/api && ../../.venv/bin/pytest tests/test_skill_pack_manifest_examples_gate.py -q
 ```
+
+## 加固：题面文本不再进 Python `eval`（2026-09-02）
+
+`algebra_core/parser.py` 此前把题面里抽出的表达式直接交给 sympy `parse_expr`，
+而 `parse_expr` 就是对转换后源码做 `eval`：白盒探针确认
+`解方程 x.__class__.__init__.__globals__=1` 这样的提示词会让
+`Symbol('x').__class__.__init__.__globals__` 真的被求值；用旧解析器解析
+`preview(x)` 会直接去调 LaTeX（报 `latex program is not installed`）。这条路径
+在 self 版无需登录即可触达（路由阶段就解析），agent 侧
+`skill.<id>.solve` 又接受自由格式的 `problem_spec`，同一段文本也能从工具面进来。
+`geometry_validators.py` 早就有 AST 白名单守卫（`test_rejects_attribute_access`），
+但没有覆盖 algebra_core 这条。
+
+现在与 geometry 同一套姿势：`stringify_expr` 得到转换后源码 → AST 白名单
+（数字字面量、`Symbol('name')`、四则与幂、`pi` / `E`、白名单数学函数的直接调用）
+→ 通过才 `eval_expr`，且命名空间只含这些名字并把 `__builtins__` 置空。属性访问、
+下标、lambda、条件表达式、字符串、其余任何 sympy 全局名（`S`、`N`、`Lambda`、
+`preview`…）一律在 `eval` 之前以 `UnsafeExpressionError`（`ValueError` 子类）拒绝。
+副作用：`oo`、`I`、`S` 这类名字不再是无穷 / 虚数单位 / 单例注册表，而是普通符号。
+
+同类入口一并收口：`calculus_core` 的 `point` / `lower` / `upper` 与
+`linear_algebra` 的矩阵元素以前走 `sp.sympify` / `sp.Matrix` 的字符串 sympify，
+现在统一经 `parse_number`（只认十进制、科学计数与 `p/q`）。
+
+守卫测试 `tests/test_algebra_core_parser_guard.py`：13 类敌意输入必须在 `eval`
+之前被拒（对 `eval_expr` 打桩计数为 0），12 类常规代数写法照常解析且只 `eval` 一次，
+另覆盖方程路径、初等代数抽取器、calculus 数值字段与线性代数矩阵字段。

--- a/docs/worklogs/render-pipeline-e2e-2026-09.md
+++ b/docs/worklogs/render-pipeline-e2e-2026-09.md
@@ -298,3 +298,30 @@ SYSTEM_PROMPT 的工作流纪律本身写得不错（LessonPlan 绑定、断言�
 描述统计）全部经真实 pipeline 转为 succeeded；biology/geography 柱状图与
 两条物理场景重渲染确认视觉修复。`code` 学科与 agent 模式仍未覆盖（无 LLM
 凭据），#287 待决策。
+
+## 追加修复：manifest 示例 55/55（2026-09-01）
+
+#288 合并后，用同一把尺子把 13 个 SkillPack manifest 的**全部 55 条**
+capability 示例走了一遍真实管线（self / single / heuristic，无 LLM），50/55
+succeeded。剩下 5 条是 #283 那类缺陷在另外三个包里的复制品，加上物理平抛的
+两个 required fact 没接上：
+
+| 包 / capability | 示例 | 拦截原因 |
+|---|---|---|
+| `elementary_algebra` equation_1var | 求 x²−5x+6=0 的解 | `step.does_not_answer_prompt` |
+| `solid_geometry` cube.line_plane_angle | 正方体棱长 2，求 A₁B 与平面 ABCD 的夹角 | `step.does_not_answer_prompt` |
+| `probability_statistics_core` contingency_table | 列联表求行列合计 | `step.does_not_answer_prompt` |
+| `physics_mechanics` projectile_motion（两条示例） | 10 m/s 水平抛出 / 20 m/s 30° 斜抛 | `lesson_plan.fact_missing`：`gravity`、`parabolic` |
+
+修法照 #283：末步旁白用题目自己的词把答案说出来（`所以方程 x^2-5x+6=0 的解为
+x=2，x=3`、`正方体中直线 A1B 与平面 ABCD 的夹角…为 θ=π/4`、`各行合计 40、60；
+各列合计 50、50`），物理 kernel 的步骤与结论明确说出「竖直方向由重力加速」
+「两个分运动合成抛物线轨迹」。复验：55/55 经真实 pipeline succeeded。
+
+这个指标现在由 `tests/test_skill_pack_manifest_examples_gate.py` 长期守住：
+每条 manifest 示例都经本包 `execute` 后过 canonical gate（带 rule-based
+LessonPlan、`specialized` 覆盖），任何 ERROR 即失败。
+
+```bash
+cd apps/api && ../../.venv/bin/pytest tests/test_skill_pack_manifest_examples_gate.py -q
+```

--- a/docs/worklogs/render-pipeline-e2e-2026-09.md
+++ b/docs/worklogs/render-pipeline-e2e-2026-09.md
@@ -318,6 +318,10 @@ x=2，x=3`、`正方体中直线 A1B 与平面 ABCD 的夹角…为 θ=π/4`、`
 各列合计 50、50`），物理 kernel 的步骤与结论明确说出「竖直方向由重力加速」
 「两个分运动合成抛物线轨迹」。复验：55/55 经真实 pipeline succeeded。
 
+顺手修了一处既有错误：斜抛分支的公式卡此前借用平抛的 `y=h-½gt²`，现在两条分支
+各写自己的运动方程（平抛 `y=h-½gt²`、`x=v_xt`；斜抛 `y=v₀sinθ·t-½gt²`、
+`x=v₀cosθ·t`），`test_physics_mechanics_skill.py` 按抛出方式各锁一条。
+
 这个指标现在由 `tests/test_skill_pack_manifest_examples_gate.py` 长期守住：
 每条 manifest 示例都经本包 `execute` 后过 canonical gate（带 rule-based
 LessonPlan、`specialized` 覆盖），任何 ERROR 即失败。


### PR DESCRIPTION
## 背景

#288 合并后，用同一把尺子把 13 个 SkillPack manifest 的**全部 55 条** capability 示例走了一遍真实管线（self / single / heuristic，无 LLM 凭据）：50/55 succeeded。剩下 5 条是 #283 那类缺陷（答案只在公式卡 / 表格里，末步旁白不说）在另外三个包里的复制品，加上物理平抛的两个 LessonPlan required fact 没接上。

| 包 / capability | 示例 | 拦截原因 |
|---|---|---|
| `elementary_algebra` equation_1var | 求 x²−5x+6=0 的解 | `step.does_not_answer_prompt` |
| `solid_geometry` cube.line_plane_angle | 正方体棱长 2，求 A₁B 与平面 ABCD 的夹角 | `step.does_not_answer_prompt` |
| `probability_statistics_core` contingency_table | 列联表求行列合计 | `step.does_not_answer_prompt` |
| `physics_mechanics` projectile_motion（两条示例） | 10 m/s 水平抛出 / 20 m/s 30° 斜抛 | `lesson_plan.fact_missing`：`gravity`、`parabolic` |

## 改动一：五条示例（提交 `54f289c`、`0ae7de5`）

照 #283 的路子，只动旁白文本与结论数据，不碰快照结构：

- **elementary_algebra**：`_script` 加 `answer_text`，末步旁白追加「所以方程 x^2-5x+6=0 的解为 x=2，x=3」；不等式、因式分解同步补上。
- **solid_geometry**：末步用题目自己的词陈述「所以正方体中直线 A1B 与平面 ABCD 的夹角，也就是线面角，为 θ=π/4」，平面标签取完整的面。
- **probability_statistics_core**：列联表 `answer_text` 改为「各行合计 40、60；各列合计 50、50；总数 total=100」，`results` 补进行 / 列合计。
- **physics_mechanics**：平抛步骤与结论明确说出「竖直方向由重力加速」「两个分运动合成抛物线轨迹」；顺手修了一处既有错误——斜抛分支的公式卡此前借用平抛的 `y=h-½gt²`，现在两条分支各写自己的运动方程（平抛 `y=h-½gt²`、`x=v_xt`；斜抛 `y=v₀sinθ·t-½gt²`、`x=v₀cosθ·t`）。
- **新增守卫** `apps/api/tests/test_skill_pack_manifest_examples_gate.py`：13 个 SkillPack 全部 55 条 manifest 示例，各自经本包 `execute` 后过 canonical gate（带 rule-based LessonPlan、`specialized` 覆盖），任何 ERROR 即失败。把源码改动 stash 掉跑一次：恰好红这 5 条、其余 50 条绿。
- `test_physics_mechanics_skill.py` 按两种抛出方式各锁一条公式。

## 改动二：题面表达式不再进 Python `eval`（提交 `a59ccab`）

`algebra_core/parser.py` 此前把题面里抽出的表达式直接交给 sympy `parse_expr`，而它本质是对转换后源码 `eval`。白盒探针确认：`解方程 x.__class__.__init__.__globals__=1` 这样的提示词会让 `Symbol('x').__class__.__init__.__globals__` 真的被求值；旧解析器解析 `preview(x)` 会直接去调 LaTeX（报 `latex program is not installed`）。这条路径在 self 版无需登录即可触达（路由阶段就解析），agent 侧 `skill.<id>.solve` 又接受自由格式 `problem_spec`。`geometry_validators.py` 早有 AST 白名单守卫（`test_rejects_attribute_access`），但没覆盖这条。

- 与 geometry 同一套姿势：`stringify_expr` → AST 白名单（数字字面量、`Symbol('name')`、四则与幂、`pi` / `E`、白名单数学函数直接调用）→ 通过才 `eval_expr`；命名空间只含这些名字，`__builtins__` 置空。属性访问、下标、lambda、条件表达式、字符串、其余 sympy 全局名（`S`、`N`、`Lambda`、`preview`…）一律在 `eval` 前以 `UnsafeExpressionError`（`ValueError` 子类）拒绝。
- 同类入口一并收口：`calculus_core` 的 `point` / `lower` / `upper` 与 `linear_algebra` 的矩阵元素以前走 `sp.sympify` / `sp.Matrix` 的字符串 sympify，现在统一经 `parse_number`（只认十进制、科学计数与 `p/q`）。
- 行为副作用：`oo`、`I`、`S` 这类名字不再是无穷 / 虚数单位 / 单例注册表，而是普通符号；未知多字母名沿用 sympy 的隐式拆分（`preview(x)` 变成字母相乘，不再是函数调用）。
- 新增 `tests/test_algebra_core_parser_guard.py`：13 类敌意输入在 `eval` 前被拒（对 `eval_expr` 打桩计数为 0），12 类常规代数写法照常解析且只 `eval` 一次；覆盖方程路径、初等代数抽取器、calculus 数值字段与线性代数矩阵字段。

## 验证

- 真实管线复跑 55 条 manifest 示例：**55/55 succeeded**（此前 50/55）
- 白盒复验：`POST /api/v1/pipeline` 带两条敌意题面，请求期间 `eval` 调用次数均为 0（加固前为 4）
- `make check` 全过：ruff 干净；API 1406 passed / 3 skipped；web 1346 passed；agent 105；mcp 18；web build 成功
- 验证命令：`cd apps/api && ../../.venv/bin/pytest tests/test_skill_pack_manifest_examples_gate.py tests/test_physics_mechanics_skill.py tests/test_algebra_core_parser_guard.py -q`

## 范围外，未动

- `statistics_kernel.py` 存在 `ruff format` 的既有漂移（二项分布一段），仓库门禁只跑 `ruff check`，未重排无关代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UAgxGh9eSQmG2q498nH4c